### PR TITLE
Changed builing orientation to be North clockwise based.

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2SourceCharacteristics.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2SourceCharacteristics.java
@@ -78,7 +78,7 @@ public class GML2SourceCharacteristics {
       final String buildingId = String.valueOf(buildingIdInt);
       final BuildingFeature buildingFeature = new BuildingFeature();
       buildingFeature.setId(buildingId);
-      final Polygon polygon = GeometryUtil.constructPolygonFromDimensions(geometry, gmlBuilding.getLength(), gmlBuilding.getWidth(),
+      final Polygon polygon = GeometryUtil.constructPolygonFromXAxisDimensions(geometry, gmlBuilding.getLength(), gmlBuilding.getWidth(),
           gmlBuilding.getOrientation());
       buildingFeature.setGeometry(polygon);
       final Building building = new Building();

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/geo/OrientedEnvelope.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/geo/OrientedEnvelope.java
@@ -16,6 +16,9 @@
  */
 package nl.overheid.aerius.shared.domain.geo;
 
+/**
+ * Envelop with length, width and clockwise North orientation of an object.
+ */
 public class OrientedEnvelope {
 
   private final double length;
@@ -43,7 +46,7 @@ public class OrientedEnvelope {
   }
 
   /**
-   * Orientation in degrees counterclockwise relative to the x-axis.
+   * Orientation in degrees clockwise relative to the North.
    */
   public double getOrientation() {
     return orientation;


### PR DESCRIPTION
Building orientation is being based on North is 0 degree and clockwise.
For the code in the IMAER-Java project this has limited impact because the building itself is kept as polygon.
But for reading older GML files these should be interpreted as X-as counter-clockwise to be backward compatible.