### PR TITLE
Refactored GML2SourceCharacteristics to be more generic

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReader.java
@@ -21,12 +21,10 @@ import java.util.List;
 
 import nl.overheid.aerius.gml.base.AeriusGMLVersion;
 import nl.overheid.aerius.gml.base.FeatureCollection;
-import nl.overheid.aerius.gml.base.GMLCharacteristicsSupplier;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLHelper;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
 import nl.overheid.aerius.gml.base.GMLVersionReaderFactory;
-import nl.overheid.aerius.shared.domain.geo.ReceptorGridSettings;
 import nl.overheid.aerius.shared.domain.scenario.SituationType;
 import nl.overheid.aerius.shared.domain.v2.building.BuildingFeature;
 import nl.overheid.aerius.shared.domain.v2.nsl.NSLCorrection;
@@ -54,21 +52,19 @@ public final class GMLReader {
    * Constructor.
    *
    * @param gmlHelper The GML Helper
-   * @param rgs the receptor grid settings
-   * @param characteristicsSupplier
    * @param factory specific version factory
    * @param featureCollection the feature collection with parsed IMAER GML data
    * @param errors list to add errors on
    * @param warnings list to add warnings on
+   * @throws AeriusException
    */
-  GMLReader(final GMLHelper gmlHelper, final ReceptorGridSettings rgs, final GMLCharacteristicsSupplier characteristicsSupplier,
-      final GMLVersionReaderFactory factory, final FeatureCollection featureCollection, final List<AeriusException> errors,
-      final List<AeriusException> warnings) {
+  GMLReader(final GMLHelper gmlHelper, final GMLVersionReaderFactory factory, final FeatureCollection featureCollection,
+      final List<AeriusException> errors, final List<AeriusException> warnings) throws AeriusException {
     this.gmlHelper = gmlHelper;
     this.factory = factory;
     this.featureCollection = featureCollection;
     metaDataReader = new GMLMetaDataReader(featureCollection);
-    conversionData = new GMLConversionData(gmlHelper, factory.getLegacyCodeConverter(), characteristicsSupplier, rgs, errors, warnings);
+    conversionData = new GMLConversionData(gmlHelper, factory.getLegacyCodeConverter(), errors, warnings);
     versionReader = factory.createReader(conversionData);
   }
 
@@ -135,11 +131,11 @@ public final class GMLReader {
   }
 
   /**
-  * Retrieve all receptor points (domain objects) from a list of FeatureMembers.
-  * Only features extending AbstractCalculationPoint will be handled (AeriusPoint, CustomCalculationPoint, etc).
-  * @param includeResults if true also read results from GML
-  * @return List of all calculation points defined in the GML
-  */
+   * Retrieve all receptor points (domain objects) from a list of FeatureMembers.
+   * Only features extending AbstractCalculationPoint will be handled (AeriusPoint, CustomCalculationPoint, etc).
+   * @param includeResults if true also read results from GML
+   * @return List of all calculation points defined in the GML
+   */
   public List<CalculationPointFeature> getAeriusPoints(final boolean includeResults) {
     final List<CalculationPointFeature> points = new ArrayList<>();
     if ((featureCollection != null) && (featureCollection.getFeatureMembers() != null)) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
@@ -39,7 +39,6 @@ import net.opengis.gml.v_3_2_1.ObjectFactory;
 import nl.overheid.aerius.gml.base.FeatureCollection;
 import nl.overheid.aerius.gml.base.GMLHelper;
 import nl.overheid.aerius.gml.base.GMLVersionReaderFactory;
-import nl.overheid.aerius.shared.domain.geo.ReceptorGridSettings;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 import nl.overheid.aerius.validation.ValidationHelper;
@@ -55,21 +54,17 @@ public final class GMLReaderFactory {
 
   private final GMLReaderProxy readerProxy;
   private final GMLHelper gmlHelper;
-  private final ReceptorGridSettings rgs;
 
   GMLReaderFactory(final GMLHelper gmlHelper) throws AeriusException {
-    this.gmlHelper = gmlHelper;
-    readerProxy = new GMLReaderProxy(gmlHelper);
-    rgs = gmlHelper.getReceptorGridSettings();
+    this(gmlHelper, new GMLReaderProxy(gmlHelper));
   }
 
   /**
    * Constructor to use this factory with a specific version reader. Only used in tests.
    */
-  GMLReaderFactory(final GMLHelper gmlHelper, final GMLReaderProxy readerProxy, final ReceptorGridSettings rgs) {
+  GMLReaderFactory(final GMLHelper gmlHelper, final GMLReaderProxy readerProxy) {
     this.gmlHelper = gmlHelper;
     this.readerProxy = readerProxy;
-    this.rgs = rgs;
   }
 
   /**
@@ -107,8 +102,7 @@ public final class GMLReaderFactory {
       reader.nextTag();
       //determine version of the XML based on the namespaces available.
       factory = readerProxy.determineReaderFactory(reader.getNamespaceContext());
-      final GMLReader gmlr = new GMLReader(gmlHelper, rgs, gmlHelper, factory, convertToCollection(reader, factory, vec, validate),
-          errors, warnings);
+      final GMLReader gmlr = new GMLReader(gmlHelper, factory, convertToCollection(reader, factory, vec, validate), errors, warnings);
       checkEvents(vec.getEvents());
       return gmlr;
     } catch (final XMLStreamException e) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/AbstractGML2Source.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/AbstractGML2Source.java
@@ -24,7 +24,7 @@ import nl.overheid.aerius.gml.base.GMLLegacyCodeConverter.GMLLegacyCodeType;
 import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.base.geo.GML2Geometry;
 import nl.overheid.aerius.gml.base.source.IsGmlEmissionSource;
-import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
@@ -38,19 +38,22 @@ import nl.overheid.aerius.shared.exception.AeriusException;
 
 /**
  * Utility class to convert to and from GML objects (specific for emission sources).
+ *
+ * @Param <T> The GML version specific emission source
+ * @param <S> The specific type of source characteristics that are to be read from the gml
  */
-public abstract class AbstractGML2Source<T extends IsGmlEmissionSource> {
+public abstract class AbstractGML2Source<T extends IsGmlEmissionSource, S extends SourceCharacteristics> {
 
   private final GMLConversionData conversionData;
   private final GML2Geometry gml2geometry;
   private final IsGML2SourceVisitor<T> visitor;
-  private final GML2SourceCharacteristics gml2SourceCharacteristics;
+  private final GML2SourceCharacteristics<S> gml2SourceCharacteristics;
 
   /**
    * @param conversionData The data to use when converting. Should be filled.
    */
   protected AbstractGML2Source(final GMLConversionData conversionData, final IsGML2SourceVisitor<T> visitor,
-      final GML2SourceCharacteristics gml2SourceCharacteristics) {
+      final GML2SourceCharacteristics<S> gml2SourceCharacteristics) {
     this.conversionData = conversionData;
     this.gml2geometry = new GML2Geometry(conversionData.getSrid());
     this.visitor = visitor;
@@ -123,13 +126,12 @@ public abstract class AbstractGML2Source<T extends IsGmlEmissionSource> {
         || returnSource instanceof MooringMaritimeShippingEmissionSource
         || returnSource instanceof OffRoadMobileEmissionSource
         || returnSource instanceof PlanEmissionSource)) {
-      final OPSSourceCharacteristics sectorCharacteristics = conversionData.determineDefaultOPSCharacteristicsBySectorId(source.getSectorId());
+      final S sectorCharacteristics = conversionData.determineDefaultCharacteristicsBySectorId(source.getSectorId());
       if (source.getCharacteristics() == null) {
         // if characteristics weren't supplied in GML, use the sector default.
         returnSource.setCharacteristics(sectorCharacteristics);
       } else {
-        returnSource.setCharacteristics(
-            gml2SourceCharacteristics.fromGML(source.getCharacteristics(), sectorCharacteristics, geometry));
+        returnSource.setCharacteristics(gml2SourceCharacteristics.fromGML(source.getCharacteristics(), sectorCharacteristics, geometry));
       }
     }
   }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLCharacteristicsSupplier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLCharacteristicsSupplier.java
@@ -16,22 +16,23 @@
  */
 package nl.overheid.aerius.gml.base;
 
-import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.CharacteristicsType;
+import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 
 /**
- *
+ * Supplier for Source characteristics.
  */
 public interface GMLCharacteristicsSupplier {
 
   /**
-   * Determine the default OPS characteristics for a sector (based on AERIUS sector ID).
-   * Characteristics should contain at least:
-   * - diurnalVariation
-   * - heatContent
-   * - emissionHeight
-   * - spread
-   * - particleSizeDistribution
+   * Determine the default characteristics for a sector (based on AERIUS sector ID).
    */
-  OPSSourceCharacteristics determineDefaultCharacteristicsBySectorId(int sectorId);
+  <S extends SourceCharacteristics> S determineDefaultCharacteristicsBySectorId(int sectorId);
 
+  /**
+   * @return returns the data type of the characteristics.
+   */
+  default CharacteristicsType getCharacteristicsType() {
+    return CharacteristicsType.OPS;
+  }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionReaderFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionReaderFactory.java
@@ -112,5 +112,5 @@ public abstract class GMLVersionReaderFactory {
    * @param conversionData
    * @return
    */
-  public abstract GMLVersionReader createReader(GMLConversionData conversionData);
+  public abstract GMLVersionReader createReader(final GMLConversionData conversionData);
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2OPSSourceCharacteristics.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2OPSSourceCharacteristics.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.gml.base.characteristics;
+
+import nl.overheid.aerius.gml.base.GMLConversionData;
+import nl.overheid.aerius.shared.domain.ops.DiurnalVariation;
+import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
+import nl.overheid.aerius.shared.exception.AeriusException;
+
+/**
+ * GML source characteristics with OPS specific parameters conversion.
+ */
+public class GML2OPSSourceCharacteristics extends GML2SourceCharacteristics<OPSSourceCharacteristics> {
+
+  public GML2OPSSourceCharacteristics(final GMLConversionData conversionData) {
+    super(conversionData);
+  }
+
+  @Override
+  protected OPSSourceCharacteristics fromGMLSpecific(final IsBaseGmlEmissionSourceCharacteristics characteristics,
+      final OPSSourceCharacteristics sectorCharacteristics, final Geometry geometry) throws AeriusException {
+    final OPSSourceCharacteristics defaultCharacteristics = sectorCharacteristics == null ? new OPSSourceCharacteristics() : sectorCharacteristics;
+    final OPSSourceCharacteristics returnCharacteristics = new OPSSourceCharacteristics();
+    returnCharacteristics.setEmissionHeight(characteristics.getEmissionHeight());
+    returnCharacteristics.setSpread(getOrDefault(characteristics.getSpread(), defaultCharacteristics.getSpread()));
+    returnCharacteristics.setParticleSizeDistribution(defaultCharacteristics.getParticleSizeDistribution());
+
+    fromGMLToDiurnalVariation(characteristics, returnCharacteristics, defaultCharacteristics, geometry);
+    fromGMLToHeatContent(characteristics, returnCharacteristics);
+
+    return returnCharacteristics;
+  }
+
+  private void fromGMLToDiurnalVariation(final IsBaseGmlEmissionSourceCharacteristics characteristics,
+      final OPSSourceCharacteristics returnCharacteristics, final OPSSourceCharacteristics defaultCharacteristics, final Geometry geometry)
+          throws AeriusException {
+    if (characteristics instanceof IsGmlEmissionSourceCharacteristicsV31) {
+      fromGMLToDiurnalVariation((IsGmlEmissionSourceCharacteristicsV31) characteristics, returnCharacteristics, defaultCharacteristics);
+    } else if (characteristics instanceof IsGmlEmissionSourceCharacteristics) {
+      fromGMLToDiurnalVariation((IsGmlEmissionSourceCharacteristics) characteristics, returnCharacteristics, defaultCharacteristics);
+    }
+  }
+
+  private void fromGMLToDiurnalVariation(final IsGmlEmissionSourceCharacteristicsV31 characteristics,
+      final OPSSourceCharacteristics returnCharacteristics, final OPSSourceCharacteristics defaultCharacteristics) {
+    if (characteristics.getDiurnalVariation() == null) {
+      returnCharacteristics.setDiurnalVariation(defaultCharacteristics.getDiurnalVariation());
+    } else {
+      final String diurnalVariationCode = characteristics.getDiurnalVariation();
+      returnCharacteristics.setDiurnalVariation(DiurnalVariation.safeValueOf(diurnalVariationCode));
+    }
+  }
+
+  private void fromGMLToDiurnalVariation(final IsGmlEmissionSourceCharacteristics characteristics,
+      final OPSSourceCharacteristics returnCharacteristics, final OPSSourceCharacteristics defaultCharacteristics) {
+    if (characteristics.getDiurnalVariation() == null) {
+      returnCharacteristics.setDiurnalVariation(defaultCharacteristics.getDiurnalVariation());
+    } else if (characteristics.getDiurnalVariation() instanceof IsGmlStandardDiurnalVariation) {
+      final String diurnalVariationCode = ((IsGmlStandardDiurnalVariation) characteristics.getDiurnalVariation()).getCode();
+      returnCharacteristics.setDiurnalVariation(DiurnalVariation.safeValueOf(diurnalVariationCode));
+    } else if (characteristics.getDiurnalVariation() instanceof IsGmlReferenceDiurnalVariation) {
+      final IsGmlReferenceDiurnalVariation gmlReferenceDiurnalVariation = (IsGmlReferenceDiurnalVariation) characteristics.getDiurnalVariation();
+      returnCharacteristics.setCustomDiurnalVariationId(gmlReferenceDiurnalVariation.getCustomDiurnalVariation().getReferredId());
+    }
+  }
+
+  private void fromGMLToHeatContent(final IsBaseGmlEmissionSourceCharacteristics characteristics,
+      final OPSSourceCharacteristics returnCharacteristics) {
+    final IsGmlHeatContent gmlHeatContent = characteristics.getHeatContent();
+    if (gmlHeatContent instanceof IsGmlSpecifiedHeatContent) {
+      returnCharacteristics.setHeatContentType(HeatContentType.NOT_FORCED);
+      returnCharacteristics.setHeatContent(((IsGmlSpecifiedHeatContent) gmlHeatContent).getValue());
+    } else if (gmlHeatContent instanceof IsGmlCalculatedHeatContent) {
+      returnCharacteristics.setHeatContentType(HeatContentType.FORCED);
+      final IsGmlCalculatedHeatContent calculatedHeatContent = (IsGmlCalculatedHeatContent) gmlHeatContent;
+      fromGmlToEmissionTemperature(returnCharacteristics, calculatedHeatContent);
+      returnCharacteristics.setOutflowDiameter(calculatedHeatContent.getOutflowDiameter());
+      returnCharacteristics.setOutflowVelocity(calculatedHeatContent.getOutflowVelocity());
+      returnCharacteristics.setOutflowDirection(calculatedHeatContent.getOutflowDirection());
+      returnCharacteristics.setOutflowVelocityType(calculatedHeatContent.getOutflowVelocityType());
+    }
+  }
+
+  protected void fromGmlToEmissionTemperature(final OPSSourceCharacteristics returnCharacteristics, final IsGmlCalculatedHeatContent gmlHeatContent) {
+    returnCharacteristics.setEmissionTemperature(gmlHeatContent.getEmissionTemperature());
+  }
+
+  private static <T extends Number> T getOrDefault(final T value, final T defaultValue) {
+    return value == null ? defaultValue : value;
+  }
+}

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2SourceCharacteristics.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2SourceCharacteristics.java
@@ -19,11 +19,9 @@ package nl.overheid.aerius.gml.base.characteristics;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGmlReferenceType;
 import nl.overheid.aerius.gml.base.building.IsGmlBuildingV31;
-import nl.overheid.aerius.shared.domain.ops.DiurnalVariation;
 import nl.overheid.aerius.shared.domain.v2.building.Building;
 import nl.overheid.aerius.shared.domain.v2.building.BuildingFeature;
-import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
-import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.domain.v2.geojson.Polygon;
 import nl.overheid.aerius.shared.exception.AeriusException;
@@ -33,7 +31,7 @@ import nl.overheid.aerius.util.gml.GMLIdUtil;
 /**
  * Class to convert to and from GML objects (specific for source characteristics).
  */
-public class GML2SourceCharacteristics {
+public abstract class GML2SourceCharacteristics<T extends SourceCharacteristics> {
 
   private final GMLConversionData conversionData;
 
@@ -41,37 +39,31 @@ public class GML2SourceCharacteristics {
     this.conversionData = conversionData;
   }
 
-  public OPSSourceCharacteristics fromGML(final IsBaseGmlEmissionSourceCharacteristics characteristics,
-      final OPSSourceCharacteristics sectorCharacteristics, final Geometry geometry) throws AeriusException {
-    final OPSSourceCharacteristics defaultCharacteristics = sectorCharacteristics == null ? new OPSSourceCharacteristics() : sectorCharacteristics;
-    final OPSSourceCharacteristics returnCharacteristics = new OPSSourceCharacteristics();
-    returnCharacteristics.setEmissionHeight(characteristics.getEmissionHeight());
-    returnCharacteristics.setSpread(getOrDefault(characteristics.getSpread(), defaultCharacteristics.getSpread()));
-    returnCharacteristics.setParticleSizeDistribution(defaultCharacteristics.getParticleSizeDistribution());
+  public T fromGML(final IsBaseGmlEmissionSourceCharacteristics characteristics, final T sectorCharacteristics,
+      final Geometry geometry)
+          throws AeriusException {
+    final T returnCharacteristics = fromGMLSpecific(characteristics, sectorCharacteristics, geometry);
 
-    fromGMLToBuildingProperties(characteristics, returnCharacteristics, defaultCharacteristics, geometry);
-
-    fromGMLToHeatContent(characteristics, returnCharacteristics);
-
+    fromGMLToBuildingProperties(characteristics, returnCharacteristics, geometry);
     return returnCharacteristics;
   }
 
+  protected abstract T fromGMLSpecific(final IsBaseGmlEmissionSourceCharacteristics characteristics,
+      final T sectorCharacteristics, final Geometry geometry) throws AeriusException;
+
   private void fromGMLToBuildingProperties(final IsBaseGmlEmissionSourceCharacteristics characteristics,
-      final OPSSourceCharacteristics returnCharacteristics, final OPSSourceCharacteristics defaultCharacteristics, final Geometry geometry)
-      throws AeriusException {
+      final SourceCharacteristics returnCharacteristics, final Geometry geometry) throws AeriusException {
     if (characteristics instanceof IsGmlEmissionSourceCharacteristicsV31) {
       final IsGmlEmissionSourceCharacteristicsV31 oldCharacteristics = (IsGmlEmissionSourceCharacteristicsV31) characteristics;
       fromGMLToBuildingProperties(oldCharacteristics, returnCharacteristics, geometry);
-      fromGMLToDiurnalVariation(oldCharacteristics, returnCharacteristics, defaultCharacteristics);
     } else if (characteristics instanceof IsGmlEmissionSourceCharacteristics) {
       final IsGmlEmissionSourceCharacteristics newCharacteristics = (IsGmlEmissionSourceCharacteristics) characteristics;
       fromGMLToBuildingProperties(newCharacteristics, returnCharacteristics);
-      fromGMLToDiurnalVariation(newCharacteristics, returnCharacteristics, defaultCharacteristics);
     }
   }
 
   private void fromGMLToBuildingProperties(final IsGmlEmissionSourceCharacteristicsV31 characteristics,
-      final OPSSourceCharacteristics returnCharacteristics, final Geometry geometry) throws AeriusException {
+      final SourceCharacteristics returnCharacteristics, final Geometry geometry) throws AeriusException {
     final IsGmlBuildingV31 gmlBuilding = characteristics.getBuilding();
     if (gmlBuilding != null && conversionData != null && geometry != null) {
       final int buildingIdInt = conversionData.getExtraBuildings().size() + 1;
@@ -94,58 +86,10 @@ public class GML2SourceCharacteristics {
   }
 
   private void fromGMLToBuildingProperties(final IsGmlEmissionSourceCharacteristics characteristics,
-      final OPSSourceCharacteristics returnCharacteristics) {
+      final SourceCharacteristics returnCharacteristics) {
     final IsGmlReferenceType gmlBuilding = characteristics.getBuilding();
     if (gmlBuilding != null) {
       returnCharacteristics.setBuildingId(gmlBuilding.getReferredId());
     }
-  }
-
-  private void fromGMLToDiurnalVariation(final IsGmlEmissionSourceCharacteristicsV31 characteristics,
-      final OPSSourceCharacteristics returnCharacteristics, final OPSSourceCharacteristics defaultCharacteristics) {
-    if (characteristics.getDiurnalVariation() == null) {
-      returnCharacteristics.setDiurnalVariation(defaultCharacteristics.getDiurnalVariation());
-    } else {
-      final String diurnalVariationCode = characteristics.getDiurnalVariation();
-      returnCharacteristics.setDiurnalVariation(DiurnalVariation.safeValueOf(diurnalVariationCode));
-    }
-  }
-
-  private void fromGMLToDiurnalVariation(final IsGmlEmissionSourceCharacteristics characteristics,
-      final OPSSourceCharacteristics returnCharacteristics, final OPSSourceCharacteristics defaultCharacteristics) {
-    if (characteristics.getDiurnalVariation() == null) {
-      returnCharacteristics.setDiurnalVariation(defaultCharacteristics.getDiurnalVariation());
-    } else if (characteristics.getDiurnalVariation() instanceof IsGmlStandardDiurnalVariation) {
-      final String diurnalVariationCode = ((IsGmlStandardDiurnalVariation) characteristics.getDiurnalVariation()).getCode();
-      returnCharacteristics.setDiurnalVariation(DiurnalVariation.safeValueOf(diurnalVariationCode));
-    } else if (characteristics.getDiurnalVariation() instanceof IsGmlReferenceDiurnalVariation) {
-      final IsGmlReferenceDiurnalVariation gmlReferenceDiurnalVariation = (IsGmlReferenceDiurnalVariation) characteristics.getDiurnalVariation();
-      returnCharacteristics.setCustomDiurnalVariationId(gmlReferenceDiurnalVariation.getCustomDiurnalVariation().getReferredId());
-    }
-  }
-
-  private void fromGMLToHeatContent(final IsBaseGmlEmissionSourceCharacteristics characteristics,
-      final OPSSourceCharacteristics returnCharacteristics) {
-    final IsGmlHeatContent gmlHeatContent = characteristics.getHeatContent();
-    if (gmlHeatContent instanceof IsGmlSpecifiedHeatContent) {
-      returnCharacteristics.setHeatContentType(HeatContentType.NOT_FORCED);
-      returnCharacteristics.setHeatContent(((IsGmlSpecifiedHeatContent) gmlHeatContent).getValue());
-    } else if (gmlHeatContent instanceof IsGmlCalculatedHeatContent) {
-      returnCharacteristics.setHeatContentType(HeatContentType.FORCED);
-      final IsGmlCalculatedHeatContent calculatedHeatContent = (IsGmlCalculatedHeatContent) gmlHeatContent;
-      fromGmlToEmissionTemperature(returnCharacteristics, calculatedHeatContent);
-      returnCharacteristics.setOutflowDiameter(calculatedHeatContent.getOutflowDiameter());
-      returnCharacteristics.setOutflowVelocity(calculatedHeatContent.getOutflowVelocity());
-      returnCharacteristics.setOutflowDirection(calculatedHeatContent.getOutflowDirection());
-      returnCharacteristics.setOutflowVelocityType(calculatedHeatContent.getOutflowVelocityType());
-    }
-  }
-
-  protected void fromGmlToEmissionTemperature(final OPSSourceCharacteristics returnCharacteristics, final IsGmlCalculatedHeatContent gmlHeatContent) {
-    returnCharacteristics.setEmissionTemperature(gmlHeatContent.getEmissionTemperature());
-  }
-
-  private <T extends Number> T getOrDefault(final T value, final T defaultValue) {
-    return value == null ? defaultValue : value;
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2SourceCharacteristicsV31.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2SourceCharacteristicsV31.java
@@ -25,7 +25,7 @@ import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacterist
  * Will ensure that the emission temperature will be set to the correct value for default,
  * if the value in the GML was the default at that time (11.85).
  */
-public class GML2SourceCharacteristicsV31 extends GML2SourceCharacteristics {
+public class GML2SourceCharacteristicsV31 extends GML2OPSSourceCharacteristics {
 
   private static final double EMISSION_TEMPERATURE_DEFAULT = 11.85;
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v31/GML2OffRoad.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v31/GML2OffRoad.java
@@ -100,7 +100,7 @@ public class GML2OffRoad<T extends IsGmlOffRoadMobileEmissionSource> extends Abs
     newSource.setSectorId(sectorId);
     newSource.setLabel(constructLabel(source.getLabel(), customMobileSource.getDescription()));
     newSource.setCharacteristics(gml2SourceCharacteristics.fromGML(customMobileSource.getCharacteristics(),
-        getConversionData().determineDefaultOPSCharacteristicsBySectorId(sectorId), null));
+        getConversionData().determineDefaultCharacteristicsBySectorId(sectorId), null));
     for (final IsGmlProperty<IsGmlEmission> emissionProperty : customMobileSource.getEmissions()) {
       final IsGmlEmission emission = emissionProperty.getProperty();
       newSource.getEmissions().put(emission.getSubstance(), emission.getValue());

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v40/GML2OffRoad.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v40/GML2OffRoad.java
@@ -94,7 +94,7 @@ public class GML2OffRoad<T extends IsGmlOffRoadMobileEmissionSource> extends Abs
     newSource.setSectorId(sectorId);
     newSource.setLabel(constructLabel(source.getLabel(), customMobileSource.getDescription()));
     newSource.setCharacteristics(gml2SourceCharacteristics.fromGML(customMobileSource.getCharacteristics(),
-        getConversionData().determineDefaultOPSCharacteristicsBySectorId(sectorId), null));
+        getConversionData().determineDefaultCharacteristicsBySectorId(sectorId), null));
     for (final IsGmlProperty<IsGmlEmission> emissionProperty : customMobileSource.getEmissions()) {
       final IsGmlEmission emission = emissionProperty.getProperty();
       newSource.getEmissions().put(emission.getSubstance(), emission.getValue());

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/GML2Source.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/GML2Source.java
@@ -21,18 +21,20 @@ import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
 import nl.overheid.aerius.gml.base.geo.GML2Geometry;
 import nl.overheid.aerius.gml.v0_5.source.EmissionSource;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 
 /**
  * Utility class to convert to and from GML objects (specific for emission sources).
  */
-class GML2Source extends AbstractGML2Source<EmissionSource> {
+class GML2Source extends AbstractGML2Source<EmissionSource, OPSSourceCharacteristics> {
 
   /**
    * @param conversionData The data to use when converting. Should be filled.
+   * @param gml2SourceCharacteristics Converter for GML to type specific source characteristics.
    */
-  public GML2Source(final GMLConversionData conversionData) {
-    super(conversionData, new GML2SourceVisitor(conversionData, new GML2Geometry(conversionData.getSrid())),
-        new GML2SourceCharacteristicsV31(conversionData));
+  public GML2Source(final GMLConversionData conversionData, final GML2SourceCharacteristicsV31 gml2SourceCharacteristics) {
+    super(conversionData, new GML2SourceVisitor(conversionData, new GML2Geometry(conversionData.getSrid()), gml2SourceCharacteristics),
+        gml2SourceCharacteristics);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/GML2SourceVisitor.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/GML2SourceVisitor.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGML2SourceVisitor;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.geo.GML2Geometry;
 import nl.overheid.aerius.gml.base.source.GML2Generic;
 import nl.overheid.aerius.gml.base.source.lodging.GML2Farm;
@@ -51,7 +51,8 @@ class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
 
   @SuppressWarnings("rawtypes") private final HashMap<Class<? extends EmissionSource>, AbstractGML2Specific> handlers = new HashMap<>();
 
-  GML2SourceVisitor(final GMLConversionData conversionData, final GML2Geometry gml2Geometry) {
+  GML2SourceVisitor(final GMLConversionData conversionData, final GML2Geometry gml2Geometry,
+      final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
     handlers.put(EmissionSource.class, new GML2Generic<EmissionSource>(conversionData));
     handlers.put(FarmLodgingEmissionSource.class, new GML2Farm<FarmLodgingEmissionSource>(conversionData));
     handlers.put(MooringInlandShippingEmissionSource.class,
@@ -59,8 +60,7 @@ class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
     handlers.put(InlandShippingEmissionSource.class, new GML2InlandRouteForceWaterway<InlandShippingEmissionSource>(conversionData, gml2Geometry));
     handlers.put(MooringMaritimeShippingEmissionSource.class, new GML2MaritimeMooring<MooringMaritimeShippingEmissionSource>(conversionData));
     handlers.put(MaritimeShippingEmissionSource.class, new GML2MaritimeRoute<MaritimeShippingEmissionSource>(conversionData));
-    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData,
-        new GML2SourceCharacteristicsV31(conversionData)));
+    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData, gml2SourceCharacteristics));
     handlers.put(PlanEmissionSource.class, new GML2Plan<PlanEmissionSource>(conversionData));
     handlers.put(SRM2RoadEmissionSource.class, new GML2SRM2RoadV10<SRM2RoadEmissionSource>(conversionData));
   }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/GMLReader.java
@@ -22,6 +22,7 @@ import nl.overheid.aerius.gml.base.FeatureMember;
 import nl.overheid.aerius.gml.base.GML2Result;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
+import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
 import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 
@@ -38,7 +39,7 @@ public class GMLReader implements GMLVersionReader {
    * @param conversionData The data to use when converting.
    */
   public GMLReader(final GMLConversionData conversionData) {
-    gml2Source = new GML2Source(conversionData);
+    gml2Source = new GML2Source(conversionData, new GML2SourceCharacteristicsV31(conversionData));
     gml2Result = new GML2Result(conversionData);
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_0/GML2Source.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_0/GML2Source.java
@@ -18,20 +18,22 @@ package nl.overheid.aerius.gml.v1_0;
 
 import nl.overheid.aerius.gml.base.AbstractGML2Source;
 import nl.overheid.aerius.gml.base.GMLConversionData;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.geo.GML2Geometry;
 import nl.overheid.aerius.gml.v1_0.source.EmissionSource;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 
 /**
  * Utility class to convert to and from GML objects (specific for emission sources).
  */
-class GML2Source extends AbstractGML2Source<EmissionSource> {
+class GML2Source extends AbstractGML2Source<EmissionSource, OPSSourceCharacteristics> {
 
   /**
    * @param conversionData The data to use when converting. Should be filled.
+   * @param gml2SourceCharacteristics Converter for GML to type specific source characteristics.
    */
-  public GML2Source(final GMLConversionData conversionData) {
-    super(conversionData, new GML2SourceVisitor(conversionData, new GML2Geometry(conversionData.getSrid())),
-        new GML2SourceCharacteristicsV31(conversionData));
+  public GML2Source(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
+    super(conversionData, new GML2SourceVisitor(conversionData, new GML2Geometry(conversionData.getSrid()), gml2SourceCharacteristics),
+        gml2SourceCharacteristics);
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_0/GML2SourceVisitor.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_0/GML2SourceVisitor.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGML2SourceVisitor;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.geo.GML2Geometry;
 import nl.overheid.aerius.gml.base.source.GML2Generic;
 import nl.overheid.aerius.gml.base.source.lodging.GML2Farm;
@@ -51,7 +51,8 @@ class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
 
   @SuppressWarnings("rawtypes") private final HashMap<Class<? extends EmissionSource>, AbstractGML2Specific> handlers = new HashMap<>();
 
-  GML2SourceVisitor(final GMLConversionData conversionData, final GML2Geometry gml2geometry) {
+  GML2SourceVisitor(final GMLConversionData conversionData, final GML2Geometry gml2geometry,
+      final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
     handlers.put(EmissionSource.class, new GML2Generic<EmissionSource>(conversionData));
     handlers.put(FarmLodgingEmissionSource.class, new GML2Farm<FarmLodgingEmissionSource>(conversionData));
     handlers.put(MooringInlandShippingEmissionSource.class,
@@ -59,8 +60,7 @@ class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
     handlers.put(InlandShippingEmissionSource.class, new GML2InlandRouteForceWaterway<InlandShippingEmissionSource>(conversionData, gml2geometry));
     handlers.put(MooringMaritimeShippingEmissionSource.class, new GML2MaritimeMooring<MooringMaritimeShippingEmissionSource>(conversionData));
     handlers.put(MaritimeShippingEmissionSource.class, new GML2MaritimeRoute<MaritimeShippingEmissionSource>(conversionData));
-    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData,
-        new GML2SourceCharacteristicsV31(conversionData)));
+    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData, gml2SourceCharacteristics));
     handlers.put(PlanEmissionSource.class, new GML2Plan<PlanEmissionSource>(conversionData));
     handlers.put(SRM2RoadEmissionSource.class, new GML2SRM2RoadV10<SRM2RoadEmissionSource>(conversionData));
   }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_0/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_0/GMLReader.java
@@ -22,6 +22,7 @@ import nl.overheid.aerius.gml.base.FeatureMember;
 import nl.overheid.aerius.gml.base.GML2Result;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
+import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
 import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 
@@ -34,7 +35,7 @@ final class GMLReader implements GMLVersionReader {
   private final GML2Result gml2Result;
 
   public GMLReader(final GMLConversionData conversionData) {
-    gml2Source = new GML2Source(conversionData);
+    gml2Source = new GML2Source(conversionData, new GML2SourceCharacteristicsV31(conversionData));
     gml2Result = new GML2Result(conversionData);
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/GML2Source.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/GML2Source.java
@@ -18,21 +18,23 @@ package nl.overheid.aerius.gml.v1_1;
 
 import nl.overheid.aerius.gml.base.AbstractGML2Source;
 import nl.overheid.aerius.gml.base.GMLConversionData;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.geo.GML2Geometry;
 import nl.overheid.aerius.gml.v1_1.source.EmissionSource;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 
 /**
  * Utility class to convert to and from GML objects (specific for emission sources).
  */
-class GML2Source extends AbstractGML2Source<EmissionSource> {
+class GML2Source extends AbstractGML2Source<EmissionSource, OPSSourceCharacteristics> {
 
   /**
    * @param conversionData The data to use when converting. Should be filled.
+   * @param gml2SourceCharacteristics Converter for GML to type specific source characteristics.
    */
-  public GML2Source(final GMLConversionData conversionData) {
-    super(conversionData, new GML2SourceVisitor(conversionData, new GML2Geometry(conversionData.getSrid())),
-        new GML2SourceCharacteristicsV31(conversionData));
+  public GML2Source(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
+    super(conversionData, new GML2SourceVisitor(conversionData, new GML2Geometry(conversionData.getSrid()), gml2SourceCharacteristics),
+        gml2SourceCharacteristics);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/GML2SourceVisitor.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/GML2SourceVisitor.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGML2SourceVisitor;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.geo.GML2Geometry;
 import nl.overheid.aerius.gml.base.source.GML2Generic;
 import nl.overheid.aerius.gml.base.source.lodging.GML2Farm;
@@ -51,7 +51,8 @@ class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
 
   @SuppressWarnings("rawtypes") private final HashMap<Class<? extends EmissionSource>, AbstractGML2Specific> handlers = new HashMap<>();
 
-  GML2SourceVisitor(final GMLConversionData conversionData, final GML2Geometry gml2Geometry) {
+  GML2SourceVisitor(final GMLConversionData conversionData, final GML2Geometry gml2Geometry,
+      final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
     handlers.put(EmissionSource.class, new GML2Generic<EmissionSource>(conversionData));
     handlers.put(FarmLodgingEmissionSource.class, new GML2Farm<FarmLodgingEmissionSource>(conversionData));
     handlers.put(MooringInlandShippingEmissionSource.class,
@@ -59,8 +60,7 @@ class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
     handlers.put(InlandShippingEmissionSource.class, new GML2InlandRouteForceWaterway<InlandShippingEmissionSource>(conversionData, gml2Geometry));
     handlers.put(MooringMaritimeShippingEmissionSource.class, new GML2MaritimeMooring<MooringMaritimeShippingEmissionSource>(conversionData));
     handlers.put(MaritimeShippingEmissionSource.class, new GML2MaritimeRoute<MaritimeShippingEmissionSource>(conversionData));
-    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData,
-        new GML2SourceCharacteristicsV31(conversionData)));
+    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData, gml2SourceCharacteristics));
     handlers.put(PlanEmissionSource.class, new GML2Plan<PlanEmissionSource>(conversionData));
     handlers.put(SRM2RoadEmissionSource.class, new GML2SRM2RoadV11<SRM2RoadEmissionSource>(conversionData));
   }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/GMLReader.java
@@ -22,6 +22,7 @@ import nl.overheid.aerius.gml.base.FeatureMember;
 import nl.overheid.aerius.gml.base.GML2Result;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 
@@ -33,8 +34,8 @@ final class GMLReader implements GMLVersionReader {
   private final GML2Source gml2Source;
   private final GML2Result gml2Result;
 
-  public GMLReader(final GMLConversionData conversionData) {
-    gml2Source = new GML2Source(conversionData);
+  public GMLReader(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
+    gml2Source = new GML2Source(conversionData, gml2SourceCharacteristics);
     gml2Result = new GML2Result(conversionData);
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/GMLReaderFactoryV11.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/GMLReaderFactoryV11.java
@@ -21,6 +21,7 @@ import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLLegacyCodesSupplier;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
 import nl.overheid.aerius.gml.base.GMLVersionReaderFactory;
+import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
 import nl.overheid.aerius.gml.v1_1.base.CalculatorSchema;
 import nl.overheid.aerius.gml.v1_1.base.FeatureCollectionImpl;
 import nl.overheid.aerius.shared.exception.AeriusException;
@@ -41,6 +42,6 @@ public class GMLReaderFactoryV11 extends GMLVersionReaderFactory {
 
   @Override
   public GMLVersionReader createReader(final GMLConversionData conversionData) {
-    return new GMLReader(conversionData);
+    return new GMLReader(conversionData, new GML2SourceCharacteristicsV31(conversionData));
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/GML2Source.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/GML2Source.java
@@ -18,19 +18,21 @@ package nl.overheid.aerius.gml.v2_0;
 
 import nl.overheid.aerius.gml.base.AbstractGML2Source;
 import nl.overheid.aerius.gml.base.GMLConversionData;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.v2_0.source.EmissionSource;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 
 /**
  * Utility class to convert to and from GML objects (specific for emission sources).
  */
-class GML2Source extends AbstractGML2Source<EmissionSource> {
+class GML2Source extends AbstractGML2Source<EmissionSource, OPSSourceCharacteristics> {
 
   /**
    * @param conversionData The data to use when converting. Should be filled.
+   * @param gml2SourceCharacteristics Converter for GML to type specific source characteristics.
    */
-  public GML2Source(final GMLConversionData conversionData) {
-    super(conversionData, new GML2SourceVisitor(conversionData), new GML2SourceCharacteristicsV31(conversionData));
+  public GML2Source(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
+    super(conversionData, new GML2SourceVisitor(conversionData, gml2SourceCharacteristics), gml2SourceCharacteristics);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/GML2SourceVisitor.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/GML2SourceVisitor.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGML2SourceVisitor;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.source.GML2Generic;
 import nl.overheid.aerius.gml.base.source.lodging.GML2Farm;
 import nl.overheid.aerius.gml.base.source.mobile.v31.GML2OffRoad;
@@ -50,15 +50,14 @@ class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
 
   @SuppressWarnings("rawtypes") private final HashMap<Class<? extends EmissionSource>, AbstractGML2Specific> handlers = new HashMap<>();
 
-  GML2SourceVisitor(final GMLConversionData conversionData) {
+  GML2SourceVisitor(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
     handlers.put(EmissionSource.class, new GML2Generic<EmissionSource>(conversionData));
     handlers.put(FarmLodgingEmissionSource.class, new GML2Farm<FarmLodgingEmissionSource>(conversionData));
     handlers.put(MooringInlandShippingEmissionSource.class, new GML2InlandMooring<MooringInlandShippingEmissionSource>(conversionData));
     handlers.put(InlandShippingEmissionSource.class, new GML2InlandRoute<InlandShippingEmissionSource>(conversionData));
     handlers.put(MooringMaritimeShippingEmissionSource.class, new GML2MaritimeMooring<MooringMaritimeShippingEmissionSource>(conversionData));
     handlers.put(MaritimeShippingEmissionSource.class, new GML2MaritimeRoute<MaritimeShippingEmissionSource>(conversionData));
-    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData,
-        new GML2SourceCharacteristicsV31(conversionData)));
+    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData, gml2SourceCharacteristics));
     handlers.put(PlanEmissionSource.class, new GML2Plan<PlanEmissionSource>(conversionData));
     handlers.put(SRM2RoadEmissionSource.class, new GML2SRM2Road<SRM2RoadEmissionSource>(conversionData));
   }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/GMLReader.java
@@ -22,6 +22,7 @@ import nl.overheid.aerius.gml.base.FeatureMember;
 import nl.overheid.aerius.gml.base.GML2Result;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 
@@ -33,8 +34,8 @@ public class GMLReader implements GMLVersionReader {
   private final GML2Source gml2Source;
   private final GML2Result gml2Result;
 
-  public GMLReader(final GMLConversionData conversionData) {
-    gml2Source = new GML2Source(conversionData);
+  public GMLReader(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
+    gml2Source = new GML2Source(conversionData, gml2SourceCharacteristics);
     gml2Result = new GML2Result(conversionData);
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/GMLReaderFactoryV20.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/GMLReaderFactoryV20.java
@@ -21,6 +21,7 @@ import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLLegacyCodesSupplier;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
 import nl.overheid.aerius.gml.base.GMLVersionReaderFactory;
+import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
 import nl.overheid.aerius.gml.v2_0.base.CalculatorSchema;
 import nl.overheid.aerius.gml.v2_0.collection.FeatureCollectionImpl;
 import nl.overheid.aerius.shared.exception.AeriusException;
@@ -41,6 +42,6 @@ public class GMLReaderFactoryV20 extends GMLVersionReaderFactory {
 
   @Override
   public GMLVersionReader createReader(final GMLConversionData conversionData) {
-    return new GMLReader(conversionData);
+    return new GMLReader(conversionData, new GML2SourceCharacteristicsV31(conversionData));
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/GML2Source.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/GML2Source.java
@@ -18,19 +18,21 @@ package nl.overheid.aerius.gml.v2_1;
 
 import nl.overheid.aerius.gml.base.AbstractGML2Source;
 import nl.overheid.aerius.gml.base.GMLConversionData;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.v2_1.source.EmissionSource;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 
 /**
  * Utility class to convert to and from GML objects (specific for emission sources).
  */
-class GML2Source extends AbstractGML2Source<EmissionSource> {
+class GML2Source extends AbstractGML2Source<EmissionSource, OPSSourceCharacteristics> {
 
   /**
    * @param conversionData The data to use when converting. Should be filled.
+   * @param gml2SourceCharacteristics Converter for GML to type specific source characteristics.
    */
-  public GML2Source(final GMLConversionData conversionData) {
-    super(conversionData, new GML2SourceVisitor(conversionData), new GML2SourceCharacteristicsV31(conversionData));
+  public GML2Source(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
+    super(conversionData, new GML2SourceVisitor(conversionData, gml2SourceCharacteristics), gml2SourceCharacteristics);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/GML2SourceVisitor.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/GML2SourceVisitor.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGML2SourceVisitor;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.source.GML2Generic;
 import nl.overheid.aerius.gml.base.source.lodging.GML2Farm;
 import nl.overheid.aerius.gml.base.source.mobile.v31.GML2OffRoad;
@@ -50,15 +50,14 @@ class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
 
   @SuppressWarnings("rawtypes") private final HashMap<Class<? extends EmissionSource>, AbstractGML2Specific> handlers = new HashMap<>();
 
-  GML2SourceVisitor(final GMLConversionData conversionData) {
+  GML2SourceVisitor(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
     handlers.put(EmissionSource.class, new GML2Generic<EmissionSource>(conversionData));
     handlers.put(FarmLodgingEmissionSource.class, new GML2Farm<FarmLodgingEmissionSource>(conversionData));
     handlers.put(MooringInlandShippingEmissionSource.class, new GML2InlandMooring<MooringInlandShippingEmissionSource>(conversionData));
     handlers.put(InlandShippingEmissionSource.class, new GML2InlandRoute<InlandShippingEmissionSource>(conversionData));
     handlers.put(MooringMaritimeShippingEmissionSource.class, new GML2MaritimeMooring<MooringMaritimeShippingEmissionSource>(conversionData));
     handlers.put(MaritimeShippingEmissionSource.class, new GML2MaritimeRoute<MaritimeShippingEmissionSource>(conversionData));
-    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData,
-        new GML2SourceCharacteristicsV31(conversionData)));
+    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData, gml2SourceCharacteristics));
     handlers.put(PlanEmissionSource.class, new GML2Plan<PlanEmissionSource>(conversionData));
     handlers.put(SRM2RoadEmissionSource.class, new GML2SRM2Road<SRM2RoadEmissionSource>(conversionData));
   }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/GMLReader.java
@@ -22,6 +22,7 @@ import nl.overheid.aerius.gml.base.FeatureMember;
 import nl.overheid.aerius.gml.base.GML2Result;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
+import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
 import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 
@@ -33,8 +34,8 @@ public class GMLReader implements GMLVersionReader {
   private final GML2Source gml2Source;
   private final GML2Result gml2Result;
 
-  public GMLReader(final GMLConversionData conversionData) {
-    gml2Source = new GML2Source(conversionData);
+  public GMLReader(final GMLConversionData conversionData, final GML2SourceCharacteristicsV31 gml2SourceCharacteristics) {
+    gml2Source = new GML2Source(conversionData, gml2SourceCharacteristics);
     gml2Result = new GML2Result(conversionData);
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/GMLReaderFactoryV21.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/GMLReaderFactoryV21.java
@@ -21,6 +21,7 @@ import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLLegacyCodesSupplier;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
 import nl.overheid.aerius.gml.base.GMLVersionReaderFactory;
+import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
 import nl.overheid.aerius.gml.v2_1.base.CalculatorSchema;
 import nl.overheid.aerius.gml.v2_1.collection.FeatureCollectionImpl;
 import nl.overheid.aerius.shared.exception.AeriusException;
@@ -41,6 +42,6 @@ public class GMLReaderFactoryV21 extends GMLVersionReaderFactory {
 
   @Override
   public GMLVersionReader createReader(final GMLConversionData conversionData) {
-    return new GMLReader(conversionData);
+    return new GMLReader(conversionData, new GML2SourceCharacteristicsV31(conversionData));
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/GML2Source.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/GML2Source.java
@@ -18,19 +18,21 @@ package nl.overheid.aerius.gml.v2_2;
 
 import nl.overheid.aerius.gml.base.AbstractGML2Source;
 import nl.overheid.aerius.gml.base.GMLConversionData;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.v2_2.source.EmissionSource;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 
 /**
  * Utility class to convert to and from GML objects (specific for emission sources).
  */
-class GML2Source extends AbstractGML2Source<EmissionSource> {
+class GML2Source extends AbstractGML2Source<EmissionSource, OPSSourceCharacteristics> {
 
   /**
    * @param conversionData The data to use when converting. Should be filled.
+   * @param gml2SourceCharacteristics Converter for GML to type specific source characteristics.
    */
-  public GML2Source(final GMLConversionData conversionData) {
-    super(conversionData, new GML2SourceVisitor(conversionData), new GML2SourceCharacteristicsV31(conversionData));
+  public GML2Source(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
+    super(conversionData, new GML2SourceVisitor(conversionData, gml2SourceCharacteristics), gml2SourceCharacteristics);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/GML2SourceVisitor.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/GML2SourceVisitor.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGML2SourceVisitor;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.source.GML2Generic;
 import nl.overheid.aerius.gml.base.source.lodging.GML2Farm;
 import nl.overheid.aerius.gml.base.source.mobile.v31.GML2OffRoad;
@@ -50,15 +50,14 @@ class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
 
   @SuppressWarnings("rawtypes") private final HashMap<Class<? extends EmissionSource>, AbstractGML2Specific> handlers = new HashMap<>();
 
-  GML2SourceVisitor(final GMLConversionData conversionData) {
+  GML2SourceVisitor(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
     handlers.put(EmissionSource.class, new GML2Generic<EmissionSource>(conversionData));
     handlers.put(FarmLodgingEmissionSource.class, new GML2Farm<FarmLodgingEmissionSource>(conversionData));
     handlers.put(MooringInlandShippingEmissionSource.class, new GML2InlandMooring<MooringInlandShippingEmissionSource>(conversionData));
     handlers.put(InlandShippingEmissionSource.class, new GML2InlandRoute<InlandShippingEmissionSource>(conversionData));
     handlers.put(MooringMaritimeShippingEmissionSource.class, new GML2MaritimeMooring<MooringMaritimeShippingEmissionSource>(conversionData));
     handlers.put(MaritimeShippingEmissionSource.class, new GML2MaritimeRoute<MaritimeShippingEmissionSource>(conversionData));
-    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData,
-        new GML2SourceCharacteristicsV31(conversionData)));
+    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData, gml2SourceCharacteristics));
     handlers.put(PlanEmissionSource.class, new GML2Plan<PlanEmissionSource>(conversionData));
     handlers.put(SRM2RoadEmissionSource.class, new GML2SRM2Road<SRM2RoadEmissionSource>(conversionData));
   }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/GMLReader.java
@@ -22,6 +22,7 @@ import nl.overheid.aerius.gml.base.FeatureMember;
 import nl.overheid.aerius.gml.base.GML2Result;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
+import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
 import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 
@@ -33,8 +34,8 @@ public class GMLReader implements GMLVersionReader {
   private final GML2Source gml2Source;
   private final GML2Result gml2Result;
 
-  public GMLReader(final GMLConversionData conversionData) {
-    gml2Source = new GML2Source(conversionData);
+  public GMLReader(final GMLConversionData conversionData, final GML2SourceCharacteristicsV31 gml2SourceCharacteristics) {
+    gml2Source = new GML2Source(conversionData, gml2SourceCharacteristics);
     gml2Result = new GML2Result(conversionData);
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/GMLReaderFactoryV22.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/GMLReaderFactoryV22.java
@@ -21,6 +21,7 @@ import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLLegacyCodesSupplier;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
 import nl.overheid.aerius.gml.base.GMLVersionReaderFactory;
+import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
 import nl.overheid.aerius.gml.v2_2.base.CalculatorSchema;
 import nl.overheid.aerius.gml.v2_2.collection.FeatureCollectionImpl;
 import nl.overheid.aerius.shared.exception.AeriusException;
@@ -41,6 +42,6 @@ public class GMLReaderFactoryV22 extends GMLVersionReaderFactory {
 
   @Override
   public GMLVersionReader createReader(final GMLConversionData conversionData) {
-    return new GMLReader(conversionData);
+    return new GMLReader(conversionData, new GML2SourceCharacteristicsV31(conversionData));
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/GML2Source.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/GML2Source.java
@@ -18,19 +18,21 @@ package nl.overheid.aerius.gml.v3_0;
 
 import nl.overheid.aerius.gml.base.AbstractGML2Source;
 import nl.overheid.aerius.gml.base.GMLConversionData;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.v3_0.source.EmissionSource;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 
 /**
  * Utility class to convert to and from GML objects (specific for emission sources).
  */
-class GML2Source extends AbstractGML2Source<EmissionSource> {
+class GML2Source extends AbstractGML2Source<EmissionSource, OPSSourceCharacteristics> {
 
   /**
    * @param conversionData The data to use when converting. Should be filled.
+   * @param gml2SourceCharacteristics Converter for GML to type specific source characteristics.
    */
-  public GML2Source(final GMLConversionData conversionData) {
-    super(conversionData, new GML2SourceVisitor(conversionData), new GML2SourceCharacteristicsV31(conversionData));
+  public GML2Source(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
+    super(conversionData, new GML2SourceVisitor(conversionData, gml2SourceCharacteristics), gml2SourceCharacteristics);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/GML2SourceVisitor.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/GML2SourceVisitor.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGML2SourceVisitor;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.source.GML2Generic;
 import nl.overheid.aerius.gml.base.source.lodging.GML2Farm;
 import nl.overheid.aerius.gml.base.source.mobile.v31.GML2OffRoad;
@@ -52,15 +52,14 @@ class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
 
   @SuppressWarnings("rawtypes") private final HashMap<Class<? extends EmissionSource>, AbstractGML2Specific> handlers = new HashMap<>();
 
-  GML2SourceVisitor(final GMLConversionData conversionData) {
+  GML2SourceVisitor(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
     handlers.put(EmissionSource.class, new GML2Generic<EmissionSource>(conversionData));
     handlers.put(FarmLodgingEmissionSource.class, new GML2Farm<FarmLodgingEmissionSource>(conversionData));
     handlers.put(MooringInlandShippingEmissionSource.class, new GML2InlandMooring<MooringInlandShippingEmissionSource>(conversionData));
     handlers.put(InlandShippingEmissionSource.class, new GML2InlandRoute<InlandShippingEmissionSource>(conversionData));
     handlers.put(MooringMaritimeShippingEmissionSource.class, new GML2MaritimeMooring<MooringMaritimeShippingEmissionSource>(conversionData));
     handlers.put(MaritimeShippingEmissionSource.class, new GML2MaritimeRoute<MaritimeShippingEmissionSource>(conversionData));
-    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData,
-        new GML2SourceCharacteristicsV31(conversionData)));
+    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData, gml2SourceCharacteristics));
     handlers.put(PlanEmissionSource.class, new GML2Plan<PlanEmissionSource>(conversionData));
     handlers.put(SRM2Road.class, new GML2SRM2Road<SRM2Road>(conversionData));
     handlers.put(SRM1Road.class, new GML2SRM1Road<SRM1Road>(conversionData));

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/GMLReader.java
@@ -26,6 +26,7 @@ import nl.overheid.aerius.gml.base.GML2NSLMeasure;
 import nl.overheid.aerius.gml.base.GML2Result;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.v3_0.result.AbstractCalculationPoint;
 import nl.overheid.aerius.shared.domain.v2.nsl.NSLCorrection;
 import nl.overheid.aerius.shared.domain.v2.nsl.NSLDispersionLineFeature;
@@ -44,8 +45,8 @@ public class GMLReader implements GMLVersionReader {
   private final GML2NSLDispersionLine gml2NSLDispersionLine;
   private final GML2NSLCorrection gml2NSLCorrection;
 
-  public GMLReader(final GMLConversionData conversionData) {
-    gml2Source = new GML2Source(conversionData);
+  public GMLReader(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
+    gml2Source = new GML2Source(conversionData, gml2SourceCharacteristics);
     gml2Result = new GML2Result(conversionData);
     gml2NSLMeasure = new GML2NSLMeasure(conversionData);
     gml2NSLDispersionLine = new GML2NSLDispersionLine();

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/GMLReaderFactoryV30.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/GMLReaderFactoryV30.java
@@ -21,6 +21,7 @@ import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLLegacyCodesSupplier;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
 import nl.overheid.aerius.gml.base.GMLVersionReaderFactory;
+import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
 import nl.overheid.aerius.gml.v3_0.base.CalculatorSchema;
 import nl.overheid.aerius.gml.v3_0.collection.FeatureCollectionImpl;
 import nl.overheid.aerius.shared.exception.AeriusException;
@@ -41,6 +42,6 @@ public class GMLReaderFactoryV30 extends GMLVersionReaderFactory {
 
   @Override
   public GMLVersionReader createReader(final GMLConversionData conversionData) {
-    return new GMLReader(conversionData);
+    return new GMLReader(conversionData, new GML2SourceCharacteristicsV31(conversionData));
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/GML2Source.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/GML2Source.java
@@ -18,19 +18,21 @@ package nl.overheid.aerius.gml.v3_1;
 
 import nl.overheid.aerius.gml.base.AbstractGML2Source;
 import nl.overheid.aerius.gml.base.GMLConversionData;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.v3_1.source.EmissionSource;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 
 /**
  * Utility class to convert to and from GML objects (specific for emission sources).
  */
-class GML2Source extends AbstractGML2Source<EmissionSource> {
+class GML2Source extends AbstractGML2Source<EmissionSource, OPSSourceCharacteristics> {
 
   /**
    * @param conversionData The data to use when converting. Should be filled.
+   * @param gml2SourceCharacteristics Converter for GML to type specific source characteristics.
    */
-  public GML2Source(final GMLConversionData conversionData) {
-    super(conversionData, new GML2SourceVisitor(conversionData), new GML2SourceCharacteristicsV31(conversionData));
+  public GML2Source(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
+    super(conversionData, new GML2SourceVisitor(conversionData, gml2SourceCharacteristics), gml2SourceCharacteristics);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/GML2SourceVisitor.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/GML2SourceVisitor.java
@@ -21,7 +21,7 @@ import java.util.HashMap;
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGML2SourceVisitor;
-import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.source.GML2Generic;
 import nl.overheid.aerius.gml.base.source.farmland.GML2Farmland;
 import nl.overheid.aerius.gml.base.source.lodging.GML2Farm;
@@ -54,7 +54,7 @@ class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
 
   @SuppressWarnings("rawtypes") private final HashMap<Class<? extends EmissionSource>, AbstractGML2Specific> handlers = new HashMap<>();
 
-  GML2SourceVisitor(final GMLConversionData conversionData) {
+  GML2SourceVisitor(final GMLConversionData conversionData, final GML2OPSSourceCharacteristics gml2SourceCharacteristics) {
     handlers.put(EmissionSource.class, new GML2Generic<EmissionSource>(conversionData));
     handlers.put(FarmLodgingEmissionSource.class, new GML2Farm<FarmLodgingEmissionSource>(conversionData));
     handlers.put(FarmlandEmissionSource.class, new GML2Farmland<FarmlandEmissionSource>(conversionData));
@@ -62,8 +62,7 @@ class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
     handlers.put(InlandShippingEmissionSource.class, new GML2InlandRoute<InlandShippingEmissionSource>(conversionData));
     handlers.put(MooringMaritimeShippingEmissionSource.class, new GML2MaritimeMooring<MooringMaritimeShippingEmissionSource>(conversionData));
     handlers.put(MaritimeShippingEmissionSource.class, new GML2MaritimeRoute<MaritimeShippingEmissionSource>(conversionData));
-    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData,
-        new GML2SourceCharacteristicsV31(conversionData)));
+    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData, gml2SourceCharacteristics));
     handlers.put(PlanEmissionSource.class, new GML2Plan<PlanEmissionSource>(conversionData));
     handlers.put(SRM2Road.class, new GML2SRM2Road<SRM2Road>(conversionData));
     handlers.put(SRM1Road.class, new GML2SRM1Road<SRM1Road>(conversionData));

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/GMLReader.java
@@ -26,6 +26,7 @@ import nl.overheid.aerius.gml.base.GML2NSLMeasure;
 import nl.overheid.aerius.gml.base.GML2Result;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
+import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristicsV31;
 import nl.overheid.aerius.gml.v3_1.result.AbstractCalculationPoint;
 import nl.overheid.aerius.shared.domain.v2.nsl.NSLCorrection;
 import nl.overheid.aerius.shared.domain.v2.nsl.NSLDispersionLineFeature;
@@ -45,7 +46,7 @@ public class GMLReader implements GMLVersionReader {
   private final GML2NSLCorrection gml2NSLCorrection;
 
   public GMLReader(final GMLConversionData conversionData) {
-    gml2Source = new GML2Source(conversionData);
+    gml2Source = new GML2Source(conversionData, new GML2SourceCharacteristicsV31(conversionData));
     gml2Result = new GML2Result(conversionData);
     gml2NSLMeasure = new GML2NSLMeasure(conversionData);
     gml2NSLDispersionLine = new GML2NSLDispersionLine();

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GML2Source.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GML2Source.java
@@ -20,17 +20,19 @@ import nl.overheid.aerius.gml.base.AbstractGML2Source;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.v4_0.source.EmissionSource;
+import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 
 /**
  * Utility class to convert to and from GML objects (specific for emission sources).
  */
-class GML2Source extends AbstractGML2Source<EmissionSource> {
+class GML2Source<S extends SourceCharacteristics> extends AbstractGML2Source<EmissionSource, S> {
 
   /**
    * @param conversionData The data to use when converting. Should be filled.
+   * @param gml2SourceCharacteristics Converter for GML to type specific source characteristics.
    */
-  public GML2Source(final GMLConversionData conversionData) {
-    super(conversionData, new GML2SourceVisitor(conversionData), new GML2SourceCharacteristics(conversionData));
+  public GML2Source(final GMLConversionData conversionData, final GML2SourceCharacteristics<S> gml2SourceCharacteristics) {
+    super(conversionData, new GML2SourceVisitor<S>(conversionData, gml2SourceCharacteristics), gml2SourceCharacteristics);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GML2SourceVisitor.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GML2SourceVisitor.java
@@ -44,17 +44,18 @@ import nl.overheid.aerius.gml.v4_0.source.ship.InlandShippingEmissionSource;
 import nl.overheid.aerius.gml.v4_0.source.ship.MaritimeShippingEmissionSource;
 import nl.overheid.aerius.gml.v4_0.source.ship.MooringInlandShippingEmissionSource;
 import nl.overheid.aerius.gml.v4_0.source.ship.MooringMaritimeShippingEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 
 /**
  *
  */
-class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
+class GML2SourceVisitor<S extends SourceCharacteristics> implements IsGML2SourceVisitor<EmissionSource> {
 
   @SuppressWarnings("rawtypes") private final HashMap<Class<? extends EmissionSource>, AbstractGML2Specific> handlers = new HashMap<>();
 
-  GML2SourceVisitor(final GMLConversionData conversionData) {
+  GML2SourceVisitor(final GMLConversionData conversionData, final GML2SourceCharacteristics<S> gml2SourceCharacteristics) {
     handlers.put(EmissionSource.class, new GML2Generic<EmissionSource>(conversionData));
     handlers.put(FarmLodgingEmissionSource.class, new GML2Farm<FarmLodgingEmissionSource>(conversionData));
     handlers.put(FarmlandEmissionSource.class, new GML2Farmland<FarmlandEmissionSource>(conversionData));
@@ -62,8 +63,7 @@ class GML2SourceVisitor implements IsGML2SourceVisitor<EmissionSource> {
     handlers.put(InlandShippingEmissionSource.class, new GML2InlandRoute<InlandShippingEmissionSource>(conversionData));
     handlers.put(MooringMaritimeShippingEmissionSource.class, new GML2MaritimeMooring<MooringMaritimeShippingEmissionSource>(conversionData));
     handlers.put(MaritimeShippingEmissionSource.class, new GML2MaritimeRoute<MaritimeShippingEmissionSource>(conversionData));
-    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData,
-        new GML2SourceCharacteristics(conversionData)));
+    handlers.put(OffRoadMobileEmissionSource.class, new GML2OffRoad<OffRoadMobileEmissionSource>(conversionData, gml2SourceCharacteristics));
     handlers.put(PlanEmissionSource.class, new GML2Plan<PlanEmissionSource>(conversionData));
     handlers.put(SRM2Road.class, new GML2SRM2Road<SRM2Road>(conversionData));
     handlers.put(SRM1Road.class, new GML2SRM1Road<SRM1Road>(conversionData));

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GMLReader.java
@@ -28,8 +28,10 @@ import nl.overheid.aerius.gml.base.GML2NSLMeasure;
 import nl.overheid.aerius.gml.base.GML2Result;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
+import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.v4_0.result.AbstractCalculationPoint;
 import nl.overheid.aerius.shared.domain.v2.building.BuildingFeature;
+import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.nsl.NSLCorrection;
 import nl.overheid.aerius.shared.domain.v2.nsl.NSLDispersionLineFeature;
 import nl.overheid.aerius.shared.domain.v2.nsl.NSLMeasureFeature;
@@ -40,9 +42,9 @@ import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 /**
  * {@link GMLVersionReader} for AERIUS GML version 4.0.
  */
-public class GMLReader implements GMLVersionReader {
+public class GMLReader<S extends SourceCharacteristics> implements GMLVersionReader {
 
-  private final GML2Source gml2Source;
+  private final GML2Source<S> gml2Source;
   private final GML2Building gml2Building;
   private final GML2Result gml2Result;
   private final GML2NSLMeasure gml2NSLMeasure;
@@ -50,8 +52,8 @@ public class GMLReader implements GMLVersionReader {
   private final GML2NSLCorrection gml2NSLCorrection;
   private final GML2Definitions gml2Definitions;
 
-  public GMLReader(final GMLConversionData conversionData) {
-    gml2Source = new GML2Source(conversionData);
+  public GMLReader(final GMLConversionData conversionData, final GML2SourceCharacteristics<S> gml2SourceCharacteristics) {
+    gml2Source = new GML2Source<S>(conversionData, gml2SourceCharacteristics);
     gml2Building = new GML2Building(conversionData);
     gml2Result = new GML2Result(conversionData);
     gml2NSLMeasure = new GML2NSLMeasure(conversionData);

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GMLReaderFactoryV40.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GMLReaderFactoryV40.java
@@ -21,8 +21,12 @@ import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLLegacyCodesSupplier;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
 import nl.overheid.aerius.gml.base.GMLVersionReaderFactory;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
+import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.v4_0.base.CalculatorSchema;
 import nl.overheid.aerius.gml.v4_0.collection.FeatureCollectionImpl;
+import nl.overheid.aerius.shared.domain.v2.characteristics.CharacteristicsType;
+import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 import nl.overheid.aerius.shared.exception.AeriusException;
 
 /**
@@ -41,6 +45,21 @@ public class GMLReaderFactoryV40 extends GMLVersionReaderFactory {
 
   @Override
   public GMLVersionReader createReader(final GMLConversionData conversionData) {
-    return new GMLReader(conversionData);
+    return createReader(conversionData, gml2SourceCharacteristics(conversionData));
+  }
+
+  private static <T extends SourceCharacteristics> GMLReader<T> createReader(final GMLConversionData conversionData,
+      final GML2SourceCharacteristics<T> gml2SourceCharacteristics) {
+    return new GMLReader<T>(conversionData, gml2SourceCharacteristics);
+  }
+
+  private static GML2SourceCharacteristics<?  extends SourceCharacteristics> gml2SourceCharacteristics(final GMLConversionData conversionData) {
+    final CharacteristicsType ct = conversionData.getCharacteristicsType();
+
+    if (ct == CharacteristicsType.OPS) {
+      return new GML2OPSSourceCharacteristics(conversionData);
+    } else {
+      throw new IllegalArgumentException("Can't read GML for characteristics of type " + ct + ". This is not implemented.");
+    }
   }
 }

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
@@ -47,6 +47,7 @@ import nl.overheid.aerius.importer.ImportOption;
 import nl.overheid.aerius.shared.domain.Substance;
 import nl.overheid.aerius.shared.domain.geo.ReceptorGridSettings;
 import nl.overheid.aerius.shared.domain.scenario.SituationType;
+import nl.overheid.aerius.shared.domain.v2.characteristics.CharacteristicsType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.domain.v2.geojson.GeometryType;
@@ -179,6 +180,7 @@ public final class AssertGML {
   static GMLHelper mockGMLHelper() throws AeriusException {
     final GMLHelper gmlHelper = mock(GMLHelper.class);
     when(gmlHelper.getReceptorGridSettings()).thenReturn(RECEPTOR_GRID_SETTINGS);
+    when(gmlHelper.getCharacteristicsType()).thenReturn(CharacteristicsType.OPS);
     final TestValidationAndEmissionHelper valiationAndEmissionHelper = new TestValidationAndEmissionHelper();
     doAnswer(invocation -> {
       final List<EmissionSourceFeature> arg1 = (List<EmissionSourceFeature>) invocation.getArgument(1);

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLReaderTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLReaderTest.java
@@ -180,7 +180,7 @@ public class GMLReaderTest {
       public GMLVersionReaderFactory determineReaderFactory(final NamespaceContext nameSpaceContext) throws AeriusException {
         return gmlReaderFactoryV05;
       }
-    }, gridSettings);
+    });
     final List<EmissionSourceFeature> sources;
     final ArrayList<AeriusException> warnings = new ArrayList<>();
     try (InputStream inputStream = new FileInputStream(file)) {
@@ -315,7 +315,7 @@ public class GMLReaderTest {
     offRoadMobileSourceMap.put("101", new Conversion("BA-B-E3", true));
     codeMaps.put(GMLLegacyCodeType.ON_ROAD_MOBILE_SOURCE, offRoadMobileSourceMap);
     when(mockHelper.getLegacyCodes(any())).thenReturn(codeMaps);
-
+    when(mockHelper.getReceptorGridSettings()).thenReturn(gridSettings);
     return mockHelper;
   }
 


### PR DESCRIPTION
Created an interface and OPS specific implementation. This will make it possible to add other type of characteristics, like ADMS, to the GML.
For older GML versions (everything < 4.0) only OPS is supported therefor it uses always OPS characteristics.
For 4.0 it now only supports OPS, but contains code a basis to add more (it's left open if this will be added to version 4.0 or a new version is needed. For this implementation that is not relevant).