### PR TITLE
Valid gml references

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/InlandRoute2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/InlandRoute2GML.java
@@ -27,6 +27,7 @@ import nl.overheid.aerius.shared.domain.v2.source.shipping.inland.CustomInlandSh
 import nl.overheid.aerius.shared.domain.v2.source.shipping.inland.InlandShipping;
 import nl.overheid.aerius.shared.domain.v2.source.shipping.inland.StandardInlandShipping;
 import nl.overheid.aerius.shared.exception.AeriusException;
+import nl.overheid.aerius.util.gml.GMLIdUtil;
 
 /**
  *
@@ -92,7 +93,8 @@ class InlandRoute2GML extends SpecificSource2GML<InlandShippingEmissionSource> {
       reference = null;
     } else {
       reference = new ReferenceType(null);
-      reference.setHref("#" + id);
+      final String gmlId = GMLIdUtil.toValidGmlId(id, GMLIdUtil.SOURCE_PREFIX);
+      reference.setHref("#" + gmlId);
     }
     return reference;
   }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/MaritimeRoute2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/MaritimeRoute2GML.java
@@ -26,6 +26,7 @@ import nl.overheid.aerius.shared.domain.v2.source.MaritimeShippingEmissionSource
 import nl.overheid.aerius.shared.domain.v2.source.shipping.maritime.CustomMaritimeShipping;
 import nl.overheid.aerius.shared.domain.v2.source.shipping.maritime.MaritimeShipping;
 import nl.overheid.aerius.shared.domain.v2.source.shipping.maritime.StandardMaritimeShipping;
+import nl.overheid.aerius.util.gml.GMLIdUtil;
 
 /**
  *
@@ -83,7 +84,8 @@ class MaritimeRoute2GML extends SpecificSource2GML<MaritimeShippingEmissionSourc
       reference = null;
     } else {
       reference = new ReferenceType(null);
-      reference.setHref("#" + id);
+      final String gmlId = GMLIdUtil.toValidGmlId(id, GMLIdUtil.SOURCE_PREFIX);
+      reference.setHref("#" + gmlId);
     }
     return reference;
   }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/SourceCharacteristics2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/SourceCharacteristics2GML.java
@@ -28,6 +28,7 @@ import nl.overheid.aerius.shared.domain.ops.OutflowDirectionType;
 import nl.overheid.aerius.shared.domain.ops.OutflowVelocityType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+import nl.overheid.aerius.util.gml.GMLIdUtil;
 
 /**
  *
@@ -89,7 +90,10 @@ final class SourceCharacteristics2GML {
   }
 
   private static ReferenceType determineBuilding(final OPSSourceCharacteristics characteristics) {
-    return toReferenceType(characteristics.getBuildingId());
+    final String validBuildingId = characteristics.getBuildingId() == null
+        ? null
+        : GMLIdUtil.toValidGmlId(characteristics.getBuildingId(), GMLIdUtil.BUILDING_PREFIX);
+    return toReferenceType(validBuildingId);
   }
 
   private static ReferenceType toReferenceType(final String id) {


### PR DESCRIPTION
As it was, the ID's used for references weren't always the same as the ID of the object being referenced, since those objects would receive an ID that was guaranteed to be valid according to the definition (for instance, not starting with a number).

By using the same utility function for those ID's, we should arrive at the same result.