### PR TITLE
Fix adding support for NSLCalculationPoints Type

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/point/CalculationPoint.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/point/CalculationPoint.java
@@ -34,6 +34,7 @@ import nl.overheid.aerius.shared.exception.AeriusException;
 @JsonSubTypes({
     @Type(value = ReceptorPoint.class, name = CalculationPointType.Names.RECEPTOR),
     @Type(value = CustomCalculationPoint.class, name = CalculationPointType.Names.CUSTOM_CALCULATION_POINT),
+    @Type(value = NSLCalculationPoint.class, name = CalculationPointType.Names.NSL_CALCULATION_POINT),
 })
 public abstract class CalculationPoint implements Serializable {
 

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/point/CalculationPointType.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/point/CalculationPointType.java
@@ -24,11 +24,16 @@ public enum CalculationPointType {
   /**
    * Custom calculation point.
    */
-  CUSTOM_CALCULATION_POINT(Names.CUSTOM_CALCULATION_POINT);
+  CUSTOM_CALCULATION_POINT(Names.CUSTOM_CALCULATION_POINT),
+  /**
+   * NSL calculation point.
+   */
+  NSL_CALCULATION_POINT(Names.NSL_CALCULATION_POINT);
 
   public static final class Names {
     public static final String RECEPTOR = "RECEPTOR";
     public static final String CUSTOM_CALCULATION_POINT = "CUSTOM_CALCULATION_POINT";
+    public static final String NSL_CALCULATION_POINT = "NSL_CALCULATION_POINT";
 
     private Names() {}
   }


### PR DESCRIPTION
NSLCaclulationPoint can also be part of GML therefor it should be added as type to CalculationPoint.

Fixes AER3-1332 where csv files imported cause an error when starting calculation because csv file is read as NSLCalculationPoint and when receiving at the server as part of a scenario to calculate it can't parse this type object causing it to crash.