### PR TITLE
AER3-1038 Changed the structure that Meteo uses

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/meteo/Meteo.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/meteo/Meteo.java
@@ -19,28 +19,97 @@ package nl.overheid.aerius.shared.domain.meteo;
 import java.io.Serializable;
 
 /**
- * Abstract meteo class, is implemented for single years (e.g. 2014) and multiple years (e.g. 1995-2004)
- * @see SingleYearMeteo
- * @see MultiYearMeteo
+ * Meteo class for single years (e.g. 2014) and multiple years (e.g. 1995-2004).
+ * If startYear is the same as the endYear it can be considered single-year meteo.
  */
-public abstract class Meteo implements Serializable {
+public class Meteo implements Serializable {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
-  private String opsFile;
+  private String code;
+  private String description;
+  private int startYear;
+  private int endYear;
 
-  public Meteo(String opsFile) {
-    this.opsFile = opsFile;
+  protected Meteo() {
+    // Default constructor, needed for serialization
   }
 
-  public Meteo() {
+  /**
+   * @param year The year for this meteo set. Will be used for both start and end year. Can be used by models to determine the correct file.
+   */
+  public Meteo(final int year) {
+    this(String.valueOf(year), String.valueOf(year), year);
   }
 
+  /**
+   * @param startYear The start year for this meteo set. Can be used by models to determine the correct file.
+   * @param endYear The end year for this meteo set. Can be used by models to determine the correct file.
+   */
+  public Meteo(final int startYear, final int endYear) {
+    this(startYear + "-" + endYear, startYear + "-" + endYear, startYear, endYear);
+  }
+
+  /**
+   * @param code Unique code for this meteo.
+   * If the same year is specified multiple times (different parts of the country for instance),
+   * this should be reflected in the code.
+   * @param description A user friendly description.
+   * @param year The year for this meteo set. Will be used for both start and end year. Can be used by models to determine the correct file.
+   */
+  public Meteo(final String code, final String description, final int year) {
+    this(code, description, year, year);
+  }
+
+  /**
+   * @param code Unique code for this meteo.
+   * If the same year is specified multiple times (different parts of the country for instance),
+   * this should be reflected in the code.
+   * @param description A user friendly description.
+   * @param startYear The start year for this meteo set. Can be used by models to determine the correct file.
+   * @param endYear The end year for this meteo set. Can be used by models to determine the correct file.
+   */
+  public Meteo(final String code, final String description, final int startYear, final int endYear) {
+    this.code = code;
+    this.description = description;
+    this.startYear = startYear;
+    this.endYear = endYear;
+  }
+
+  /**
+   * To be removed soon-ish.
+   */
+  @Deprecated
   public String getOpsFile() {
-    return opsFile;
+    return null;
   }
 
-  public void setOpsFile(String opsFile) {
-    this.opsFile = opsFile;
+  public String getCode() {
+    return code;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public int getStartYear() {
+    return startYear;
+  }
+
+  public int getEndYear() {
+    return endYear;
+  }
+
+  public boolean isSingleYear() {
+    return !isMultiYear();
+  }
+
+  public boolean isMultiYear() {
+    return endYear > startYear;
+  }
+
+  @Override
+  public String toString() {
+    return code;
   }
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/meteo/MultiYearMeteo.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/meteo/MultiYearMeteo.java
@@ -20,65 +20,40 @@ import java.util.Objects;
 
 /**
  * Represents multiple years (e.g. 1995-2004)
+ * @deprecated Use Meteo directly instead.
  */
+@Deprecated
 public class MultiYearMeteo extends Meteo {
 
   private static final long serialVersionUID = 1L;
 
-  private int startYear;
-  private int endYear;
-
-  public MultiYearMeteo(int startYear, int endYear, String opsFile) {
-    super(opsFile);
-    this.startYear = startYear;
-    this.endYear = endYear;
+  public MultiYearMeteo(final int startYear, final int endYear, final String opsFile) {
+    super(startYear, endYear);
   }
 
-  public MultiYearMeteo(int startYear, int endYear) {
-    super("");
-    this.startYear = startYear;
-    this.endYear = endYear;
+  public MultiYearMeteo(final int startYear, final int endYear) {
+    super(startYear, endYear);
   }
 
   public MultiYearMeteo() {
   }
 
-  public int getStartYear() {
-    return startYear;
-  }
-
-  public void setStartYear(int startYear) {
-    this.startYear = startYear;
-  }
-
-  public int getEndYear() {
-    return endYear;
-  }
-
-  public void setEndYear(int endYear) {
-    this.endYear = endYear;
-  }
-
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    MultiYearMeteo that = (MultiYearMeteo) o;
-    return startYear == that.startYear &&
-        endYear == that.endYear;
+    final MultiYearMeteo that = (MultiYearMeteo) o;
+    return getStartYear() == that.getStartYear() &&
+        getEndYear() == that.getEndYear();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(startYear, endYear);
+    return Objects.hash(getStartYear(), getEndYear());
   }
 
-  @Override
-  public String toString() {
-    return String.valueOf(startYear) + "-" + String.valueOf(endYear);
-  }
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/meteo/SingleYearMeteo.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/meteo/SingleYearMeteo.java
@@ -20,53 +20,43 @@ import java.util.Objects;
 
 /**
  * Represents a single year (e.g. 2014)
+ * @deprecated Use Meteo directly instead.
  */
+@Deprecated
 public class SingleYearMeteo extends Meteo {
 
   private static final long serialVersionUID = 1L;
 
-  private int year;
-
-  public SingleYearMeteo(int year, String opsFile) {
-    super(opsFile);
-    this.year = year;
+  public SingleYearMeteo(final int year, final String opsFile) {
+    super(year);
   }
 
-  public SingleYearMeteo(int year) {
-    super("");
-    this.year = year;
+  public SingleYearMeteo(final int year) {
+    super(year);
   }
 
   public SingleYearMeteo() {
   }
 
   @Override
-  public boolean equals(Object o) {
+  public boolean equals(final Object o) {
     if (this == o) {
       return true;
     }
     if (o == null || getClass() != o.getClass()) {
       return false;
     }
-    SingleYearMeteo that = (SingleYearMeteo) o;
-    return year == that.year;
+    final SingleYearMeteo that = (SingleYearMeteo) o;
+    return getYear() == that.getYear();
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(year);
+    return Objects.hash(getStartYear());
   }
 
   public int getYear() {
-    return year;
+    return getStartYear();
   }
 
-  public void setYear(int year) {
-    this.year = year;
-  }
-
-  @Override
-  public String toString() {
-    return String.valueOf(year);
-  }
 }


### PR DESCRIPTION
That is, it's no longer abstract, but incorporates both start and end year. This way it replaces SingleYearMeteo and MultiYearMeteo. If start and end year are the same, it can be considered a single year meteo, but that shouldn't matter too much for most applications. 
Removed the opsFile to be part of the object as well: this is too model specific, and determining the correct files is something that can be done in the OPS part of AERIUS based on the start and end year (there's a certain structure to those file names).
This is in preparation of using meteo for ADMS and making it selectable in the UI.
Using @deprecated to avoid causing compilation errors in the Calculator repository.