### PR TITLE
AER3-1161 Converting plan emission sources to generic sources on import

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLConversionData.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLConversionData.java
@@ -27,8 +27,10 @@ import java.util.Set;
 import nl.overheid.aerius.gml.base.GMLLegacyCodeConverter.Conversion;
 import nl.overheid.aerius.gml.base.GMLLegacyCodeConverter.GMLLegacyCodeType;
 import nl.overheid.aerius.gml.base.conversion.MobileSourceOffRoadConversion;
+import nl.overheid.aerius.gml.base.conversion.PlanConversion;
 import nl.overheid.aerius.gml.base.source.ship.v31.GMLInlandShippingSupplier;
 import nl.overheid.aerius.gml.base.source.ship.v31.InlandShippingUtil;
+import nl.overheid.aerius.shared.domain.Substance;
 import nl.overheid.aerius.shared.domain.geo.ReceptorGridSettings;
 import nl.overheid.aerius.shared.domain.v2.building.BuildingFeature;
 import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
@@ -149,6 +151,20 @@ public class GMLConversionData {
       estimation = conversion.estimageOffRoadOperatingHours(literFuelPerYear, hoursIdlePerYear, engineDisplacement);
     }
     return estimation;
+  }
+
+  public boolean isInvalidPlanActivityCode(final String oldCode) {
+    return legacyCodeConverter.getPlanConversion(oldCode) == null;
+  }
+
+  public Map<Substance, Double> determinePlanActivityEmissions(final String oldCode, final int amount) {
+    final PlanConversion conversion = legacyCodeConverter.getPlanConversion(oldCode);
+    return conversion == null ? Map.of() : conversion.calculateEmissionsForActivity(amount);
+  }
+
+  public OPSSourceCharacteristics determinePlanActivityCharacteristics(final String oldCode) {
+    final PlanConversion conversion = legacyCodeConverter.getPlanConversion(oldCode);
+    return conversion == null ? null : conversion.getCharacteristics();
   }
 
   private Reason getReason(final GMLLegacyCodeType codeType) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLLegacyCodeConverter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLLegacyCodeConverter.java
@@ -16,10 +16,10 @@
  */
 package nl.overheid.aerius.gml.base;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import nl.overheid.aerius.gml.base.conversion.MobileSourceOffRoadConversion;
+import nl.overheid.aerius.gml.base.conversion.PlanConversion;
 
 /**
  * Util class to convert old codes in previous versions of AERIUS gml files to the codes of the latest version.
@@ -39,15 +39,19 @@ public class GMLLegacyCodeConverter {
 
   private final Map<GMLLegacyCodeType, Map<String, Conversion>> codeMaps;
   private final Map<String, MobileSourceOffRoadConversion> mobileSourceOffRoadConversions;
+  private final Map<String, PlanConversion> planConversions;
 
   /**
    * @param codeMaps The &lt;OldCode, NewCode&gt; maps to use for each legacy code type.
    * @param mobileSourceOffRoadConversions The &lt;OldCode, ConversionValues&gt; to use for mobile sources.
+   * @param planConversions The &lt;OldCode, ConversionValues&gt; to use for plan activities.
    */
   public GMLLegacyCodeConverter(final Map<GMLLegacyCodeType, Map<String, Conversion>> codeMaps,
-      final Map<String, MobileSourceOffRoadConversion> mobileSourceOffRoadConversions) {
-    this.codeMaps = codeMaps == null ? new HashMap<>() : codeMaps;
-    this.mobileSourceOffRoadConversions = mobileSourceOffRoadConversions == null ? new HashMap<>() : mobileSourceOffRoadConversions;
+      final Map<String, MobileSourceOffRoadConversion> mobileSourceOffRoadConversions,
+      final Map<String, PlanConversion> planConversions) {
+    this.codeMaps = codeMaps == null ? Map.of() : codeMaps;
+    this.mobileSourceOffRoadConversions = mobileSourceOffRoadConversions == null ? Map.of() : mobileSourceOffRoadConversions;
+    this.planConversions = planConversions == null ? Map.of() : planConversions;
   }
 
   /**
@@ -63,6 +67,10 @@ public class GMLLegacyCodeConverter {
 
   protected MobileSourceOffRoadConversion getMobileSourceOffRoadConversion(final String oldCode) {
     return mobileSourceOffRoadConversions.get(oldCode);
+  }
+
+  protected PlanConversion getPlanConversion(final String oldCode) {
+    return planConversions.get(oldCode);
   }
 
   /**

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLLegacyCodesSupplier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLLegacyCodesSupplier.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import nl.overheid.aerius.gml.base.GMLLegacyCodeConverter.Conversion;
 import nl.overheid.aerius.gml.base.GMLLegacyCodeConverter.GMLLegacyCodeType;
 import nl.overheid.aerius.gml.base.conversion.MobileSourceOffRoadConversion;
+import nl.overheid.aerius.gml.base.conversion.PlanConversion;
 import nl.overheid.aerius.shared.exception.AeriusException;
 
 /**
@@ -46,5 +47,15 @@ public interface GMLLegacyCodesSupplier {
    * @throws AeriusException
    */
   Map<String, MobileSourceOffRoadConversion> getLegacyMobileSourceOffRoadConversions() throws AeriusException;
+
+  /**
+   * Returns a map with old codes and the values to use for conversion for plan activities.
+   *
+   * @return mapping of the codes
+   * @throws AeriusException
+   */
+  default Map<String, PlanConversion> getLegacyPlanConversions() throws AeriusException {
+    return Map.of();
+  }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionReaderFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionReaderFactory.java
@@ -61,7 +61,8 @@ public abstract class GMLVersionReaderFactory {
     this.featureCollectionClass = featureCollectionClass;
     schema = createSchema(schemaLocation);
     legacyCodeConverter =
-        new GMLLegacyCodeConverter(legacyCodeSupplier.getLegacyCodes(version), legacyCodeSupplier.getLegacyMobileSourceOffRoadConversions());
+        new GMLLegacyCodeConverter(legacyCodeSupplier.getLegacyCodes(version), legacyCodeSupplier.getLegacyMobileSourceOffRoadConversions(),
+            legacyCodeSupplier.getLegacyPlanConversions());
   }
 
   private static Schema createSchema(final String schemaLocation) throws AeriusException {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/conversion/PlanConversion.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/conversion/PlanConversion.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.gml.base.conversion;
+
+import java.math.BigDecimal;
+import java.util.EnumMap;
+import java.util.Map;
+
+import nl.overheid.aerius.shared.domain.Substance;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+
+/**
+ * Class to be used to convert from properties used for plan activities for the older IMAER versions (<= 4.0)
+ * to a generic emission source.
+ */
+public class PlanConversion {
+
+  private final Map<Substance, BigDecimal> emissionFactors = new EnumMap<>(Substance.class);
+  private final OPSSourceCharacteristics characteristics;
+
+  /**
+   * @param emissionFactors The emission factors to use.
+   * @param fuelConsumptionIdle The characteristics to use.
+   */
+  public PlanConversion(final Map<Substance, Double> emissionFactors, final OPSSourceCharacteristics characteristics) {
+    emissionFactors.forEach(
+        (key, value) -> this.emissionFactors.put(key, BigDecimal.valueOf(value)));
+    this.characteristics = characteristics;
+  }
+
+  public Map<Substance, Double> calculateEmissionsForActivity(final int amount) {
+    final Map<Substance, Double> result = new EnumMap<>(Substance.class);
+    emissionFactors.forEach(
+        (key, value) -> result.put(key, value.multiply(BigDecimal.valueOf(amount)).doubleValue()));
+    return result;
+  }
+
+  public OPSSourceCharacteristics getCharacteristics() {
+    return characteristics;
+  }
+
+}

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/plan/GML2Plan.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/plan/GML2Plan.java
@@ -36,6 +36,7 @@ import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 public class GML2Plan<T extends IsGmlPlanEmissionSource> extends AbstractGML2Specific<T, PlanEmissionSource> {
 
   private static final int DEFAULT_SECTOR = 9999;
+  private static final String DESCRIPTION_PREFIX = "Plan";
 
   private final GML2Geometry gml2Geometry;
 
@@ -86,7 +87,7 @@ public class GML2Plan<T extends IsGmlPlanEmissionSource> extends AbstractGML2Spe
   }
 
   private String constructLabel(final String sourceLabel, final String subSourceDescription) {
-    return Stream.of(sourceLabel, subSourceDescription)
+    return Stream.of(DESCRIPTION_PREFIX, sourceLabel, subSourceDescription)
         .filter(x -> x != null && !x.isBlank())
         .collect(Collectors.joining("; "));
   }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/plan/GML2Plan.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/plan/GML2Plan.java
@@ -16,37 +16,79 @@
  */
 package nl.overheid.aerius.gml.base.source.plan;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGmlProperty;
+import nl.overheid.aerius.gml.base.geo.GML2Geometry;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
+import nl.overheid.aerius.shared.domain.v2.source.GenericEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.PlanEmissionSource;
-import nl.overheid.aerius.shared.domain.v2.source.plan.Plan;
 import nl.overheid.aerius.shared.exception.AeriusException;
+import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 
 /**
  *
  */
 public class GML2Plan<T extends IsGmlPlanEmissionSource> extends AbstractGML2Specific<T, PlanEmissionSource> {
 
+  private static final int DEFAULT_SECTOR = 9999;
+
+  private final GML2Geometry gml2Geometry;
+
   /**
    * @param conversionData The conversion data to use.
    */
   public GML2Plan(final GMLConversionData conversionData) {
     super(conversionData);
+    this.gml2Geometry = new GML2Geometry(conversionData.getSrid());
   }
 
   @Override
   public PlanEmissionSource convert(final T source) throws AeriusException {
-    final PlanEmissionSource emissionSource = new PlanEmissionSource();
     for (final IsGmlProperty<IsGmlPlan> planProperty : source.getPlans()) {
       final IsGmlPlan plan = planProperty.getProperty();
-      final Plan planEmission = new Plan();
-      planEmission.setPlanCode(plan.getCode());
-      planEmission.setAmount(plan.getAmount());
-      planEmission.setDescription(plan.getDescription());
-      emissionSource.getSubSources().add(planEmission);
+
+      final GenericEmissionSource newSource = new GenericEmissionSource();
+      newSource.setGmlId(source.getId() + "_" + source.getPlans().indexOf(planProperty));
+      newSource.setSectorId(DEFAULT_SECTOR);
+      newSource.setLabel(constructLabel(source.getLabel(), plan.getDescription()));
+
+      final String planCode = plan.getCode();
+      validatePlanCode(planCode, source.getId());
+      newSource.setCharacteristics(getCharacteristics(planCode));
+      newSource.setEmissions(getConversionData().determinePlanActivityEmissions(planCode, plan.getAmount()));
+
+      final EmissionSourceFeature feature = new EmissionSourceFeature();
+      feature.setProperties(newSource);
+      feature.setGeometry(gml2Geometry.getGeometry(source));
+      getConversionData().getExtraSources().add(feature);
     }
-    return emissionSource;
+    return null;
+  }
+
+  private void validatePlanCode(final String code, final String sourceId) throws AeriusException {
+    if (getConversionData().isInvalidPlanActivityCode(code)) {
+      throw new AeriusException(ImaerExceptionReason.GML_UNKNOWN_PLAN_CODE, sourceId, code);
+    }
+  }
+
+  private OPSSourceCharacteristics getCharacteristics(final String code) {
+    final OPSSourceCharacteristics characteristics = new OPSSourceCharacteristics();
+    final OPSSourceCharacteristics planCharacteristics = getConversionData().determinePlanActivityCharacteristics(code);
+    if (planCharacteristics != null) {
+      planCharacteristics.copyTo(characteristics);
+    }
+    return characteristics;
+  }
+
+  private String constructLabel(final String sourceLabel, final String subSourceDescription) {
+    return Stream.of(sourceLabel, subSourceDescription)
+        .filter(x -> x != null && !x.isBlank())
+        .collect(Collectors.joining("; "));
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/SourceCharacteristics2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/SourceCharacteristics2GML.java
@@ -66,7 +66,9 @@ final class SourceCharacteristics2GML {
       return heatContent;
     } else {
       final SpecifiedHeatContent heatContent = new SpecifiedHeatContent();
-      heatContent.setValue(characteristics.getHeatContent());
+      heatContent.setValue(characteristics.getHeatContent() == null
+          ? 0
+          : characteristics.getHeatContent());
       return heatContent;
 
     }

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
@@ -193,6 +193,8 @@ public final class AssertGML {
     when(gmlHelper.getLegacyCodes(any())).thenAnswer(invocation -> TestValidationAndEmissionHelper.legacyCodes());
     when(gmlHelper.getLegacyMobileSourceOffRoadConversions())
         .thenAnswer(invocation -> TestValidationAndEmissionHelper.legacyMobileSourceOffRoadConversions());
+    when(gmlHelper.getLegacyPlanConversions())
+        .thenAnswer(invocation -> TestValidationAndEmissionHelper.legacyPlanConversions());
     when(gmlHelper.determineDefaultCharacteristicsBySectorId(anyInt())).thenReturn(mock(OPSSourceCharacteristics.class));
     when(gmlHelper.getValidationHelper()).thenReturn(valiationAndEmissionHelper);
     return gmlHelper;

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/test/TestValidationAndEmissionHelper.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/test/TestValidationAndEmissionHelper.java
@@ -27,7 +27,10 @@ import java.util.stream.Collectors;
 import nl.overheid.aerius.gml.base.GMLLegacyCodeConverter.Conversion;
 import nl.overheid.aerius.gml.base.GMLLegacyCodeConverter.GMLLegacyCodeType;
 import nl.overheid.aerius.gml.base.conversion.MobileSourceOffRoadConversion;
+import nl.overheid.aerius.gml.base.conversion.PlanConversion;
 import nl.overheid.aerius.shared.domain.Substance;
+import nl.overheid.aerius.shared.domain.ops.DiurnalVariation;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.domain.v2.source.road.RoadSpeedType;
 import nl.overheid.aerius.shared.domain.v2.source.road.RoadType;
@@ -148,7 +151,7 @@ public class TestValidationAndEmissionHelper implements ValidationHelper, Emissi
       new OffRoadOldCodesHelper("SVM4C30", "B4T", 1.0687796, null),
       new OffRoadOldCodesHelper("P1980", "SI75560DSN", 16.208658, 0.410843));
 
-  private static final List<GenericConstructHelper> PLAN_CATEGORIES = Arrays.asList(
+  private static final List<GenericConstructHelper> OLD_PLAN_CATEGORIES = Arrays.asList(
       new GenericConstructHelper("PHA", new EmissionHelper(1.10997, 0.0)),
       new GenericConstructHelper("PHB", new EmissionHelper(1.55043, 0.0)),
       new GenericConstructHelper("POA", new EmissionHelper(0.161545, 0.0)),
@@ -380,6 +383,24 @@ public class TestValidationAndEmissionHelper implements ValidationHelper, Emissi
     OFF_ROAD_MOBILE_SOURCE_OLD_CODES.forEach(
         helper -> conversions.put(helper.oldCode, new MobileSourceOffRoadConversion(helper.fuelConsumptionUnderLoad, helper.fuelConsumptionIdle)));
     return conversions;
+  }
+
+  public static Map<String, PlanConversion> legacyPlanConversions() {
+    final Map<String, PlanConversion> conversions = new HashMap<>();
+    OLD_PLAN_CATEGORIES.forEach(
+        helper -> conversions.put(helper.code,
+            new PlanConversion(helper.emissions.toEmissions(), mockPlanCharacteristics(OLD_PLAN_CATEGORIES.indexOf(helper) + 1))));
+    return conversions;
+  }
+
+  private static final OPSSourceCharacteristics mockPlanCharacteristics(final int index) {
+    final OPSSourceCharacteristics characteristics = new OPSSourceCharacteristics();
+    characteristics.setEmissionHeight(index * 2.0);
+    characteristics.setSpread(index * 1.0);
+    characteristics.setHeatContent(index * 10.0);
+    characteristics.setParticleSizeDistribution(index);
+    characteristics.setDiurnalVariation(DiurnalVariation.INDUSTRIAL_ACTIVITY);
+    return characteristics;
   }
 
   @Override
@@ -764,7 +785,7 @@ public class TestValidationAndEmissionHelper implements ValidationHelper, Emissi
   }
 
   private Optional<GenericConstructHelper> plan(final String planCode) {
-    return PLAN_CATEGORIES.stream()
+    return OLD_PLAN_CATEGORIES.stream()
         .filter(c -> c.code.equalsIgnoreCase(planCode))
         .findFirst();
   }

--- a/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/plan.gml
+++ b/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/plan.gml
@@ -31,7 +31,7 @@
                     <imaer:localId>ES.1_0</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
-            <imaer:label>Woonwijk; Huizen</imaer:label>
+            <imaer:label>Plan; Woonwijk; Huizen</imaer:label>
             <imaer:emissionSourceCharacteristics>
                 <imaer:EmissionSourceCharacteristics>
                     <imaer:heatContent>
@@ -91,7 +91,7 @@
                     <imaer:localId>ES.1_1</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
-            <imaer:label>Woonwijk; Tussenwoningen</imaer:label>
+            <imaer:label>Plan; Woonwijk; Tussenwoningen</imaer:label>
             <imaer:emissionSourceCharacteristics>
                 <imaer:EmissionSourceCharacteristics>
                     <imaer:heatContent>
@@ -151,7 +151,7 @@
                     <imaer:localId>ES.1_2</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
-            <imaer:label>Woonwijk; Kantoren</imaer:label>
+            <imaer:label>Plan; Woonwijk; Kantoren</imaer:label>
             <imaer:emissionSourceCharacteristics>
                 <imaer:EmissionSourceCharacteristics>
                     <imaer:heatContent>
@@ -211,7 +211,7 @@
                     <imaer:localId>ES.1_3</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
-            <imaer:label>Woonwijk; Kassen</imaer:label>
+            <imaer:label>Plan; Woonwijk; Kassen</imaer:label>
             <imaer:emissionSourceCharacteristics>
                 <imaer:EmissionSourceCharacteristics>
                     <imaer:heatContent>
@@ -271,7 +271,7 @@
                     <imaer:localId>ES.1_4</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
-            <imaer:label>Woonwijk; Centrale</imaer:label>
+            <imaer:label>Plan; Woonwijk; Centrale</imaer:label>
             <imaer:emissionSourceCharacteristics>
                 <imaer:EmissionSourceCharacteristics>
                     <imaer:heatContent>
@@ -331,7 +331,7 @@
                     <imaer:localId>ES.1_5</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
-            <imaer:label>Woonwijk; Bouwmaterialen</imaer:label>
+            <imaer:label>Plan; Woonwijk; Bouwmaterialen</imaer:label>
             <imaer:emissionSourceCharacteristics>
                 <imaer:EmissionSourceCharacteristics>
                     <imaer:heatContent>
@@ -391,7 +391,7 @@
                     <imaer:localId>ES.1_6</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
-            <imaer:label>Woonwijk; Afvalverwerking</imaer:label>
+            <imaer:label>Plan; Woonwijk; Afvalverwerking</imaer:label>
             <imaer:emissionSourceCharacteristics>
                 <imaer:EmissionSourceCharacteristics>
                     <imaer:heatContent>
@@ -451,7 +451,7 @@
                     <imaer:localId>ES.1_7</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
-            <imaer:label>Woonwijk; Café</imaer:label>
+            <imaer:label>Plan; Woonwijk; Café</imaer:label>
             <imaer:emissionSourceCharacteristics>
                 <imaer:EmissionSourceCharacteristics>
                     <imaer:heatContent>

--- a/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/plan.gml
+++ b/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/plan.gml
@@ -24,18 +24,34 @@
         </imaer:AeriusCalculatorMetadata>
     </imaer:metadata>
     <imaer:featureMember>
-        <imaer:PlanEmissionSource sectorId="9000" gml:id="ES.1">
+        <imaer:EmissionSource sectorId="9999" gml:id="ES.1_0">
             <imaer:identifier>
                 <imaer:NEN3610ID>
                     <imaer:namespace>NL.IMAER</imaer:namespace>
-                    <imaer:localId>ES.1</imaer:localId>
+                    <imaer:localId>ES.1_0</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
-            <imaer:label>Woonwijk</imaer:label>
+            <imaer:label>Woonwijk; Huizen</imaer:label>
+            <imaer:emissionSourceCharacteristics>
+                <imaer:EmissionSourceCharacteristics>
+                    <imaer:heatContent>
+                        <imaer:SpecifiedHeatContent>
+                            <imaer:value>10.0</imaer:value>
+                        </imaer:SpecifiedHeatContent>
+                    </imaer:heatContent>
+                    <imaer:emissionHeight>2.0</imaer:emissionHeight>
+                    <imaer:spread>1.0</imaer:spread>
+                    <imaer:diurnalVariation>
+                        <imaer:StandardDiurnalVariation>
+                            <imaer:standardType>INDUSTRIAL_ACTIVITY</imaer:standardType>
+                        </imaer:StandardDiurnalVariation>
+                    </imaer:diurnalVariation>
+                </imaer:EmissionSourceCharacteristics>
+            </imaer:emissionSourceCharacteristics>
             <imaer:geometry>
                 <imaer:EmissionSourceGeometry>
                     <imaer:GM_Surface>
-                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="ES.1.SURFACE">
+                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="ES.1_0.SURFACE">
                             <gml:exterior>
 <gml:LinearRing>
     <gml:posList>68555.26 443877.84 68924.86 443635.92 69072.7 443810.64 68709.82 444072.72 68555.26 443877.84</gml:posList>
@@ -52,7 +68,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>472547.716035</imaer:value>
+                    <imaer:value>110.997</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -65,54 +81,426 @@
                     <imaer:value>0.0</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
-            <imaer:plan>
-                <imaer:Plan planType="PHA">
-                    <imaer:description>Huizen</imaer:description>
-                    <imaer:amount>100</imaer:amount>
-                </imaer:Plan>
-            </imaer:plan>
-            <imaer:plan>
-                <imaer:Plan planType="PHB">
-                    <imaer:description>Tussenwoningen</imaer:description>
-                    <imaer:amount>10</imaer:amount>
-                </imaer:Plan>
-            </imaer:plan>
-            <imaer:plan>
-                <imaer:Plan planType="POA">
-                    <imaer:description>Kantoren</imaer:description>
-                    <imaer:amount>105783</imaer:amount>
-                </imaer:Plan>
-            </imaer:plan>
-            <imaer:plan>
-                <imaer:Plan planType="PGA">
-                    <imaer:description>Kassen</imaer:description>
-                    <imaer:amount>1</imaer:amount>
-                </imaer:Plan>
-            </imaer:plan>
-            <imaer:plan>
-                <imaer:Plan planType="PEA">
-                    <imaer:description>Centrale</imaer:description>
-                    <imaer:amount>10000</imaer:amount>
-                </imaer:Plan>
-            </imaer:plan>
-            <imaer:plan>
-                <imaer:Plan planType="PIA">
-                    <imaer:description>Bouwmaterialen</imaer:description>
-                    <imaer:amount>100</imaer:amount>
-                </imaer:Plan>
-            </imaer:plan>
-            <imaer:plan>
-                <imaer:Plan planType="PWA">
-                    <imaer:description>Afvalverwerking</imaer:description>
-                    <imaer:amount>1</imaer:amount>
-                </imaer:Plan>
-            </imaer:plan>
-            <imaer:plan>
-                <imaer:Plan planType="PFA">
-                    <imaer:description>Café</imaer:description>
-                    <imaer:amount>1</imaer:amount>
-                </imaer:Plan>
-            </imaer:plan>
-        </imaer:PlanEmissionSource>
+        </imaer:EmissionSource>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:EmissionSource sectorId="9999" gml:id="ES.1_1">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>ES.1_1</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:label>Woonwijk; Tussenwoningen</imaer:label>
+            <imaer:emissionSourceCharacteristics>
+                <imaer:EmissionSourceCharacteristics>
+                    <imaer:heatContent>
+                        <imaer:SpecifiedHeatContent>
+                            <imaer:value>20.0</imaer:value>
+                        </imaer:SpecifiedHeatContent>
+                    </imaer:heatContent>
+                    <imaer:emissionHeight>4.0</imaer:emissionHeight>
+                    <imaer:spread>2.0</imaer:spread>
+                    <imaer:diurnalVariation>
+                        <imaer:StandardDiurnalVariation>
+                            <imaer:standardType>INDUSTRIAL_ACTIVITY</imaer:standardType>
+                        </imaer:StandardDiurnalVariation>
+                    </imaer:diurnalVariation>
+                </imaer:EmissionSourceCharacteristics>
+            </imaer:emissionSourceCharacteristics>
+            <imaer:geometry>
+                <imaer:EmissionSourceGeometry>
+                    <imaer:GM_Surface>
+                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="ES.1_1.SURFACE">
+                            <gml:exterior>
+<gml:LinearRing>
+    <gml:posList>68555.26 443877.84 68924.86 443635.92 69072.7 443810.64 68709.82 444072.72 68555.26 443877.84</gml:posList>
+</gml:LinearRing>
+                            </gml:exterior>
+                        </gml:Polygon>
+                    </imaer:GM_Surface>
+                </imaer:EmissionSourceGeometry>
+            </imaer:geometry>
+            <imaer:emission>
+                <imaer:Emission substance="NH3">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NOX">
+                    <imaer:value>15.5043</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="PM10">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NO2">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+        </imaer:EmissionSource>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:EmissionSource sectorId="9999" gml:id="ES.1_2">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>ES.1_2</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:label>Woonwijk; Kantoren</imaer:label>
+            <imaer:emissionSourceCharacteristics>
+                <imaer:EmissionSourceCharacteristics>
+                    <imaer:heatContent>
+                        <imaer:SpecifiedHeatContent>
+                            <imaer:value>30.0</imaer:value>
+                        </imaer:SpecifiedHeatContent>
+                    </imaer:heatContent>
+                    <imaer:emissionHeight>6.0</imaer:emissionHeight>
+                    <imaer:spread>3.0</imaer:spread>
+                    <imaer:diurnalVariation>
+                        <imaer:StandardDiurnalVariation>
+                            <imaer:standardType>INDUSTRIAL_ACTIVITY</imaer:standardType>
+                        </imaer:StandardDiurnalVariation>
+                    </imaer:diurnalVariation>
+                </imaer:EmissionSourceCharacteristics>
+            </imaer:emissionSourceCharacteristics>
+            <imaer:geometry>
+                <imaer:EmissionSourceGeometry>
+                    <imaer:GM_Surface>
+                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="ES.1_2.SURFACE">
+                            <gml:exterior>
+<gml:LinearRing>
+    <gml:posList>68555.26 443877.84 68924.86 443635.92 69072.7 443810.64 68709.82 444072.72 68555.26 443877.84</gml:posList>
+</gml:LinearRing>
+                            </gml:exterior>
+                        </gml:Polygon>
+                    </imaer:GM_Surface>
+                </imaer:EmissionSourceGeometry>
+            </imaer:geometry>
+            <imaer:emission>
+                <imaer:Emission substance="NH3">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NOX">
+                    <imaer:value>17088.714735</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="PM10">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NO2">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+        </imaer:EmissionSource>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:EmissionSource sectorId="9999" gml:id="ES.1_3">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>ES.1_3</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:label>Woonwijk; Kassen</imaer:label>
+            <imaer:emissionSourceCharacteristics>
+                <imaer:EmissionSourceCharacteristics>
+                    <imaer:heatContent>
+                        <imaer:SpecifiedHeatContent>
+                            <imaer:value>40.0</imaer:value>
+                        </imaer:SpecifiedHeatContent>
+                    </imaer:heatContent>
+                    <imaer:emissionHeight>8.0</imaer:emissionHeight>
+                    <imaer:spread>4.0</imaer:spread>
+                    <imaer:diurnalVariation>
+                        <imaer:StandardDiurnalVariation>
+                            <imaer:standardType>INDUSTRIAL_ACTIVITY</imaer:standardType>
+                        </imaer:StandardDiurnalVariation>
+                    </imaer:diurnalVariation>
+                </imaer:EmissionSourceCharacteristics>
+            </imaer:emissionSourceCharacteristics>
+            <imaer:geometry>
+                <imaer:EmissionSourceGeometry>
+                    <imaer:GM_Surface>
+                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="ES.1_3.SURFACE">
+                            <gml:exterior>
+<gml:LinearRing>
+    <gml:posList>68555.26 443877.84 68924.86 443635.92 69072.7 443810.64 68709.82 444072.72 68555.26 443877.84</gml:posList>
+</gml:LinearRing>
+                            </gml:exterior>
+                        </gml:Polygon>
+                    </imaer:GM_Surface>
+                </imaer:EmissionSourceGeometry>
+            </imaer:geometry>
+            <imaer:emission>
+                <imaer:Emission substance="NH3">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NOX">
+                    <imaer:value>1004.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="PM10">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NO2">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+        </imaer:EmissionSource>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:EmissionSource sectorId="9999" gml:id="ES.1_4">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>ES.1_4</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:label>Woonwijk; Centrale</imaer:label>
+            <imaer:emissionSourceCharacteristics>
+                <imaer:EmissionSourceCharacteristics>
+                    <imaer:heatContent>
+                        <imaer:SpecifiedHeatContent>
+                            <imaer:value>50.0</imaer:value>
+                        </imaer:SpecifiedHeatContent>
+                    </imaer:heatContent>
+                    <imaer:emissionHeight>10.0</imaer:emissionHeight>
+                    <imaer:spread>5.0</imaer:spread>
+                    <imaer:diurnalVariation>
+                        <imaer:StandardDiurnalVariation>
+                            <imaer:standardType>INDUSTRIAL_ACTIVITY</imaer:standardType>
+                        </imaer:StandardDiurnalVariation>
+                    </imaer:diurnalVariation>
+                </imaer:EmissionSourceCharacteristics>
+            </imaer:emissionSourceCharacteristics>
+            <imaer:geometry>
+                <imaer:EmissionSourceGeometry>
+                    <imaer:GM_Surface>
+                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="ES.1_4.SURFACE">
+                            <gml:exterior>
+<gml:LinearRing>
+    <gml:posList>68555.26 443877.84 68924.86 443635.92 69072.7 443810.64 68709.82 444072.72 68555.26 443877.84</gml:posList>
+</gml:LinearRing>
+                            </gml:exterior>
+                        </gml:Polygon>
+                    </imaer:GM_Surface>
+                </imaer:EmissionSourceGeometry>
+            </imaer:geometry>
+            <imaer:emission>
+                <imaer:Emission substance="NH3">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NOX">
+                    <imaer:value>3000.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="PM10">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NO2">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+        </imaer:EmissionSource>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:EmissionSource sectorId="9999" gml:id="ES.1_5">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>ES.1_5</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:label>Woonwijk; Bouwmaterialen</imaer:label>
+            <imaer:emissionSourceCharacteristics>
+                <imaer:EmissionSourceCharacteristics>
+                    <imaer:heatContent>
+                        <imaer:SpecifiedHeatContent>
+                            <imaer:value>60.0</imaer:value>
+                        </imaer:SpecifiedHeatContent>
+                    </imaer:heatContent>
+                    <imaer:emissionHeight>12.0</imaer:emissionHeight>
+                    <imaer:spread>6.0</imaer:spread>
+                    <imaer:diurnalVariation>
+                        <imaer:StandardDiurnalVariation>
+                            <imaer:standardType>INDUSTRIAL_ACTIVITY</imaer:standardType>
+                        </imaer:StandardDiurnalVariation>
+                    </imaer:diurnalVariation>
+                </imaer:EmissionSourceCharacteristics>
+            </imaer:emissionSourceCharacteristics>
+            <imaer:geometry>
+                <imaer:EmissionSourceGeometry>
+                    <imaer:GM_Surface>
+                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="ES.1_5.SURFACE">
+                            <gml:exterior>
+<gml:LinearRing>
+    <gml:posList>68555.26 443877.84 68924.86 443635.92 69072.7 443810.64 68709.82 444072.72 68555.26 443877.84</gml:posList>
+</gml:LinearRing>
+                            </gml:exterior>
+                        </gml:Polygon>
+                    </imaer:GM_Surface>
+                </imaer:EmissionSourceGeometry>
+            </imaer:geometry>
+            <imaer:emission>
+                <imaer:Emission substance="NH3">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NOX">
+                    <imaer:value>67.5</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="PM10">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NO2">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+        </imaer:EmissionSource>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:EmissionSource sectorId="9999" gml:id="ES.1_6">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>ES.1_6</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:label>Woonwijk; Afvalverwerking</imaer:label>
+            <imaer:emissionSourceCharacteristics>
+                <imaer:EmissionSourceCharacteristics>
+                    <imaer:heatContent>
+                        <imaer:SpecifiedHeatContent>
+                            <imaer:value>70.0</imaer:value>
+                        </imaer:SpecifiedHeatContent>
+                    </imaer:heatContent>
+                    <imaer:emissionHeight>14.0</imaer:emissionHeight>
+                    <imaer:spread>7.0</imaer:spread>
+                    <imaer:diurnalVariation>
+                        <imaer:StandardDiurnalVariation>
+                            <imaer:standardType>INDUSTRIAL_ACTIVITY</imaer:standardType>
+                        </imaer:StandardDiurnalVariation>
+                    </imaer:diurnalVariation>
+                </imaer:EmissionSourceCharacteristics>
+            </imaer:emissionSourceCharacteristics>
+            <imaer:geometry>
+                <imaer:EmissionSourceGeometry>
+                    <imaer:GM_Surface>
+                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="ES.1_6.SURFACE">
+                            <gml:exterior>
+<gml:LinearRing>
+    <gml:posList>68555.26 443877.84 68924.86 443635.92 69072.7 443810.64 68709.82 444072.72 68555.26 443877.84</gml:posList>
+</gml:LinearRing>
+                            </gml:exterior>
+                        </gml:Polygon>
+                    </imaer:GM_Surface>
+                </imaer:EmissionSourceGeometry>
+            </imaer:geometry>
+            <imaer:emission>
+                <imaer:Emission substance="NH3">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NOX">
+                    <imaer:value>341647.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="PM10">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NO2">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+        </imaer:EmissionSource>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:EmissionSource sectorId="9999" gml:id="ES.1_7">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>ES.1_7</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:label>Woonwijk; Café</imaer:label>
+            <imaer:emissionSourceCharacteristics>
+                <imaer:EmissionSourceCharacteristics>
+                    <imaer:heatContent>
+                        <imaer:SpecifiedHeatContent>
+                            <imaer:value>80.0</imaer:value>
+                        </imaer:SpecifiedHeatContent>
+                    </imaer:heatContent>
+                    <imaer:emissionHeight>16.0</imaer:emissionHeight>
+                    <imaer:spread>8.0</imaer:spread>
+                    <imaer:diurnalVariation>
+                        <imaer:StandardDiurnalVariation>
+                            <imaer:standardType>INDUSTRIAL_ACTIVITY</imaer:standardType>
+                        </imaer:StandardDiurnalVariation>
+                    </imaer:diurnalVariation>
+                </imaer:EmissionSourceCharacteristics>
+            </imaer:emissionSourceCharacteristics>
+            <imaer:geometry>
+                <imaer:EmissionSourceGeometry>
+                    <imaer:GM_Surface>
+                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="ES.1_7.SURFACE">
+                            <gml:exterior>
+<gml:LinearRing>
+    <gml:posList>68555.26 443877.84 68924.86 443635.92 69072.7 443810.64 68709.82 444072.72 68555.26 443877.84</gml:posList>
+</gml:LinearRing>
+                            </gml:exterior>
+                        </gml:Polygon>
+                    </imaer:GM_Surface>
+                </imaer:EmissionSourceGeometry>
+            </imaer:geometry>
+            <imaer:emission>
+                <imaer:Emission substance="NH3">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NOX">
+                    <imaer:value>109614.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="PM10">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NO2">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+        </imaer:EmissionSource>
     </imaer:featureMember>
 </imaer:FeatureCollectionCalculator>


### PR DESCRIPTION
Plan emissionsources are not directly supported anymore. Hence the need to convert these types of sources to something else: generic emission sources.

With this change each activity ends up in it's own separate source. While it might be possible to merge activities into one source if the characteristics are the same, there was probably a reason why the activities were separate in the first place. It's easier for a user to merge the sources if he requires than to split the sources if already merged (because that would require knowing emission factors and original amounts being input).