### PR TITLE
Remove deprecated constructor

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/conversion/MobileSourceOffRoadConversion.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/conversion/MobileSourceOffRoadConversion.java
@@ -28,15 +28,6 @@ public class MobileSourceOffRoadConversion {
   private final BigDecimal fuelConsumption;
 
   /**
-   * @deprecated since fuelConsumptionIdle has no effect anymore.
-   * Left in for now to let existing branches be compilable.
-   */
-  @Deprecated
-  public MobileSourceOffRoadConversion(final double fuelConsumption, final Double fuelConsumptionIdle) {
-    this(fuelConsumption);
-  }
-
-  /**
    * @param fuelConsumption The average fuel consumption per hour (in l/h).
    */
   public MobileSourceOffRoadConversion(final double fuelConsumption) {


### PR DESCRIPTION
Constructor was used to avoid compilation issues in other repository. Should be save to remove after some time (a few days).