### PR TITLE
AER-262 Fix empty value in results gml when using actual chemistry.

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/OPSOptions.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/OPSOptions.java
@@ -183,14 +183,14 @@ public class OPSOptions implements Serializable {
      */
     ACTUAL("");
 
-    private final String opsLabel;
+    private final String controlFileLabel;
 
-    Chemistry(final String opsLabel) {
-      this.opsLabel = opsLabel;
+    Chemistry(final String controlFileLabel) {
+      this.controlFileLabel = controlFileLabel;
     }
 
-    public String getOpsLabel() {
-      return opsLabel;
+    public String getControlFileLabel() {
+      return controlFileLabel;
     }
   }
 }

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/util/OptionsMetadataUtil.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/util/OptionsMetadataUtil.java
@@ -100,7 +100,7 @@ public final class OptionsMetadataUtil {
     if (options != null) {
       addBooleanValue(mapToAddTo, Option.OPS_RAW_INPUT, options.isRawInput(), addDefaults);
       addValue(mapToAddTo, Option.OPS_YEAR, options.getYear(), addDefaults);
-      addValue(mapToAddTo, Option.OPS_CHEMISTRY, Optional.ofNullable(options.getChemistry()).map(OPSOptions.Chemistry::getOpsLabel).orElse(null), addDefaults);
+      addValue(mapToAddTo, Option.OPS_CHEMISTRY, Optional.ofNullable(options.getChemistry()).map(OPSOptions.Chemistry::name).orElse(null), addDefaults);
       addValue(mapToAddTo, Option.OPS_COMP_CODE, options.getCompCode(), addDefaults);
       addValue(mapToAddTo, Option.OPS_MOL_WEIGHT, options.getMolWeight(), addDefaults);
       addValue(mapToAddTo, Option.OPS_PHASE, options.getPhase(), addDefaults);

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/util/OptionsMetadataUtilTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/util/OptionsMetadataUtilTest.java
@@ -167,6 +167,6 @@ class OptionsMetadataUtilTest {
     assertEquals("reject", result.get("ops_washout"));
     assertEquals("8 out of 10", result.get("ops_conv_rate"));
     assertEquals("8.19", result.get("ops_roughness"));
-    assertEquals("prognosis", result.get("ops_chemistry"));
+    assertEquals("PROGNOSIS", result.get("ops_chemistry"));
   }
 }


### PR DESCRIPTION
The input value is written to gml instead of the label used in the control file to prevent empty values when using ACTUAL chemistry.

Rename field in chemistry enum to make the distinction more clear.