### PR TITLE
AER3-1224 Shipping mooring backwards comp. route names

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/AbstractGML2Specific.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/AbstractGML2Specific.java
@@ -16,6 +16,9 @@
  */
 package nl.overheid.aerius.gml.base;
 
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSource;
 import nl.overheid.aerius.shared.exception.AeriusException;
 
@@ -44,6 +47,12 @@ public abstract class AbstractGML2Specific<T, E extends EmissionSource> {
 
   protected GMLConversionData getConversionData() {
     return conversionData;
+  }
+
+  protected static String constructLabelOf(final String... nameparts) {
+    return Stream.of(nameparts)
+        .filter(x -> x != null && !x.isBlank())
+        .collect(Collectors.joining("; "));
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v31/GML2OffRoad.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v31/GML2OffRoad.java
@@ -16,9 +16,6 @@
  */
 package nl.overheid.aerius.gml.base.source.mobile.v31;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -116,9 +113,7 @@ public class GML2OffRoad<T extends IsGmlOffRoadMobileEmissionSource> extends Abs
   }
 
   private String constructLabel(final String sourceLabel, final String subSourceDescription) {
-    return Stream.of(sourceLabel, subSourceDescription)
-        .filter(x -> x != null && !x.isBlank())
-        .collect(Collectors.joining("; "));
+    return constructLabelOf(sourceLabel, subSourceDescription);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v40/GML2OffRoad.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v40/GML2OffRoad.java
@@ -16,9 +16,6 @@
  */
 package nl.overheid.aerius.gml.base.source.mobile.v40;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -109,9 +106,7 @@ public class GML2OffRoad<T extends IsGmlOffRoadMobileEmissionSource> extends Abs
   }
 
   private String constructLabel(final String sourceLabel, final String subSourceDescription) {
-    return Stream.of(sourceLabel, subSourceDescription)
-        .filter(x -> x != null && !x.isBlank())
-        .collect(Collectors.joining("; "));
+    return constructLabelOf(sourceLabel, subSourceDescription);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/plan/GML2Plan.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/plan/GML2Plan.java
@@ -16,9 +16,6 @@
  */
 package nl.overheid.aerius.gml.base.source.plan;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGmlProperty;
@@ -87,9 +84,7 @@ public class GML2Plan<T extends IsGmlPlanEmissionSource> extends AbstractGML2Spe
   }
 
   private String constructLabel(final String sourceLabel, final String subSourceDescription) {
-    return Stream.of(DESCRIPTION_PREFIX, sourceLabel, subSourceDescription)
-        .filter(x -> x != null && !x.isBlank())
-        .collect(Collectors.joining("; "));
+    return constructLabelOf(DESCRIPTION_PREFIX, sourceLabel, subSourceDescription);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/ship/v31/GML2InlandMooring.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/ship/v31/GML2InlandMooring.java
@@ -16,6 +16,10 @@
  */
 package nl.overheid.aerius.gml.base.source.ship.v31;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGmlProperty;
@@ -49,21 +53,22 @@ public class GML2InlandMooring<T extends IsGmlMooringInlandShippingEmissionSourc
   @Override
   public MooringInlandShippingEmissionSource convert(final T source) throws AeriusException {
     final MooringInlandShippingEmissionSource emissionSource = new MooringInlandShippingEmissionSource();
+    final AtomicInteger routeIndexTracker = new AtomicInteger(1);
     for (final IsGmlProperty<IsGmlMooringInlandShipping> mooringInlandShippingProperty : source.getShips()) {
-      addVesselGroup(mooringInlandShippingProperty.getProperty(), emissionSource, source.getId());
+      addVesselGroup(mooringInlandShippingProperty.getProperty(), emissionSource, source, routeIndexTracker);
     }
     return emissionSource;
   }
 
   private void addVesselGroup(final IsGmlMooringInlandShipping mooringInlandShipping, final MooringInlandShippingEmissionSource emissionSource,
-      final String sourceId) throws AeriusException {
+      final T source, final AtomicInteger routeIndexTracker) throws AeriusException {
     final StandardMooringInlandShipping vesselGroupEmissionValues = new StandardMooringInlandShipping();
     vesselGroupEmissionValues.setDescription(mooringInlandShipping.getDescription());
     vesselGroupEmissionValues.setShipCode(mooringInlandShipping.getCode());
     vesselGroupEmissionValues.setAverageResidenceTime(mooringInlandShipping.getAverageResidenceTime());
     if (mooringInlandShipping.getRoutes() != null) {
       for (final IsGmlProperty<IsGmlInlandShippingRoute> isrp : mooringInlandShipping.getRoutes()) {
-        addRoute(isrp.getProperty(), vesselGroupEmissionValues, sourceId);
+        addRoute(isrp.getProperty(), vesselGroupEmissionValues, source, routeIndexTracker);
       }
     }
     // Assume movements in arrival and departure match, and we can divide by 2 to get to the number of ships moored.
@@ -72,10 +77,11 @@ public class GML2InlandMooring<T extends IsGmlMooringInlandShippingEmissionSourc
   }
 
   private void addRoute(final IsGmlInlandShippingRoute inlandShippingRoute, final StandardMooringInlandShipping vesselGroupEmissionValues,
-      final String sourceId) throws AeriusException {
+      final T source, final AtomicInteger routeIndexTracker) throws AeriusException {
+    final String sourceId = source.getId();
     final InlandShippingEmissionSource route = gml2route.findRoute(
         inlandShippingRoute.getRoute(), getConversionData().getInlandRoutes(), sourceId, "InlandMooringRoute",
-        () -> this.createRoute(inlandShippingRoute.getInlandWaterwayProperty()));
+        () -> this.createRoute(inlandShippingRoute.getInlandWaterwayProperty(), source.getLabel(), routeIndexTracker));
     final StandardInlandShipping imr = new StandardInlandShipping();
     imr.setDescription(vesselGroupEmissionValues.getDescription());
     imr.setShipCode(vesselGroupEmissionValues.getShipCode());
@@ -95,6 +101,12 @@ public class GML2InlandMooring<T extends IsGmlMooringInlandShippingEmissionSourc
     route.getSubSources().add(imr);
     route.setMooringAId(sourceId);
     addRouteShipsToMooringShips(inlandShippingRoute, vesselGroupEmissionValues);
+    additionalRouteStuff(inlandShippingRoute, route, source);
+  }
+
+  protected void additionalRouteStuff(final IsGmlInlandShippingRoute inlandShippingRoute, final InlandShippingEmissionSource route, final T source)
+      throws AeriusException {
+    // NO-OP for this version
   }
 
   private void addRouteShipsToMooringShips(final IsGmlInlandShippingRoute inlandShippingRoute,
@@ -131,12 +143,24 @@ public class GML2InlandMooring<T extends IsGmlMooringInlandShippingEmissionSourc
     return (percentageLadenExisting * shipsExisting + percentageLadenToAdd * shipsToAdd) / (shipsExisting + shipsToAdd);
   }
 
-  private InlandShippingEmissionSource createRoute(final IsGmlProperty<IsGmlInlandWaterway> waterwayProperty) {
+  protected InlandShippingEmissionSource createRoute(final IsGmlProperty<IsGmlInlandWaterway> waterwayProperty, final String sourceLabel,
+      final AtomicInteger routeIndexTracker) {
     final InlandShippingEmissionSource mooringRoute = new InlandShippingEmissionSource();
     final InlandWaterway waterway = GML2InlandUtil.toInlandWaterway(waterwayProperty);
     mooringRoute.setSectorId(DEFAULT_ROUTE_SECTOR_ID);
     mooringRoute.setWaterway(waterway);
+    mooringRoute.setLabel(constructLabel(sourceLabel, routeIndexTracker));
     return mooringRoute;
+  }
+
+  protected String constructLabel(final String sourceLabel, final AtomicInteger routeIndexTracker) {
+    // Routes did not have a name in old GML, so come up with our own label
+    // Might not be completely i18n, but works for both NL and EN at least.
+    final int currentIndex = routeIndexTracker.getAndIncrement();
+    final String routeDescription = "Route " + currentIndex;
+    return Stream.of(sourceLabel, routeDescription)
+        .filter(x -> x != null && !x.isBlank())
+        .collect(Collectors.joining("; "));
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/ship/v31/GML2InlandMooring.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/ship/v31/GML2InlandMooring.java
@@ -17,8 +17,6 @@
 package nl.overheid.aerius.gml.base.source.ship.v31;
 
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
@@ -106,7 +104,7 @@ public class GML2InlandMooring<T extends IsGmlMooringInlandShippingEmissionSourc
 
   protected void additionalRouteStuff(final IsGmlInlandShippingRoute inlandShippingRoute, final InlandShippingEmissionSource route, final T source)
       throws AeriusException {
-    // NO-OP for this version
+    // NO-OP, intended for behavior by child class that for example enforces waterway
   }
 
   private void addRouteShipsToMooringShips(final IsGmlInlandShippingRoute inlandShippingRoute,
@@ -158,9 +156,7 @@ public class GML2InlandMooring<T extends IsGmlMooringInlandShippingEmissionSourc
     // Might not be completely i18n, but works for both NL and EN at least.
     final int currentIndex = routeIndexTracker.getAndIncrement();
     final String routeDescription = "Route " + currentIndex;
-    return Stream.of(sourceLabel, routeDescription)
-        .filter(x -> x != null && !x.isBlank())
-        .collect(Collectors.joining("; "));
+    return constructLabelOf(sourceLabel, routeDescription);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/ship/v31/GML2MaritimeMooring.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/ship/v31/GML2MaritimeMooring.java
@@ -18,8 +18,6 @@ package nl.overheid.aerius.gml.base.source.ship.v31;
 
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.IntSupplier;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
@@ -127,9 +125,7 @@ public class GML2MaritimeMooring<T extends IsGmlMooringMaritimeShippingEmissionS
     // Might not be completely i18n, but works for both NL and EN at least.
     final int currentIndex = routeIndexTracker.getAsInt();
     final String routeDescription = "Route " + currentIndex;
-    return Stream.of(sourceLabel, routeDescription)
-        .filter(x -> x != null && !x.isBlank())
-        .collect(Collectors.joining("; "));
+    return constructLabelOf(sourceLabel, routeDescription);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/ship/v31/GML2MaritimeMooring.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/ship/v31/GML2MaritimeMooring.java
@@ -16,6 +16,11 @@
  */
 package nl.overheid.aerius.gml.base.source.ship.v31;
 
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.IntSupplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGmlProperty;
@@ -50,6 +55,7 @@ public class GML2MaritimeMooring<T extends IsGmlMooringMaritimeShippingEmissionS
   @Override
   public MooringMaritimeShippingEmissionSource convert(final T source) throws AeriusException {
     final MooringMaritimeShippingEmissionSource emissionValues = new MooringMaritimeShippingEmissionSource();
+    final AtomicInteger inlandRouteIndexTracker = new AtomicInteger(1);
     for (final IsGmlProperty<IsGmlMooringMaritimeShipping> mooringMaritimeShippingProperty : source.getShips()) {
       final IsGmlMooringMaritimeShipping mooringMaritimeShipping = mooringMaritimeShippingProperty.getProperty();
       final StandardMooringMaritimeShipping vesselGroupEmissionValues = new StandardMooringMaritimeShipping();
@@ -59,7 +65,7 @@ public class GML2MaritimeMooring<T extends IsGmlMooringMaritimeShippingEmissionS
       vesselGroupEmissionValues.setShipsPerTimeUnit(mooringMaritimeShipping.getShipsPerTimeUnit());
       vesselGroupEmissionValues.setTimeUnit(TimeUnit.valueOf(mooringMaritimeShipping.getTimeUnit().name()));
       if (mooringMaritimeShipping.getInlandRoute() != null) {
-        handleInlandRoute(mooringMaritimeShipping, source.getId());
+        handleInlandRoute(mooringMaritimeShipping, source, inlandRouteIndexTracker);
       }
       handleMaritimeRoutes(mooringMaritimeShipping, source.getId());
       emissionValues.getSubSources().add(vesselGroupEmissionValues);
@@ -68,9 +74,11 @@ public class GML2MaritimeMooring<T extends IsGmlMooringMaritimeShippingEmissionS
   }
 
   private void handleInlandRoute(final IsGmlMooringMaritimeShipping mooringMaritimeShipping,
-      final String sourceId) throws AeriusException {
+      final T source, final AtomicInteger inlandRouteIndexTracker) throws AeriusException {
+    final String sourceId = source.getId();
     final InlandMaritimeShippingEmissionSource route = gml2route.findRoute(mooringMaritimeShipping.getInlandRoute(),
-        getConversionData().getMaritimeInlandRoutes(), sourceId, "MaritimeInlandMooringRoute", this::createInlandRoute);
+        getConversionData().getMaritimeInlandRoutes(), sourceId, "MaritimeInlandMooringRoute",
+        () -> createInlandRoute(source.getLabel(), inlandRouteIndexTracker));
     final StandardMaritimeShipping mr = new StandardMaritimeShipping();
     mr.setDescription(mooringMaritimeShipping.getDescription());
     mr.setShipCode(mooringMaritimeShipping.getCode());
@@ -81,9 +89,10 @@ public class GML2MaritimeMooring<T extends IsGmlMooringMaritimeShippingEmissionS
     route.setMooringAId(sourceId);
   }
 
-  private InlandMaritimeShippingEmissionSource createInlandRoute() {
+  private InlandMaritimeShippingEmissionSource createInlandRoute(final String sourceLabel, final AtomicInteger inlandRouteIndexTracker) {
     final InlandMaritimeShippingEmissionSource source = new InlandMaritimeShippingEmissionSource();
     source.setSectorId(DEFAULT_SECTOR_INLAND_ROUTE);
+    source.setLabel(constructLabel(sourceLabel, inlandRouteIndexTracker::getAndIncrement));
     return source;
   }
 
@@ -107,7 +116,20 @@ public class GML2MaritimeMooring<T extends IsGmlMooringMaritimeShippingEmissionS
   private MaritimeMaritimeShippingEmissionSource createMaritimeRoute() {
     final MaritimeMaritimeShippingEmissionSource source = new MaritimeMaritimeShippingEmissionSource();
     source.setSectorId(DEFAULT_SECTOR_MARITIME_ROUTE);
+    // Maritime routes used to be global, so can't really tie them to 1 source.
+    // Hence, use the global available routes to determine index, and don't use anything source specific.
+    source.setLabel(constructLabel(null, () -> getConversionData().getMaritimeMaritimeRoutes().size() + 1));
     return source;
+  }
+
+  private String constructLabel(final String sourceLabel, final IntSupplier routeIndexTracker) {
+    // Routes did not have a name in old GML, so come up with our own label
+    // Might not be completely i18n, but works for both NL and EN at least.
+    final int currentIndex = routeIndexTracker.getAsInt();
+    final String routeDescription = "Route " + currentIndex;
+    return Stream.of(sourceLabel, routeDescription)
+        .filter(x -> x != null && !x.isBlank())
+        .collect(Collectors.joining("; "));
   }
 
 }

--- a/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/mooringinland.gml
+++ b/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/mooringinland.gml
@@ -81,6 +81,7 @@
                     <imaer:localId>ES.InlandMooringRoute.0</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
+            <imaer:label>binnenvaart aanlegplaats; Route 1</imaer:label>
             <imaer:geometry>
                 <imaer:EmissionSourceGeometry>
                     <imaer:GM_Curve>
@@ -137,6 +138,7 @@
                     <imaer:localId>ES.InlandMooringRoute.1</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
+            <imaer:label>binnenvaart aanlegplaats; Route 2</imaer:label>
             <imaer:geometry>
                 <imaer:EmissionSourceGeometry>
                     <imaer:GM_Curve>

--- a/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/mooringmaritime.gml
+++ b/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/mooringmaritime.gml
@@ -80,6 +80,7 @@
                     <imaer:localId>ES.MaritimeInlandMooringRoute.0</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
+            <imaer:label>Zeescheepvaart haven; Route 1</imaer:label>
             <imaer:geometry>
                 <imaer:EmissionSourceGeometry>
                     <imaer:GM_Curve>
@@ -127,6 +128,7 @@
                     <imaer:localId>ES.MaritimeMaritimeMooringRoute.0</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
+            <imaer:label>Route 1</imaer:label>
             <imaer:geometry>
                 <imaer:EmissionSourceGeometry>
                     <imaer:GM_Curve>
@@ -173,6 +175,7 @@
                     <imaer:localId>ES.MaritimeMaritimeMooringRoute.1</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
+            <imaer:label>Route 2</imaer:label>
             <imaer:geometry>
                 <imaer:EmissionSourceGeometry>
                     <imaer:GM_Curve>


### PR DESCRIPTION
As it was the label for sources that were created for routes for mooring shipping for older IMAER versions (<= 3.1) were always empty. 

With this change, an attempt is made to get a label for these sources based on their context.
- Inland mooring routes get `[mooring source label]; Route [route index within the mooring source]`
- Maritime Inland mooring routes ('binnengaats') get `[mooring source label]; Route [route index within the mooring source]`
- Maritime maritime mooring routes get `Route [global route index]` (as these routes were re-usable in AERIUS-II between sources, this made a bit more sense).