### PR TITLE
AER3-1127 Correctly grouping standard vehicles for roads

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/GML2SRMRoad.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/GML2SRMRoad.java
@@ -18,6 +18,7 @@ package nl.overheid.aerius.gml.base.source.road;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
@@ -50,8 +51,9 @@ abstract class GML2SRMRoad<T extends IsGmlRoadEmissionSource, S extends RoadEmis
   @Override
   public S convert(final T source) throws AeriusException {
     final S emissionSource = construct();
+    final List<StandardVehicles> mergingStandardVehicles = new ArrayList<>();
     for (final IsGmlProperty<IsGmlVehicle> vp : source.getVehicles()) {
-      addVehicleEmissions(emissionSource.getSubSources(), source, vp);
+      addVehicleEmissions(emissionSource.getSubSources(), source, vp, mergingStandardVehicles);
     }
     emissionSource.setTrafficDirection(source.getTrafficDirection());
     emissionSource.setRoadManager(source.getRoadManager());
@@ -69,9 +71,9 @@ abstract class GML2SRMRoad<T extends IsGmlRoadEmissionSource, S extends RoadEmis
 
   protected abstract void setOptionalVariables(T source, S emissionSource) throws AeriusException;
 
-  protected void addVehicleEmissions(final List<Vehicles> addToVehicles, final T source, final IsGmlProperty<IsGmlVehicle> vp) {
+  protected void addVehicleEmissions(final List<Vehicles> addToVehicles, final T source, final IsGmlProperty<IsGmlVehicle> vp,
+      final List<StandardVehicles> mergingStandardVehicles) {
     final IsGmlVehicle av = vp.getProperty();
-    final List<StandardVehicles> mergingStandardVehicles = new ArrayList<>();
     if (av instanceof IsGmlStandardVehicle) {
       addEmissionValues(addToVehicles, source, (IsGmlStandardVehicle) av, mergingStandardVehicles);
     } else if (av instanceof IsGmlSpecificVehicle) {
@@ -103,8 +105,8 @@ abstract class GML2SRMRoad<T extends IsGmlRoadEmissionSource, S extends RoadEmis
 
   protected Optional<StandardVehicles> findExistingMatch(final IsGmlStandardVehicle sv, final List<StandardVehicles> mergingStandardVehicles) {
     return mergingStandardVehicles.stream()
-        .filter(x -> x.getMaximumSpeed() == sv.getMaximumSpeed())
-        .filter(x -> x.getStrictEnforcement() == sv.isStrictEnforcement())
+        .filter(x -> Objects.equals(x.getMaximumSpeed(), sv.getMaximumSpeed()))
+        .filter(x -> Objects.equals(x.getStrictEnforcement(), sv.isStrictEnforcement()))
         .filter(x -> x.getTimeUnit() == TimeUnit.valueOf(sv.getTimeUnit().name()))
         .filter(x -> !x.getValuesPerVehicleTypes().containsKey(sv.getVehicleType()))
         .findFirst();

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/Road2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/Road2GML.java
@@ -18,7 +18,6 @@ package nl.overheid.aerius.gml.v4_0.togml;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map.Entry;
 
 import nl.overheid.aerius.gml.v4_0.source.TimeUnit;
 import nl.overheid.aerius.gml.v4_0.source.road.CustomVehicle;
@@ -176,17 +175,21 @@ class Road2GML extends SpecificSource2GML<nl.overheid.aerius.shared.domain.v2.so
   }
 
   private void addVehicleEmissionSource(final List<VehiclesProperty> vehiclesList, final StandardVehicles vse, final boolean isFreeway) {
-    for (final Entry<VehicleType, ValuesPerVehicleType> entry : vse.getValuesPerVehicleTypes().entrySet()) {
-      final StandardVehicle sv = new StandardVehicle();
-      sv.setVehiclesPerTimeUnit(entry.getValue().getVehiclesPerTimeUnit());
-      sv.setStagnationFactor(entry.getValue().getStagnationFraction());
-      sv.setVehicleType(entry.getKey());
-      sv.setMaximumSpeed(vse.getMaximumSpeed());
-      if (isFreeway) {
-        sv.setStrictEnforcement(vse.getStrictEnforcement());
+    // Loop over possible VehicleType values instead of over EntrySet to get a predictable order
+    for (final VehicleType vehicleType : VehicleType.values()) {
+      if (vse.getValuesPerVehicleTypes().containsKey(vehicleType)) {
+        final ValuesPerVehicleType valuesPerVehicleType = vse.getValuesPerVehicleTypes().get(vehicleType);
+        final StandardVehicle sv = new StandardVehicle();
+        sv.setVehiclesPerTimeUnit(valuesPerVehicleType.getVehiclesPerTimeUnit());
+        sv.setStagnationFactor(valuesPerVehicleType.getStagnationFraction());
+        sv.setVehicleType(vehicleType);
+        sv.setMaximumSpeed(vse.getMaximumSpeed());
+        if (isFreeway) {
+          sv.setStrictEnforcement(vse.getStrictEnforcement());
+        }
+        sv.setTimeUnit(TimeUnit.from(vse.getTimeUnit()));
+        vehiclesList.add(new VehiclesProperty(sv));
       }
-      sv.setTimeUnit(TimeUnit.from(vse.getTimeUnit()));
-      vehiclesList.add(new VehiclesProperty(sv));
     }
   }
 


### PR DESCRIPTION
As it was, the mergingStandardVehicles list would only be kept for one property, which was not terribly useful...
Also ensured that the export order of standard vehicles is more predictable. Especially handy for roundtrip tests.