### PR TITLE
Fix unit test that failed on GitHub due to conflict with mock and sta…

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/importer/ImaerImporter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/importer/ImaerImporter.java
@@ -70,7 +70,11 @@ public class ImaerImporter {
   private final EPSG epsg;
 
   public ImaerImporter(final GMLHelper gmlHelper) throws AeriusException {
-    factory = GMLReaderFactory.getFactory(gmlHelper);
+    this(gmlHelper, GMLReaderFactory.getFactory(gmlHelper));
+  }
+
+  public ImaerImporter(final GMLHelper gmlHelper, final GMLReaderFactory factory) throws AeriusException {
+    this.factory = factory;
     epsg = gmlHelper.getReceptorGridSettings().getEpsg();
   }
 

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
@@ -93,8 +93,8 @@ public final class AssertGML {
     //util convenience class.
   }
 
-  static void assertEqualsGML(final String expected, final String actual) {
-    assertEquals(getCleanGML(expected), getCleanGML(actual), "GML contented compared not equal");
+  static void assertEqualsGML(final String expected, final String actual, final String gmlName) {
+    assertEquals(getCleanGML(expected), getCleanGML(actual), "GML (" + gmlName + ") content is not the same.");
   }
 
   private static String getCleanGML(final String gml) {
@@ -141,7 +141,8 @@ public final class AssertGML {
   static ImportParcel getImportResult(final String relativePath, final String fileName)
       throws IOException, AeriusException {
     final File file = getFile(relativePath, fileName);
-    final ImaerImporter importer = new ImaerImporter(AssertGML.mockGMLHelper());
+    final GMLHelper mockGMLHelper = AssertGML.mockGMLHelper();
+    final ImaerImporter importer = new ImaerImporter(mockGMLHelper, new GMLReaderFactory(mockGMLHelper));
     final ImportParcel result = new ImportParcel();
     try (final InputStream inputStream = new BufferedInputStream(new FileInputStream(file))) {
       importer.importStream(inputStream, ImportOption.getDefaultOptions(), result);
@@ -190,11 +191,9 @@ public final class AssertGML {
       return null;
     }).when(gmlHelper).enforceEmissions(anyInt(), any());
     when(gmlHelper.suggestInlandShippingWaterway(any())).thenAnswer(invocation -> suggest((Geometry) invocation.getArgument(0)));
-    when(gmlHelper.getLegacyCodes(any())).thenAnswer(invocation -> TestValidationAndEmissionHelper.legacyCodes());
-    when(gmlHelper.getLegacyMobileSourceOffRoadConversions())
-        .thenAnswer(invocation -> TestValidationAndEmissionHelper.legacyMobileSourceOffRoadConversions());
-    when(gmlHelper.getLegacyPlanConversions())
-        .thenAnswer(invocation -> TestValidationAndEmissionHelper.legacyPlanConversions());
+    when(gmlHelper.getLegacyCodes(any())).thenReturn(TestValidationAndEmissionHelper.legacyCodes());
+    when(gmlHelper.getLegacyMobileSourceOffRoadConversions()).thenReturn(TestValidationAndEmissionHelper.legacyMobileSourceOffRoadConversions());
+    when(gmlHelper.getLegacyPlanConversions()).thenReturn(TestValidationAndEmissionHelper.legacyPlanConversions());
     when(gmlHelper.determineDefaultCharacteristicsBySectorId(anyInt())).thenReturn(mock(OPSSourceCharacteristics.class));
     when(gmlHelper.getValidationHelper()).thenReturn(valiationAndEmissionHelper);
     return gmlHelper;

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLOldVersionTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLOldVersionTest.java
@@ -95,7 +95,7 @@ public class GMLOldVersionTest {
     private TestFile(final List<AeriusGMLVersion> skipEmissionCheckIn, final AeriusGMLVersion... warningsIn) {
       this(false, skipEmissionCheckIn, Collections.emptyList(), warningsIn);
     }
-    
+
     private TestFile(final boolean skipNumberOfSourcesCheck, final List<AeriusGMLVersion> skipEmissionCheckIn, final AeriusGMLVersion... warningsIn) {
       this(skipNumberOfSourcesCheck, skipEmissionCheckIn, Collections.emptyList(), warningsIn);
     }
@@ -154,7 +154,7 @@ public class GMLOldVersionTest {
     return files;
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{0}-{1}")
   @MethodSource("data")
   public void testVersionGML(final AeriusGMLVersion version, final TestFile testFile) throws IOException, AeriusException {
     final ImportParcel oldResult = getImportResult(version.name().toLowerCase() + TEST_FOLDER, testFile);

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateWarningsTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateWarningsTest.java
@@ -70,7 +70,7 @@ public class GMLValidateWarningsTest {
     return files;
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{0}-{1}")
   @MethodSource("data")
   public void testVersionGML(final AeriusGMLVersion version, final TestFile testFile) throws IOException, AeriusException {
     final ImportParcel oldResult = getImportResult(version.name().toLowerCase(), testFile);

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterTest.java
@@ -80,7 +80,7 @@ public class GMLWriterTest {
     final List<EmissionSourceFeature> sources = getExampleEmissionSources();
     final String result = getConversionResult(builder, sources);
     assertFalse(result.isEmpty(), "Result shouldn't be empty");
-    AssertGML.assertEqualsGML(AssertGML.getFileContent(PATH_CURRENT_VERSION, SOURCES_ONLY_FILE), result);
+    AssertGML.assertEqualsGML(AssertGML.getFileContent(PATH_CURRENT_VERSION, SOURCES_ONLY_FILE), result, SOURCES_ONLY_FILE);
   }
 
   private String getConversionResult(final GMLWriter builder, final List<EmissionSourceFeature> sources) throws IOException, AeriusException {
@@ -230,7 +230,7 @@ public class GMLWriterTest {
       result = bos.toString(StandardCharsets.UTF_8.name());
     }
     assertFalse(result.isEmpty(), "Result shouldn't be empty for " + receptorFile);
-    AssertGML.assertEqualsGML(AssertGML.getFileContent(PATH_CURRENT_VERSION, receptorFile), result);
+    AssertGML.assertEqualsGML(AssertGML.getFileContent(PATH_CURRENT_VERSION, receptorFile), result, receptorFile);
   }
 
   private ArrayList<CalculationPointFeature> getExampleAeriusPoints(final boolean includeDeposition, final boolean includeConcentration) {
@@ -311,7 +311,7 @@ public class GMLWriterTest {
       result = bos.toString(StandardCharsets.UTF_8.name());
     }
     assertFalse(result.isEmpty(), "Result shouldn't be empty");
-    AssertGML.assertEqualsGML(AssertGML.getFileContent(PATH_CURRENT_VERSION, MIXED_FEATURES_FILE), result);
+    AssertGML.assertEqualsGML(AssertGML.getFileContent(PATH_CURRENT_VERSION, MIXED_FEATURES_FILE), result, MIXED_FEATURES_FILE);
   }
 
   private ScenarioMetaData getScenarioMetaData() {

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/UnsupportedFeaturesTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/UnsupportedFeaturesTest.java
@@ -82,7 +82,7 @@ public class UnsupportedFeaturesTest {
    *           Thrown if an error occurred while re-accessing the test file.
    * @throws AeriusException
    */
-  @ParameterizedTest
+  @ParameterizedTest(name = "{0}")
   @MethodSource("data")
   public void testValidationFailure(final String fileName, final File file) throws FileNotFoundException, IOException, AeriusException {
     final ImaerImporter importer = new ImaerImporter(AssertGML.mockGMLHelper());

--- a/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/domain/JsonRoundTripTest.java
+++ b/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/domain/JsonRoundTripTest.java
@@ -54,7 +54,7 @@ class JsonRoundTripTest {
     mapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{0}")
   @ValueSource(strings = {
       "SourceWithPointGeometry.json",
       "SourceWithLineStringGeometry.json",
@@ -67,7 +67,7 @@ class JsonRoundTripTest {
     assertEquals(originalJson, convertedBack + System.lineSeparator(), "Original should be same as converted");
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{0}")
   @ValueSource(strings = {
       "GenericEmissionSource.json",
       "FarmLodgingEmissionSource.json",
@@ -92,7 +92,7 @@ class JsonRoundTripTest {
     assertEquals(originalJson, convertedBack + System.lineSeparator(), "Original should be same as converted");
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{0}")
   @ValueSource(strings = {
       "SourcesCollection.json",
   })
@@ -131,7 +131,7 @@ class JsonRoundTripTest {
     assertEquals(originalJson, convertedBack + System.lineSeparator(), "Original should be same as converted");
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "{0}")
   @ValueSource(strings = {
       "NSLDispersionLine.json",
   })

--- a/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/geometry/ReceptorUtilTest.java
+++ b/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/geometry/ReceptorUtilTest.java
@@ -215,7 +215,7 @@ class ReceptorUtilTest {
     return Math.sqrt(tx * tx + ty * ty);
   }
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "ReceptorId: {0}, zoomLevel:{1}")
   @MethodSource("zoomLevelReceptors")
   void testGetZoomLevelForReceptor(final int id, final int expectedZoomLevel) {
     assertEquals(expectedZoomLevel, RECEPTOR_UTIL.getZoomLevelForReceptor(id), "Not the expected zoomlevel for id " + id);

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/util/ConstructPolygonTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/util/ConstructPolygonTest.java
@@ -37,7 +37,7 @@ import nl.overheid.aerius.shared.exception.AeriusException;
  */
 class ConstructPolygonTest {
 
-  @ParameterizedTest
+  @ParameterizedTest(name = "Orientation North:{0}")
   @ValueSource(doubles = {0, 45, 90, 100, 180, 270, 360, 400})
   void testOrientationTransformation(final double orientationNorth) {
     final double computed = GeometryUtil.orientationXToNorth(GeometryUtil.orientationNorthToX(orientationNorth));


### PR DESCRIPTION
…tic instances. (#46)

* Changed test to use an ImaerImporter that doesn't use the static GMLReaderFactory. The static GMLReaderFactory gets a mocked GMLHelper. On the GitHub action build server the tests seem to run in 1 jvm run and therefor the same GMLReaderFactory is returned. However, because the GMLHelper is
mocked it's a different one in different tests, but still the original is in the static GMLReaderFactory. The initial mocked GMLHelper doesn't work well in the other tests causing the mocking to return empty in other tests.
* Added filename to assert message of unit tests comparing GML content.
* Add name to @ParameterizedTest to better identify specific tests.
* Added more context information in assert message.
* Changed some test mock to use thenReturn.

(cherry picked from commit 7ca958d4282835e8662c64b71ba5bb31b17abdda)