### PR TITLE
Introduced Theme to Scenario

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/metadata/CalculationMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/metadata/CalculationMetadata.java
@@ -17,7 +17,6 @@
 package nl.overheid.aerius.gml.v2_0.metadata;
 
 import java.util.List;
-import java.util.stream.Stream;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
@@ -34,23 +33,19 @@ import nl.overheid.aerius.shared.domain.result.EmissionResultType;
     "maximumRange", "researchArea"})
 public class CalculationMetadata {
 
-  private CalculationTypeLegacy calculationType;
+  private CalculationType calculationType;
   private List<Substance> substances;
   private List<EmissionResultType> resultTypes;
   private Double maximumRange;
   private Boolean researchArea;
 
   @XmlElement(name = "type", namespace = CalculatorSchema.NAMESPACE)
-  public CalculationTypeLegacy getCalculationType() {
+  public CalculationType getCalculationType() {
     return calculationType;
   }
 
-  public void setCalculationType(final CalculationTypeLegacy calculationType) {
-    this.calculationType = calculationType;
-  }
-
   public void setCalculationType(final CalculationType calculationType) {
-    setCalculationType(CalculationTypeLegacy.to(calculationType));
+    this.calculationType = calculationType;
   }
 
   @XmlElement(name = "substance", namespace = CalculatorSchema.NAMESPACE)
@@ -87,42 +82,5 @@ public class CalculationMetadata {
 
   public void setResearchArea(final Boolean researchArea) {
     this.researchArea = researchArea;
-  }
-
-  /**
-   * Legacy type to convert IMAER calculation type to internal {@link CalculationType} enum.
-   */
-  public enum CalculationTypeLegacy {
-
-    /**
-     * Calculate deposition at custom points (fixed set of receptors or user defined points).
-     */
-    CUSTOM_POINTS(CalculationType.CUSTOM_POINTS),
-    /**
-     * Calculate deposition in nature areas.
-     */
-    NATURE_AREA(CalculationType.NATURE_AREA),
-    /**
-     * Calculate for the Dutch NB-wet (Nature Compliance Act) compliance.
-     */
-    PERMIT(CalculationType.WNB),
-    /**
-     * Calculate deposition in a radius around the sources.
-     */
-    RADIUS(CalculationType.RADIUS);
-
-    private final CalculationType calculationType;
-
-    private CalculationTypeLegacy(final CalculationType calculationType) {
-      this.calculationType = calculationType;
-    }
-
-    public CalculationType from() {
-      return calculationType;
-    }
-
-    public static CalculationTypeLegacy to(final CalculationType calculationType) {
-      return Stream.of(values()).filter(e -> e.calculationType == calculationType).findFirst().orElse(null);
-    }
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/metadata/CalculationMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/metadata/CalculationMetadata.java
@@ -34,9 +34,6 @@ import nl.overheid.aerius.shared.domain.result.EmissionResultType;
     "maximumRange", "researchArea"})
 public class CalculationMetadata {
 
-  //TODO Calculation Type PERMIT should become PAS, preferable not being a enum either.
-  private static final String PERMIT = "PERMIT";
-
   private String calculationType;
   private List<Substance> substances;
   private List<EmissionResultType> resultTypes;
@@ -49,7 +46,7 @@ public class CalculationMetadata {
   }
 
   public void setCalculationType(final CalculationType calculationType) {
-    setCalculationType(calculationType == CalculationType.WNB ? PERMIT : calculationType.toString().toUpperCase(Locale.ENGLISH));
+    setCalculationType(calculationType.toString().toUpperCase(Locale.ROOT));
   }
 
   public void setCalculationType(final String calculationType) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/metadata/CalculationMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/metadata/CalculationMetadata.java
@@ -17,7 +17,6 @@
 package nl.overheid.aerius.gml.v2_1.metadata;
 
 import java.util.List;
-import java.util.Locale;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
@@ -46,7 +45,7 @@ public class CalculationMetadata {
   }
 
   public void setCalculationType(final CalculationType calculationType) {
-    setCalculationType(calculationType.toString().toUpperCase(Locale.ROOT));
+    setCalculationType(calculationType.type());
   }
 
   public void setCalculationType(final String calculationType) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/metadata/CalculationMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/metadata/CalculationMetadata.java
@@ -34,9 +34,6 @@ import nl.overheid.aerius.shared.domain.result.EmissionResultType;
     "maximumRange", "researchArea"})
 public class CalculationMetadata {
 
-  //TODO Calculation Type PERMIT should become PAS, preferable not being a enum either.
-  private static final String PERMIT = "PERMIT";
-
   private String calculationType;
   private List<Substance> substances;
   private List<EmissionResultType> resultTypes;
@@ -49,7 +46,7 @@ public class CalculationMetadata {
   }
 
   public void setCalculationType(final CalculationType calculationType) {
-    setCalculationType(calculationType == CalculationType.WNB ? PERMIT : calculationType.toString().toUpperCase(Locale.ENGLISH));
+    setCalculationType(calculationType.toString().toUpperCase(Locale.ROOT));
   }
 
   public void setCalculationType(final String calculationType) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/metadata/CalculationMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/metadata/CalculationMetadata.java
@@ -17,7 +17,6 @@
 package nl.overheid.aerius.gml.v2_2.metadata;
 
 import java.util.List;
-import java.util.Locale;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
@@ -46,7 +45,7 @@ public class CalculationMetadata {
   }
 
   public void setCalculationType(final CalculationType calculationType) {
-    setCalculationType(calculationType.toString().toUpperCase(Locale.ROOT));
+    setCalculationType(calculationType.type());
   }
 
   public void setCalculationType(final String calculationType) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/metadata/CalculationMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/metadata/CalculationMetadata.java
@@ -34,9 +34,6 @@ import nl.overheid.aerius.shared.domain.result.EmissionResultType;
     "maximumRange", "researchArea", "monitorSrm2Year"})
 public class CalculationMetadata {
 
-  //TODO Calculation Type PERMIT should become PAS, preferable not being a enum either.
-  private static final String PERMIT = "PERMIT";
-
   private String calculationType;
   private List<Substance> substances;
   private List<EmissionResultType> resultTypes;
@@ -50,7 +47,7 @@ public class CalculationMetadata {
   }
 
   public void setCalculationType(final CalculationType calculationType) {
-    setCalculationType(calculationType == CalculationType.WNB ? PERMIT : calculationType.toString().toUpperCase(Locale.ENGLISH));
+    setCalculationType(calculationType.toString().toUpperCase(Locale.ROOT));
   }
 
   public void setCalculationType(final String calculationType) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/metadata/CalculationMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/metadata/CalculationMetadata.java
@@ -17,7 +17,6 @@
 package nl.overheid.aerius.gml.v3_0.metadata;
 
 import java.util.List;
-import java.util.Locale;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
@@ -47,7 +46,7 @@ public class CalculationMetadata {
   }
 
   public void setCalculationType(final CalculationType calculationType) {
-    setCalculationType(calculationType.toString().toUpperCase(Locale.ROOT));
+    setCalculationType(calculationType.type());
   }
 
   public void setCalculationType(final String calculationType) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/metadata/CalculationMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/metadata/CalculationMetadata.java
@@ -17,7 +17,6 @@
 package nl.overheid.aerius.gml.v3_1.metadata;
 
 import java.util.List;
-import java.util.Locale;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
@@ -47,7 +46,7 @@ public class CalculationMetadata {
   }
 
   public void setCalculationType(final CalculationType calculationType) {
-    setCalculationType(calculationType.toString().toUpperCase(Locale.ROOT));
+    setCalculationType(calculationType.type());
   }
 
   public void setCalculationType(final String calculationType) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/metadata/CalculationMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/metadata/CalculationMetadata.java
@@ -34,9 +34,6 @@ import nl.overheid.aerius.shared.domain.result.EmissionResultType;
     "maximumRange", "researchArea", "monitorSrm2Year"})
 public class CalculationMetadata {
 
-  //TODO Calculation Type PERMIT should become PAS, preferable not being a enum either.
-  private static final String PERMIT = "PERMIT";
-
   private String calculationType;
   private List<Substance> substances;
   private List<EmissionResultType> resultTypes;
@@ -50,7 +47,7 @@ public class CalculationMetadata {
   }
 
   public void setCalculationType(final CalculationType calculationType) {
-    setCalculationType(calculationType == CalculationType.WNB ? PERMIT : calculationType.toString().toUpperCase(Locale.ENGLISH));
+    setCalculationType(calculationType.toString().toUpperCase(Locale.ROOT));
   }
 
   public void setCalculationType(final String calculationType) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/metadata/CalculationMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/metadata/CalculationMetadata.java
@@ -17,7 +17,6 @@
 package nl.overheid.aerius.gml.v4_0.metadata;
 
 import java.util.List;
-import java.util.Locale;
 
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
@@ -48,7 +47,7 @@ public class CalculationMetadata {
   }
 
   public void setCalculationType(final CalculationType calculationType) {
-    setCalculationType(calculationType.toString().toUpperCase(Locale.ROOT));
+    setCalculationType(calculationType.type());
   }
 
   public void setCalculationType(final String calculationType) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/metadata/CalculationMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/metadata/CalculationMetadata.java
@@ -34,9 +34,6 @@ import nl.overheid.aerius.shared.domain.result.EmissionResultType;
     "maximumRange", "researchArea", "monitorSrm2Year", "options"})
 public class CalculationMetadata {
 
-  //TODO Calculation Type PERMIT should become PAS, preferable not being a enum either.
-  private static final String PERMIT = "PERMIT";
-
   private String calculationType;
   private List<Substance> substances;
   private List<EmissionResultType> resultTypes;
@@ -51,7 +48,7 @@ public class CalculationMetadata {
   }
 
   public void setCalculationType(final CalculationType calculationType) {
-    setCalculationType(calculationType == CalculationType.WNB ? PERMIT : calculationType.toString().toUpperCase(Locale.ENGLISH));
+    setCalculationType(calculationType.toString().toUpperCase(Locale.ROOT));
   }
 
   public void setCalculationType(final String calculationType) {

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLReaderTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLReaderTest.java
@@ -215,7 +215,7 @@ public class GMLReaderTest {
     metaDataInput.setSituationType(SITUATION_TYPE);
     metaDataInput.setVersion(VERSION);
     metaDataInput.setDatabaseVersion(DATABASE_VERSION);
-    metaDataInput.getOptions().setCalculationType(CalculationType.WNB);
+    metaDataInput.getOptions().setCalculationType(CalculationType.PERMIT);
     metaDataInput.getOptions().setMonitorSrm2Year(MONITOR_SRM2_YEAR);
     metaDataInput.setResultsIncluded(true);
     final InternalGMLWriter writer = new InternalGMLWriter(gridSettings, GMLTestDomain.TEST_REFERENCE_GENERATOR);

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/Theme.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/Theme.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.shared.domain;
+
+import java.util.Locale;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * A Theme determines the context in which the data will be used.
+ */
+public enum Theme {
+  /**
+   * UK Nature Conservation Act calculation (NCA).
+   */
+  NCA,
+  /**
+   * Dutch Regeling Beoordeling Luchtkwaliteit (RBL).
+   */
+  RBL,
+  /**
+   * Dutch Wet NatuurBescherming (WNB)
+   */
+  WNB;
+
+  public String getKey() {
+    return name().toLowerCase(Locale.ROOT);
+  }
+
+  public static Optional<Theme> fromKey(final String key) {
+    return Stream.of(values())
+        .filter(v -> v.name().equalsIgnoreCase(key))
+        .findFirst();
+  }
+}

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationSetOptions.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationSetOptions.java
@@ -33,7 +33,7 @@ public class CalculationSetOptions implements Serializable {
   private static final long serialVersionUID = 4L;
 
   private int calculationSetOptionsId;
-  private CalculationType calculationType = CalculationType.PERMIT;
+  private CalculationType calculationType = CalculationType.WNB;
   private double calculateMaximumRange;
   private final ArrayList<Substance> substances = new ArrayList<>();
   private final Set<EmissionResultKey> emissionResultKeys = new HashSet<>();
@@ -63,6 +63,13 @@ public class CalculationSetOptions implements Serializable {
 
   public ArrayList<Substance> getSubstances() {
     return substances;
+  }
+
+  /**
+   * @return Returns true if WNB maximum distance calculation is to be applied.
+   */
+  public boolean isWNBMaxDistance() {
+    return calculationType == CalculationType.WNB;
   }
 
   public boolean isStacking() {

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationSetOptions.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationSetOptions.java
@@ -33,7 +33,7 @@ public class CalculationSetOptions implements Serializable {
   private static final long serialVersionUID = 4L;
 
   private int calculationSetOptionsId;
-  private CalculationType calculationType = CalculationType.WNB;
+  private CalculationType calculationType = CalculationType.PERMIT;
   private double calculateMaximumRange;
   private final ArrayList<Substance> substances = new ArrayList<>();
   private final Set<EmissionResultKey> emissionResultKeys = new HashSet<>();
@@ -63,13 +63,6 @@ public class CalculationSetOptions implements Serializable {
 
   public ArrayList<Substance> getSubstances() {
     return substances;
-  }
-
-  /**
-   * @return Returns true if WNB maximum distance calculation is to be applied.
-   */
-  public boolean isWNBMaxDistance() {
-    return calculationType == CalculationType.WNB;
   }
 
   public boolean isStacking() {

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationType.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationType.java
@@ -23,7 +23,7 @@ package nl.overheid.aerius.shared.domain.calculation;
 public enum CalculationType {
 
   /**
-   * Calculate deposition at custom points (fixed set of receptors or user defined points).
+   * Calculate with custom points (fixed set of receptors or user defined points).
    */
   CUSTOM_POINTS,
   /**
@@ -31,17 +31,13 @@ public enum CalculationType {
    */
   NATURE_AREA,
   /**
-   * Calculates for the Dutch Nationaal Samenwerkingsprogramma Luchtkwaliteit (NSL)
+   * Calculates using calculation points and settings established by policy.
    */
-  NSL,
+  PERMIT,
   /**
    * Calculate deposition in a radius around the sources.
    */
-  RADIUS,
-  /**
-   * Calculate for the Dutch WetNB (Nature Compliance Act) compliance.
-   */
-  WNB;
+  RADIUS;
 
   /**
    * Safely returns a CalculationType. It is case independent and returns null in

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationType.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationType.java
@@ -16,6 +16,8 @@
  */
 package nl.overheid.aerius.shared.domain.calculation;
 
+import java.util.Locale;
+
 /**
  * Type of calculation. It be a radius from the source point or to only
  * calculate points within nature areas.
@@ -37,7 +39,13 @@ public enum CalculationType {
   /**
    * Calculate deposition in a radius around the sources.
    */
-  RADIUS;
+  RADIUS,
+
+  @Deprecated
+  WNB,
+  @Deprecated
+  NSL
+  ;
 
   /**
    * Safely returns a CalculationType. It is case independent and returns null in
@@ -54,13 +62,17 @@ public enum CalculationType {
     }
   }
 
+  public String type() {
+    return (this == WNB ? CalculationType.PERMIT : this).name().toString();
+  }
+
   /**
    * Returns the name in lowercase.
    * @return name in lowercase
    */
   @Override
   public String toString() {
-    return name().toLowerCase();
+    return name().toLowerCase(Locale.ROOT);
   }
 
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/Scenario.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/Scenario.java
@@ -33,7 +33,7 @@ import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
  */
 public class Scenario implements Serializable {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   private Theme theme;
   private CalculationSetOptions options = new CalculationSetOptions();
@@ -45,7 +45,7 @@ public class Scenario implements Serializable {
     this.theme = theme;
   }
 
-  protected Scenario() {
+  public Scenario() {
     // protected scenario for serialization.
   }
 

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/Scenario.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/Scenario.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
+import nl.overheid.aerius.shared.domain.Theme;
 import nl.overheid.aerius.shared.domain.calculation.CalculationSetOptions;
 import nl.overheid.aerius.shared.domain.v2.geojson.FeatureCollection;
 import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
@@ -34,10 +35,27 @@ public class Scenario implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
+  private Theme theme;
   private CalculationSetOptions options = new CalculationSetOptions();
   private ScenarioMetaData metaData = new ScenarioMetaData();
   private List<ScenarioSituation> situations = new ArrayList<>();
   private final FeatureCollection<CalculationPointFeature> customPoints = new FeatureCollection<>();
+
+  public Scenario(final Theme theme) {
+    this.theme = theme;
+  }
+
+  protected Scenario() {
+    // protected scenario for serialization.
+  }
+
+  public Theme getTheme() {
+    return theme;
+  }
+
+  public void setTheme(final Theme theme) {
+    this.theme = theme;
+  }
 
   public CalculationSetOptions getOptions() {
     return options;


### PR DESCRIPTION
Because we get more themes that have similar calculation types it makes sense to remove the theme like types from CalculationType and add the Theme as a separate variable to Scenario.
This will make it easier to use the same calculation type among different themes.