### PR TITLE
AER3-1238 Mobile source backwards compatibility change

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLConversionData.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLConversionData.java
@@ -143,12 +143,11 @@ public class GMLConversionData {
     return returnCode;
   }
 
-  public int estimageOffRoadOperatingHours(final String oldCode, final int literFuelPerYear,
-      final Integer hoursIdlePerYear, final Double engineDisplacement) {
+  public int estimageOffRoadOperatingHours(final String oldCode, final int literFuelPerYear) {
     final MobileSourceOffRoadConversion conversion = legacyCodeConverter.getMobileSourceOffRoadConversion(oldCode);
     int estimation = 0;
     if (conversion != null) {
-      estimation = conversion.estimageOffRoadOperatingHours(literFuelPerYear, hoursIdlePerYear, engineDisplacement);
+      estimation = conversion.estimageOffRoadOperatingHours(literFuelPerYear);
     }
     return estimation;
   }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/conversion/MobileSourceOffRoadConversion.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/conversion/MobileSourceOffRoadConversion.java
@@ -28,6 +28,15 @@ public class MobileSourceOffRoadConversion {
   private final BigDecimal fuelConsumption;
 
   /**
+   * @deprecated since fuelConsumptionIdle has no effect anymore.
+   * Left in for now to let existing branches be compilable.
+   */
+  @Deprecated
+  public MobileSourceOffRoadConversion(final double fuelConsumption, final Double fuelConsumptionIdle) {
+    this(fuelConsumption);
+  }
+
+  /**
    * @param fuelConsumption The average fuel consumption per hour (in l/h).
    */
   public MobileSourceOffRoadConversion(final double fuelConsumption) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v31/GML2OffRoad.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v31/GML2OffRoad.java
@@ -84,8 +84,7 @@ public class GML2OffRoad<T extends IsGmlOffRoadMobileEmissionSource> extends Abs
     if (!oldCode.equals(newCode)) {
       // If the code was converted, that means we can convert from the old properties to the new properties
       // In theory this should be for all codes, but there's a possibility that the code supplied was incorrect in the first place.
-      final int estimatedOperatingHours = getConversionData().estimageOffRoadOperatingHours(oldCode, mobileSource.getLiterFuelPerYear(),
-          mobileSource.getHoursIdlePerYear(), mobileSource.getEngineDisplacement());
+      final int estimatedOperatingHours = getConversionData().estimageOffRoadOperatingHours(oldCode, mobileSource.getLiterFuelPerYear());
       vehicleEmissionValues.setOperatingHoursPerYear(estimatedOperatingHours);
       vehicleEmissionValues.setLiterAdBluePerYear(0);
     }

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/base/conversion/MobileSourceOffRoadConversionTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/base/conversion/MobileSourceOffRoadConversionTest.java
@@ -26,56 +26,12 @@ import org.junit.jupiter.api.Test;
 class MobileSourceOffRoadConversionTest {
 
   @Test
-  void testWithIdle() {
-    final double fuelConsumptionUnderLoad = 2.4;
-    final double fuelConsumptionIdle = 0.42;
-    final MobileSourceOffRoadConversion conversion = new MobileSourceOffRoadConversion(fuelConsumptionUnderLoad, fuelConsumptionIdle);
+  void testConversion() {
+    final double fuelConsumption = 2.4;
+    final MobileSourceOffRoadConversion conversion = new MobileSourceOffRoadConversion(fuelConsumption);
 
-    // No idle supplied: 1000 / 2.4 = 416.6667
-    assertEquals(417, conversion.estimageOffRoadOperatingHours(1000, null, null));
-    // Only hours idle but no engine displacement has same effect
-    assertEquals(417, conversion.estimageOffRoadOperatingHours(1000, 30, null));
-    // Only engine displacement but no hours idle has same effect
-    assertEquals(417, conversion.estimageOffRoadOperatingHours(1000, null, 4.0));
-    // zero engine displacement and non-zero idle hours does have effect
-    assertEquals(447, conversion.estimageOffRoadOperatingHours(1000, 30, 0.0));
-    // non-zero engine displacement and zero idle hours does not have effect
-    assertEquals(417, conversion.estimageOffRoadOperatingHours(1000, 0, 4.0));
-    // all three supplied:
-    // 30 * (1 - (0.42 * 4.0) / 2.4) + 1000 / 2.4 = 425.6667
-    assertEquals(426, conversion.estimageOffRoadOperatingHours(1000, 30, 4.0));
-  }
-
-  @Test
-  void testWithIdleExcessive() {
-    final double fuelConsumptionUnderLoad = 2.4;
-    final double fuelConsumptionIdle = 0.42;
-    final MobileSourceOffRoadConversion conversion = new MobileSourceOffRoadConversion(fuelConsumptionUnderLoad, fuelConsumptionIdle);
-
-    // It's possible that a user supplies unrealistic value for engine displacement (which we no longer validate)
-    // 30 * (1 - (0.42 * 400.0) / 2.4) + 1000 / 2.4 = -1653.3333
-    // we're avoiding negative values however, so should end up with an estimation of 0
-    assertEquals(0, conversion.estimageOffRoadOperatingHours(1000, 30, 400.0));
-  }
-
-  @Test
-  void testWithoutIdle() {
-    final double fuelConsumptionUnderLoad = 2.4;
-    final MobileSourceOffRoadConversion conversion = new MobileSourceOffRoadConversion(fuelConsumptionUnderLoad, null);
-
-    // No idle supplied: 1000 / 2.4 = 416.6667
-    assertEquals(417, conversion.estimageOffRoadOperatingHours(1000, null, null));
-    // Only hours idle but no engine displacement has same effect
-    assertEquals(417, conversion.estimageOffRoadOperatingHours(1000, 30, null));
-    // Only engine displacement but no hours idle has same effect
-    assertEquals(417, conversion.estimageOffRoadOperatingHours(1000, null, 4.0));
-    // zero engine displacement and non-zero idle hours does have effect
-    assertEquals(447, conversion.estimageOffRoadOperatingHours(1000, 30, 0.0));
-    // non-zero engine displacement and zero idle hours does not have effect
-    assertEquals(417, conversion.estimageOffRoadOperatingHours(1000, 0, 4.0));
-    // all three supplied:
-    // 30 * (1 - (0 * 4.0) / 2.4) + 1000 / 2.4 = 446.6667
-    assertEquals(447, conversion.estimageOffRoadOperatingHours(1000, 30, 4.0));
+    // Result should be: 1000 / 2.4 = 416.6667
+    assertEquals(417, conversion.estimageOffRoadOperatingHours(1000));
   }
 
 }

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/test/TestValidationAndEmissionHelper.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/test/TestValidationAndEmissionHelper.java
@@ -146,10 +146,10 @@ public class TestValidationAndEmissionHelper implements ValidationHelper, Emissi
           new EmissionHelper(-0.46, 0.0)));
 
   private static final List<OffRoadOldCodesHelper> OFF_ROAD_MOBILE_SOURCE_OLD_CODES = Arrays.asList(
-      new OffRoadOldCodesHelper("S1A", "SI75560DSN", 14.690993, 0.410843),
-      new OffRoadOldCodesHelper("S2F", "SII75560DSN", 6.8731995, 0.410843),
-      new OffRoadOldCodesHelper("SVM4C30", "B4T", 1.0687796, null),
-      new OffRoadOldCodesHelper("P1980", "SI75560DSN", 16.208658, 0.410843));
+      new OffRoadOldCodesHelper("S1A", "SI75560DSN", 19.54),
+      new OffRoadOldCodesHelper("S2F", "SII75560DSN", 19.54),
+      new OffRoadOldCodesHelper("SVM4C30", "B4T", 2.44),
+      new OffRoadOldCodesHelper("P1980", "SI75560DSN", 19.54));
 
   private static final List<GenericConstructHelper> OLD_PLAN_CATEGORIES = Arrays.asList(
       new GenericConstructHelper("PHA", new EmissionHelper(1.10997, 0.0)),
@@ -288,15 +288,12 @@ public class TestValidationAndEmissionHelper implements ValidationHelper, Emissi
 
     final String oldCode;
     final String newCode;
-    final double fuelConsumptionUnderLoad;
-    final Double fuelConsumptionIdle;
+    final double fuelConsumption;
 
-    public OffRoadOldCodesHelper(final String oldCode, final String newCode, final double fuelConsumptionUnderLoad,
-        final Double fuelConsumptionIdle) {
+    public OffRoadOldCodesHelper(final String oldCode, final String newCode, final double fuelConsumption) {
       this.oldCode = oldCode;
       this.newCode = newCode;
-      this.fuelConsumptionUnderLoad = fuelConsumptionUnderLoad;
-      this.fuelConsumptionIdle = fuelConsumptionIdle;
+      this.fuelConsumption = fuelConsumption;
     }
 
   }
@@ -381,7 +378,7 @@ public class TestValidationAndEmissionHelper implements ValidationHelper, Emissi
   public static Map<String, MobileSourceOffRoadConversion> legacyMobileSourceOffRoadConversions() {
     final Map<String, MobileSourceOffRoadConversion> conversions = new HashMap<>();
     OFF_ROAD_MOBILE_SOURCE_OLD_CODES.forEach(
-        helper -> conversions.put(helper.oldCode, new MobileSourceOffRoadConversion(helper.fuelConsumptionUnderLoad, helper.fuelConsumptionIdle)));
+        helper -> conversions.put(helper.oldCode, new MobileSourceOffRoadConversion(helper.fuelConsumption)));
     return conversions;
   }
 

--- a/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/offroad.gml
+++ b/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/offroad.gml
@@ -52,7 +52,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>3034.035</imaer:value>
+                    <imaer:value>3025.59</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -69,7 +69,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="SI75560DSN">
                     <imaer:description>Voertuigen</imaer:description>
                     <imaer:literFuelPerYear>100000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>6807</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>5118</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>
@@ -103,7 +103,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>9102.105</imaer:value>
+                    <imaer:value>9076.765</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -120,7 +120,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="SI75560DSN">
                     <imaer:description></imaer:description>
                     <imaer:literFuelPerYear>300000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>20421</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>15353</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>
@@ -154,7 +154,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>30340.345</imaer:value>
+                    <imaer:value>30255.885</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -171,7 +171,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="SI75560DSN">
                     <imaer:description></imaer:description>
                     <imaer:literFuelPerYear>1000000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>68069</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>51177</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>
@@ -201,7 +201,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>15170.17</imaer:value>
+                    <imaer:value>15127.945</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -218,7 +218,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="SI75560DSN">
                     <imaer:description></imaer:description>
                     <imaer:literFuelPerYear>500000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>34034</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>25589</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>
@@ -252,7 +252,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>27306.31</imaer:value>
+                    <imaer:value>27230.295</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -269,7 +269,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="SI75560DSN">
                     <imaer:description></imaer:description>
                     <imaer:literFuelPerYear>900000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>61262</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>46059</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>
@@ -303,7 +303,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>207.275</imaer:value>
+                    <imaer:value>202.56</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -320,7 +320,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="SII75560DSN">
                     <imaer:description>Traktors</imaer:description>
                     <imaer:literFuelPerYear>10000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>1455</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>512</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>

--- a/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/offroad_idle_and_nh3.gml
+++ b/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/offroad_idle_and_nh3.gml
@@ -52,7 +52,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>207.995</imaer:value>
+                    <imaer:value>202.56</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -69,7 +69,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="SII75560DSN">
                     <imaer:description>Traktors</imaer:description>
                     <imaer:literFuelPerYear>10000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>1599</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>512</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>

--- a/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/offroad_non_idle.gml
+++ b/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/offroad_non_idle.gml
@@ -69,7 +69,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="B4T">
                     <imaer:description>Traktors</imaer:description>
                     <imaer:literFuelPerYear>10000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>9356</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>4098</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>

--- a/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/offroad_with_specifications.gml
+++ b/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/offroad_with_specifications.gml
@@ -52,7 +52,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>3034.035</imaer:value>
+                    <imaer:value>3025.59</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -69,7 +69,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="SI75560DSN">
                     <imaer:description>Voertuigen</imaer:description>
                     <imaer:literFuelPerYear>100000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>6807</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>5118</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>
@@ -103,7 +103,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>9102.105</imaer:value>
+                    <imaer:value>9076.765</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -120,7 +120,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="SI75560DSN">
                     <imaer:description></imaer:description>
                     <imaer:literFuelPerYear>300000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>20421</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>15353</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>
@@ -154,7 +154,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>30340.345</imaer:value>
+                    <imaer:value>30255.885</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -171,7 +171,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="SI75560DSN">
                     <imaer:description></imaer:description>
                     <imaer:literFuelPerYear>1000000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>68069</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>51177</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>
@@ -201,7 +201,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>15170.17</imaer:value>
+                    <imaer:value>15127.945</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -218,7 +218,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="SI75560DSN">
                     <imaer:description></imaer:description>
                     <imaer:literFuelPerYear>500000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>34034</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>25589</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>
@@ -252,7 +252,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>27306.31</imaer:value>
+                    <imaer:value>27230.295</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -269,7 +269,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="SI75560DSN">
                     <imaer:description></imaer:description>
                     <imaer:literFuelPerYear>900000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>61262</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>46059</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>
@@ -303,7 +303,7 @@
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>207.275</imaer:value>
+                    <imaer:value>202.56</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
@@ -320,7 +320,7 @@
                 <imaer:StandardOffRoadMobileSource offRoadMobileSourceType="SII75560DSN">
                     <imaer:description>Traktors</imaer:description>
                     <imaer:literFuelPerYear>10000</imaer:literFuelPerYear>
-                    <imaer:operatingHoursPerYear>1455</imaer:operatingHoursPerYear>
+                    <imaer:operatingHoursPerYear>512</imaer:operatingHoursPerYear>
                 </imaer:StandardOffRoadMobileSource>
             </imaer:offRoadMobileSource>
         </imaer:OffRoadMobileSourceEmissionSource>


### PR DESCRIPTION
Where we used to determine operating hours based on fuel consumption for the old category (which also had a possible idle component), we are now doing it based on the fuel consumption of the new category. The assumption is made that the literFuelPerYear is correct (as we don't know if the user specified this based on experience or based on a 'handreiking'). So all we're doing now is converting the liters fuel used to a total number of operating hours, and any idle properties possibly specified by the user are not taken into account.
Numbers used in the unittests are the ones supplied by the 'actualisatieteam' for the corresponding categories.