### PR TITLE
Switched to newer JTS library (1.18.2)

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/geo/Geo2GeometryUtil.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/geo/Geo2GeometryUtil.java
@@ -22,11 +22,11 @@ import java.util.List;
 
 import javax.xml.bind.JAXBElement;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LinearRing;
-import com.vividsolutions.jts.geom.Point;
-import com.vividsolutions.jts.geom.PrecisionModel;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 
 import net.opengis.gml.v_3_2_1.AbstractGeometryType;
 import net.opengis.gml.v_3_2_1.AbstractRingPropertyType;

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/geo/Geometry2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/geo/Geometry2GML.java
@@ -21,8 +21,8 @@ import java.util.List;
 
 import javax.xml.bind.JAXBElement;
 
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
 
 import net.opengis.gml.v_3_2_1.AbstractRingPropertyType;
 import net.opengis.gml.v_3_2_1.DirectPositionListType;
@@ -99,8 +99,8 @@ public final class Geometry2GML {
     polygonType.setSrsName(srsName);
     final Geometry poly = GeometryUtil.getGeometry(polygon);
 
-    if (poly instanceof com.vividsolutions.jts.geom.Polygon) {
-      final com.vividsolutions.jts.geom.Polygon polygonJts = (com.vividsolutions.jts.geom.Polygon) poly;
+    if (poly instanceof org.locationtech.jts.geom.Polygon) {
+      final org.locationtech.jts.geom.Polygon polygonJts = (org.locationtech.jts.geom.Polygon) poly;
       final AbstractRingPropertyType exterior = setCoordinates(factory, getCoordinates(polygonJts.getExteriorRing().getCoordinates()));
       polygonType.setExterior(exterior);
       final List<AbstractRingPropertyType> interiors = new ArrayList<>();

--- a/source/imaer-util/pom.xml
+++ b/source/imaer-util/pom.xml
@@ -31,7 +31,7 @@
   <description>The Information Model AERIUS Util Library.</description>
 
   <properties>
-    <jts.version>1.13</jts.version>
+    <jts.version>1.18.2</jts.version>
   </properties>
 
   <dependencies>
@@ -41,8 +41,8 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>com.vividsolutions</groupId>
-      <artifactId>jts</artifactId>
+      <groupId>org.locationtech.jts</groupId>
+      <artifactId>jts-core</artifactId>
       <version>${jts.version}</version>
     </dependency>
 

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/util/GeometryCalculatorImpl.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/util/GeometryCalculatorImpl.java
@@ -61,7 +61,7 @@ public class GeometryCalculatorImpl implements GeometryCalculator {
     }
   }
 
-  private com.vividsolutions.jts.geom.Geometry toJtsGeometry(final Geometry geometry) throws AeriusException {
+  private org.locationtech.jts.geom.Geometry toJtsGeometry(final Geometry geometry) throws AeriusException {
     return GeometryUtil.getGeometry(geometry);
   }
 

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/util/GeometryUtil.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/util/GeometryUtil.java
@@ -22,23 +22,22 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 
+import org.locationtech.jts.algorithm.ConvexHull;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineSegment;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.LinearRing;
+import org.locationtech.jts.geom.MultiPolygon;
+import org.locationtech.jts.geom.Polygon;
+import org.locationtech.jts.geom.util.AffineTransformation;
+import org.locationtech.jts.io.ParseException;
+import org.locationtech.jts.io.WKTReader;
+import org.locationtech.jts.linearref.LengthIndexedLine;
+import org.locationtech.jts.operation.IsSimpleOp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.vividsolutions.jts.algorithm.ConvexHull;
-import com.vividsolutions.jts.geom.Coordinate;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.geom.GeometryFactory;
-import com.vividsolutions.jts.geom.LineSegment;
-import com.vividsolutions.jts.geom.LineString;
-import com.vividsolutions.jts.geom.LinearRing;
-import com.vividsolutions.jts.geom.MultiPolygon;
-import com.vividsolutions.jts.geom.Polygon;
-import com.vividsolutions.jts.geom.util.AffineTransformation;
-import com.vividsolutions.jts.io.ParseException;
-import com.vividsolutions.jts.io.WKTReader;
-import com.vividsolutions.jts.linearref.LengthIndexedLine;
-import com.vividsolutions.jts.operation.IsSimpleOp;
 
 import nl.overheid.aerius.geo.shared.WKTGeometry;
 import nl.overheid.aerius.shared.domain.geo.OrientedEnvelope;
@@ -114,7 +113,7 @@ public final class GeometryUtil {
     return geometry;
   }
 
-  private static com.vividsolutions.jts.geom.Point toJtsPoint(final nl.overheid.aerius.shared.domain.v2.geojson.Point aeriusPoint)
+  private static org.locationtech.jts.geom.Point toJtsPoint(final nl.overheid.aerius.shared.domain.v2.geojson.Point aeriusPoint)
       throws AeriusException {
     final GeometryFactory geometryFactory = new GeometryFactory();
     final Coordinate coordinate = toJtsCoordinate(aeriusPoint.getCoordinates(), aeriusPoint);
@@ -175,24 +174,24 @@ public final class GeometryUtil {
    */
   public static final nl.overheid.aerius.shared.domain.v2.geojson.Geometry getAeriusGeometry(final Geometry jtsGeometry) throws AeriusException {
     final nl.overheid.aerius.shared.domain.v2.geojson.Geometry aeriusGeometry;
-    if (jtsGeometry instanceof com.vividsolutions.jts.geom.Point) {
-      aeriusGeometry = toAeriusPoint((com.vividsolutions.jts.geom.Point) jtsGeometry);
-    } else if (jtsGeometry instanceof com.vividsolutions.jts.geom.LineString) {
-      aeriusGeometry = toAeriusLineString((com.vividsolutions.jts.geom.LineString) jtsGeometry);
-    } else if (jtsGeometry instanceof com.vividsolutions.jts.geom.Polygon) {
-      aeriusGeometry = toAeriusPolygon((com.vividsolutions.jts.geom.Polygon) jtsGeometry);
+    if (jtsGeometry instanceof org.locationtech.jts.geom.Point) {
+      aeriusGeometry = toAeriusPoint((org.locationtech.jts.geom.Point) jtsGeometry);
+    } else if (jtsGeometry instanceof org.locationtech.jts.geom.LineString) {
+      aeriusGeometry = toAeriusLineString((org.locationtech.jts.geom.LineString) jtsGeometry);
+    } else if (jtsGeometry instanceof org.locationtech.jts.geom.Polygon) {
+      aeriusGeometry = toAeriusPolygon((org.locationtech.jts.geom.Polygon) jtsGeometry);
     } else {
       throw new AeriusException(ImaerExceptionReason.GEOMETRY_INVALID, String.valueOf(jtsGeometry));
     }
     return aeriusGeometry;
   }
 
-  private static nl.overheid.aerius.shared.domain.v2.geojson.Point toAeriusPoint(final com.vividsolutions.jts.geom.Point jtsPoint) {
+  private static nl.overheid.aerius.shared.domain.v2.geojson.Point toAeriusPoint(final org.locationtech.jts.geom.Point jtsPoint) {
     return new nl.overheid.aerius.shared.domain.v2.geojson.Point(jtsPoint.getX(), jtsPoint.getY());
   }
 
   private static nl.overheid.aerius.shared.domain.v2.geojson.LineString toAeriusLineString(
-      final com.vividsolutions.jts.geom.LineString jtsLineString) {
+      final org.locationtech.jts.geom.LineString jtsLineString) {
     final nl.overheid.aerius.shared.domain.v2.geojson.LineString aeriusLinestring = new nl.overheid.aerius.shared.domain.v2.geojson.LineString();
     final double[][] aeriusCoordinates = toAeriusCoordinates(jtsLineString);
     aeriusLinestring.setCoordinates(aeriusCoordinates);
@@ -200,7 +199,7 @@ public final class GeometryUtil {
   }
 
   private static nl.overheid.aerius.shared.domain.v2.geojson.Polygon toAeriusPolygon(
-      final com.vividsolutions.jts.geom.Polygon jtsPolygon) {
+      final org.locationtech.jts.geom.Polygon jtsPolygon) {
     final nl.overheid.aerius.shared.domain.v2.geojson.Polygon aeriusPolygon = new nl.overheid.aerius.shared.domain.v2.geojson.Polygon();
     final double[][][] aeriusCoordinates = new double[jtsPolygon.getNumInteriorRing() + 1][][];
     aeriusCoordinates[0] = toAeriusCoordinates(jtsPolygon.getExteriorRing());
@@ -211,7 +210,7 @@ public final class GeometryUtil {
     return aeriusPolygon;
   }
 
-  private static double[][] toAeriusCoordinates(final com.vividsolutions.jts.geom.LineString jtsLineString) {
+  private static double[][] toAeriusCoordinates(final org.locationtech.jts.geom.LineString jtsLineString) {
     final Coordinate[] jtsCoordinates = jtsLineString.getCoordinates();
     final double[][] aeriusCoordinates = new double[jtsCoordinates.length][];
     for (int i = 0; i < jtsCoordinates.length; i++) {
@@ -428,7 +427,7 @@ public final class GeometryUtil {
    * @return The corresponding polygon.
    */
   private static nl.overheid.aerius.shared.domain.v2.geojson.Polygon constructPolygonFromDimensions(
-      final com.vividsolutions.jts.geom.Point point, final double length, final double width, final double orientationToNorth)
+      final org.locationtech.jts.geom.Point point, final double length, final double width, final double orientationToNorth)
       throws AeriusException {
     final nl.overheid.aerius.shared.domain.v2.geojson.Polygon polygon = toBasePolygon(length, width);
     final Geometry jtsPolygon = toJtsPolygon(polygon);

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/EmissionSourceValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/EmissionSourceValidator.java
@@ -24,7 +24,7 @@ import javax.validation.ConstraintViolation;
 import javax.validation.Validation;
 import javax.validation.Validator;
 
-import com.vividsolutions.jts.geom.Geometry;
+import org.locationtech.jts.geom.Geometry;
 
 import nl.overheid.aerius.shared.MathUtil;
 import nl.overheid.aerius.shared.domain.v2.geojson.GeometryType;


### PR DESCRIPTION
In 2016/2017 JTS moved to locationtech. With version 1.15 (nov 2017) the package names and maven groupIds were changed as well. Think now is a good time to switch along with it (gives some more options as well, which might help with the overlapping hexagon detection for instance). Should contain some performance improvements as well (though not too sure how that'll affect us).
This will probably break applications when using classes like GeometryUtil.