### PR TITLE
Added ADMSRoadEmissionSource domain object

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/GML2SRM2Road.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/GML2SRM2Road.java
@@ -22,7 +22,7 @@ import java.util.List;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGmlProperty;
 import nl.overheid.aerius.shared.domain.v2.source.SRM2RoadEmissionSource;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrier;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrier;
 import nl.overheid.aerius.shared.domain.v2.source.road.SRM2LinearReference;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
@@ -121,9 +121,9 @@ public class GML2SRM2Road<T extends IsGmlSRM2Road> extends GML2SRMRoad<T, SRM2Ro
     }
   }
 
-  private RoadSideBarrier getRoadSideBarrier(final IsGmlProperty<IsGmlRoadSideBarrier> barrierProperty) {
+  private SRM2RoadSideBarrier getRoadSideBarrier(final IsGmlProperty<IsGmlRoadSideBarrier> barrierProperty) {
     final IsGmlRoadSideBarrier gmlBarrier = barrierProperty.getProperty();
-    final RoadSideBarrier barrier = new RoadSideBarrier();
+    final SRM2RoadSideBarrier barrier = new SRM2RoadSideBarrier();
     barrier.setBarrierType(gmlBarrier.getBarrierType());
     barrier.setHeight(gmlBarrier.getHeight());
     barrier.setDistance(gmlBarrier.getDistance());

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/v40/GML2SRM2Road.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/v40/GML2SRM2Road.java
@@ -24,7 +24,7 @@ import nl.overheid.aerius.gml.base.IsGmlProperty;
 import nl.overheid.aerius.gml.base.source.road.IsGmlRoadSideBarrier;
 import nl.overheid.aerius.gml.base.source.road.IsGmlSRM2RoadLinearReference;
 import nl.overheid.aerius.shared.domain.v2.source.SRM2RoadEmissionSource;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrier;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrier;
 import nl.overheid.aerius.shared.domain.v2.source.road.SRM2LinearReference;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
@@ -123,9 +123,9 @@ public class GML2SRM2Road<T extends IsGmlSRM2Road> extends GML2SRMRoad<T, SRM2Ro
     }
   }
 
-  private RoadSideBarrier getRoadSideBarrier(final IsGmlProperty<IsGmlRoadSideBarrier> barrierProperty) {
+  private SRM2RoadSideBarrier getRoadSideBarrier(final IsGmlProperty<IsGmlRoadSideBarrier> barrierProperty) {
     final IsGmlRoadSideBarrier gmlBarrier = barrierProperty.getProperty();
-    final RoadSideBarrier barrier = new RoadSideBarrier();
+    final SRM2RoadSideBarrier barrier = new SRM2RoadSideBarrier();
     barrier.setBarrierType(gmlBarrier.getBarrierType());
     barrier.setHeight(gmlBarrier.getHeight());
     barrier.setDistance(gmlBarrier.getDistance());

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/source/road/RoadSideBarrier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/source/road/RoadSideBarrier.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 
 import nl.overheid.aerius.gml.base.source.road.IsGmlRoadSideBarrier;
 import nl.overheid.aerius.gml.v0_5.base.CalculatorSchema;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrierType;
 
 /**
  *
@@ -31,17 +31,17 @@ import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
 @XmlType(name = "RoadSideBarrierType", namespace = CalculatorSchema.NAMESPACE, propOrder = {"barrierType", "height", "distance"})
 public class RoadSideBarrier implements IsGmlRoadSideBarrier {
 
-  private RoadSideBarrierType barrierType;
+  private SRM2RoadSideBarrierType barrierType;
   private double height;
   private double distance;
 
   @Override
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
-  public RoadSideBarrierType getBarrierType() {
+  public SRM2RoadSideBarrierType getBarrierType() {
     return barrierType;
   }
 
-  public void setBarrierType(final RoadSideBarrierType barrierType) {
+  public void setBarrierType(final SRM2RoadSideBarrierType barrierType) {
     this.barrierType = barrierType;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_0/source/road/RoadSideBarrier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_0/source/road/RoadSideBarrier.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 
 import nl.overheid.aerius.gml.base.source.road.IsGmlRoadSideBarrier;
 import nl.overheid.aerius.gml.v1_0.base.CalculatorSchema;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrierType;
 
 /**
  *
@@ -31,17 +31,17 @@ import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
 @XmlType(name = "RoadSideBarrierType", namespace = CalculatorSchema.NAMESPACE, propOrder = {"barrierType", "height", "distance"})
 public class RoadSideBarrier implements IsGmlRoadSideBarrier {
 
-  private RoadSideBarrierType barrierType;
+  private SRM2RoadSideBarrierType barrierType;
   private double height;
   private double distance;
 
   @Override
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
-  public RoadSideBarrierType getBarrierType() {
+  public SRM2RoadSideBarrierType getBarrierType() {
     return barrierType;
   }
 
-  public void setBarrierType(final RoadSideBarrierType barrierType) {
+  public void setBarrierType(final SRM2RoadSideBarrierType barrierType) {
     this.barrierType = barrierType;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/source/road/RoadSideBarrier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/source/road/RoadSideBarrier.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 
 import nl.overheid.aerius.gml.base.source.road.IsGmlRoadSideBarrier;
 import nl.overheid.aerius.gml.v1_1.base.CalculatorSchema;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrierType;
 
 /**
  *
@@ -31,17 +31,17 @@ import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
 @XmlType(name = "RoadSideBarrierType", namespace = CalculatorSchema.NAMESPACE, propOrder = {"barrierType", "height", "distance"})
 public class RoadSideBarrier implements IsGmlRoadSideBarrier {
 
-  private RoadSideBarrierType barrierType;
+  private SRM2RoadSideBarrierType barrierType;
   private double height;
   private double distance;
 
   @Override
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
-  public RoadSideBarrierType getBarrierType() {
+  public SRM2RoadSideBarrierType getBarrierType() {
     return barrierType;
   }
 
-  public void setBarrierType(final RoadSideBarrierType barrierType) {
+  public void setBarrierType(final SRM2RoadSideBarrierType barrierType) {
     this.barrierType = barrierType;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/source/road/RoadSideBarrier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/source/road/RoadSideBarrier.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 
 import nl.overheid.aerius.gml.base.source.road.IsGmlRoadSideBarrier;
 import nl.overheid.aerius.gml.v2_0.base.CalculatorSchema;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrierType;
 
 /**
  *
@@ -31,17 +31,17 @@ import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
 @XmlType(name = "RoadSideBarrierType", namespace = CalculatorSchema.NAMESPACE, propOrder = {"barrierType", "height", "distance"})
 public class RoadSideBarrier implements IsGmlRoadSideBarrier {
 
-  private RoadSideBarrierType barrierType;
+  private SRM2RoadSideBarrierType barrierType;
   private double height;
   private double distance;
 
   @Override
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
-  public RoadSideBarrierType getBarrierType() {
+  public SRM2RoadSideBarrierType getBarrierType() {
     return barrierType;
   }
 
-  public void setBarrierType(final RoadSideBarrierType barrierType) {
+  public void setBarrierType(final SRM2RoadSideBarrierType barrierType) {
     this.barrierType = barrierType;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/source/road/RoadSideBarrier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/source/road/RoadSideBarrier.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 
 import nl.overheid.aerius.gml.base.source.road.IsGmlRoadSideBarrier;
 import nl.overheid.aerius.gml.v2_1.base.CalculatorSchema;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrierType;
 
 /**
  *
@@ -31,17 +31,17 @@ import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
 @XmlType(name = "RoadSideBarrierType", namespace = CalculatorSchema.NAMESPACE, propOrder = {"barrierType", "height", "distance"})
 public class RoadSideBarrier implements IsGmlRoadSideBarrier {
 
-  private RoadSideBarrierType barrierType;
+  private SRM2RoadSideBarrierType barrierType;
   private double height;
   private double distance;
 
   @Override
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
-  public RoadSideBarrierType getBarrierType() {
+  public SRM2RoadSideBarrierType getBarrierType() {
     return barrierType;
   }
 
-  public void setBarrierType(final RoadSideBarrierType barrierType) {
+  public void setBarrierType(final SRM2RoadSideBarrierType barrierType) {
     this.barrierType = barrierType;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/source/road/RoadSideBarrier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/source/road/RoadSideBarrier.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 
 import nl.overheid.aerius.gml.base.source.road.IsGmlRoadSideBarrier;
 import nl.overheid.aerius.gml.v2_2.base.CalculatorSchema;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrierType;
 
 /**
  *
@@ -31,17 +31,17 @@ import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
 @XmlType(name = "RoadSideBarrierType", namespace = CalculatorSchema.NAMESPACE, propOrder = {"barrierType", "height", "distance"})
 public class RoadSideBarrier implements IsGmlRoadSideBarrier {
 
-  private RoadSideBarrierType barrierType;
+  private SRM2RoadSideBarrierType barrierType;
   private double height;
   private double distance;
 
   @Override
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
-  public RoadSideBarrierType getBarrierType() {
+  public SRM2RoadSideBarrierType getBarrierType() {
     return barrierType;
   }
 
-  public void setBarrierType(final RoadSideBarrierType barrierType) {
+  public void setBarrierType(final SRM2RoadSideBarrierType barrierType) {
     this.barrierType = barrierType;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/source/road/RoadSideBarrier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/source/road/RoadSideBarrier.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 
 import nl.overheid.aerius.gml.base.source.road.IsGmlRoadSideBarrier;
 import nl.overheid.aerius.gml.v3_0.base.CalculatorSchema;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrierType;
 
 /**
  *
@@ -31,17 +31,17 @@ import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
 @XmlType(name = "RoadSideBarrierType", namespace = CalculatorSchema.NAMESPACE, propOrder = {"barrierType", "height", "distance"})
 public class RoadSideBarrier implements IsGmlRoadSideBarrier {
 
-  private RoadSideBarrierType barrierType;
+  private SRM2RoadSideBarrierType barrierType;
   private double height;
   private double distance;
 
   @Override
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
-  public RoadSideBarrierType getBarrierType() {
+  public SRM2RoadSideBarrierType getBarrierType() {
     return barrierType;
   }
 
-  public void setBarrierType(final RoadSideBarrierType barrierType) {
+  public void setBarrierType(final SRM2RoadSideBarrierType barrierType) {
     this.barrierType = barrierType;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/source/road/RoadSideBarrier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/source/road/RoadSideBarrier.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 
 import nl.overheid.aerius.gml.base.source.road.IsGmlRoadSideBarrier;
 import nl.overheid.aerius.gml.v3_1.base.CalculatorSchema;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrierType;
 
 /**
  *
@@ -31,17 +31,17 @@ import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
 @XmlType(name = "RoadSideBarrierType", namespace = CalculatorSchema.NAMESPACE, propOrder = {"barrierType", "height", "distance"})
 public class RoadSideBarrier implements IsGmlRoadSideBarrier {
 
-  private RoadSideBarrierType barrierType;
+  private SRM2RoadSideBarrierType barrierType;
   private double height;
   private double distance;
 
   @Override
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
-  public RoadSideBarrierType getBarrierType() {
+  public SRM2RoadSideBarrierType getBarrierType() {
     return barrierType;
   }
 
-  public void setBarrierType(final RoadSideBarrierType barrierType) {
+  public void setBarrierType(final SRM2RoadSideBarrierType barrierType) {
     this.barrierType = barrierType;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/source/road/RoadSideBarrier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/source/road/RoadSideBarrier.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 
 import nl.overheid.aerius.gml.base.source.road.IsGmlRoadSideBarrier;
 import nl.overheid.aerius.gml.v4_0.base.CalculatorSchema;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrierType;
 
 /**
  *
@@ -31,17 +31,17 @@ import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
 @XmlType(name = "RoadSideBarrierType", namespace = CalculatorSchema.NAMESPACE, propOrder = {"barrierType", "height", "distance"})
 public class RoadSideBarrier implements IsGmlRoadSideBarrier {
 
-  private RoadSideBarrierType barrierType;
+  private SRM2RoadSideBarrierType barrierType;
   private double height;
   private double distance;
 
   @Override
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
-  public RoadSideBarrierType getBarrierType() {
+  public SRM2RoadSideBarrierType getBarrierType() {
     return barrierType;
   }
 
-  public void setBarrierType(final RoadSideBarrierType barrierType) {
+  public void setBarrierType(final SRM2RoadSideBarrierType barrierType) {
     this.barrierType = barrierType;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/Road2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/Road2GML.java
@@ -37,10 +37,10 @@ import nl.overheid.aerius.shared.domain.v2.source.SRM1RoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.SRM2RoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.road.CustomVehicles;
 import nl.overheid.aerius.shared.domain.v2.source.road.RoadElevation;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrier;
 import nl.overheid.aerius.shared.domain.v2.source.road.RoadSpeedType;
 import nl.overheid.aerius.shared.domain.v2.source.road.SRM1LinearReference;
 import nl.overheid.aerius.shared.domain.v2.source.road.SRM2LinearReference;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrier;
 import nl.overheid.aerius.shared.domain.v2.source.road.SpecificVehicles;
 import nl.overheid.aerius.shared.domain.v2.source.road.StandardVehicles;
 import nl.overheid.aerius.shared.domain.v2.source.road.ValuesPerVehicleType;
@@ -61,6 +61,7 @@ class Road2GML extends SpecificSource2GML<nl.overheid.aerius.shared.domain.v2.so
       returnSource = convertSrm1((SRM1RoadEmissionSource) emissionSource);
     } else if (emissionSource instanceof SRM2RoadEmissionSource) {
       returnSource = convertSrm2((SRM2RoadEmissionSource) emissionSource);
+      // TODO: ADMSRoadEmissionSource ? UK specific, and UK shouldn't be using IMAER 4.0
     } else {
       returnSource = null;
     }
@@ -147,7 +148,7 @@ class Road2GML extends SpecificSource2GML<nl.overheid.aerius.shared.domain.v2.so
     }
   }
 
-  private RoadSideBarrierProperty toGMLRoadSideBarrier(final RoadSideBarrier barrier) {
+  private RoadSideBarrierProperty toGMLRoadSideBarrier(final SRM2RoadSideBarrier barrier) {
     final nl.overheid.aerius.gml.v4_0.source.road.RoadSideBarrier gmlBarrier = new nl.overheid.aerius.gml.v4_0.source.road.RoadSideBarrier();
     gmlBarrier.setBarrierType(barrier.getBarrierType());
     gmlBarrier.setHeight(barrier.getHeight());

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/Source2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/Source2GML.java
@@ -30,6 +30,7 @@ import nl.overheid.aerius.shared.domain.Substance;
 import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.geojson.IsFeature;
 import nl.overheid.aerius.shared.domain.v2.geojson.Point;
+import nl.overheid.aerius.shared.domain.v2.source.ADMSRoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceVisitor;
@@ -174,6 +175,12 @@ final class Source2GML implements EmissionSourceVisitor<nl.overheid.aerius.gml.v
 
   @Override
   public nl.overheid.aerius.gml.v4_0.source.EmissionSource visit(final SRM2RoadEmissionSource emissionSource, final IsFeature feature)
+      throws AeriusException {
+    return new Road2GML().convert(emissionSource);
+  }
+
+  @Override
+  public nl.overheid.aerius.gml.v4_0.source.EmissionSource visit(final ADMSRoadEmissionSource emissionSource, final IsFeature feature)
       throws AeriusException {
     return new Road2GML().convert(emissionSource);
   }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/source/road/RoadSideBarrier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/source/road/RoadSideBarrier.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 
 import nl.overheid.aerius.gml.base.source.road.IsGmlRoadSideBarrier;
 import nl.overheid.aerius.gml.v5_0.base.CalculatorSchema;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrierType;
 
 /**
  *
@@ -31,17 +31,17 @@ import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrierType;
 @XmlType(name = "RoadSideBarrierType", namespace = CalculatorSchema.NAMESPACE, propOrder = {"barrierType", "height", "distance"})
 public class RoadSideBarrier implements IsGmlRoadSideBarrier {
 
-  private RoadSideBarrierType barrierType;
+  private SRM2RoadSideBarrierType barrierType;
   private double height;
   private double distance;
 
   @Override
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
-  public RoadSideBarrierType getBarrierType() {
+  public SRM2RoadSideBarrierType getBarrierType() {
     return barrierType;
   }
 
-  public void setBarrierType(final RoadSideBarrierType barrierType) {
+  public void setBarrierType(final SRM2RoadSideBarrierType barrierType) {
     this.barrierType = barrierType;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/Road2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/Road2GML.java
@@ -38,9 +38,9 @@ import nl.overheid.aerius.shared.domain.v2.source.SRM1RoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.SRM2RoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.road.CustomVehicles;
 import nl.overheid.aerius.shared.domain.v2.source.road.RoadElevation;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrier;
 import nl.overheid.aerius.shared.domain.v2.source.road.SRM1LinearReference;
 import nl.overheid.aerius.shared.domain.v2.source.road.SRM2LinearReference;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrier;
 import nl.overheid.aerius.shared.domain.v2.source.road.SpecificVehicles;
 import nl.overheid.aerius.shared.domain.v2.source.road.StandardVehicles;
 import nl.overheid.aerius.shared.domain.v2.source.road.ValuesPerVehicleType;
@@ -60,6 +60,7 @@ class Road2GML extends SpecificSource2GML<nl.overheid.aerius.shared.domain.v2.so
       returnSource = convertSrm1((SRM1RoadEmissionSource) emissionSource);
     } else if (emissionSource instanceof SRM2RoadEmissionSource) {
       returnSource = convertSrm2((SRM2RoadEmissionSource) emissionSource);
+      // TODO: ADMSRoadEmissionSource
     } else {
       returnSource = null;
     }
@@ -156,7 +157,7 @@ class Road2GML extends SpecificSource2GML<nl.overheid.aerius.shared.domain.v2.so
     }
   }
 
-  private RoadSideBarrierProperty toGMLRoadSideBarrier(final RoadSideBarrier barrier) {
+  private RoadSideBarrierProperty toGMLRoadSideBarrier(final SRM2RoadSideBarrier barrier) {
     final nl.overheid.aerius.gml.v5_0.source.road.RoadSideBarrier gmlBarrier = new nl.overheid.aerius.gml.v5_0.source.road.RoadSideBarrier();
     gmlBarrier.setBarrierType(barrier.getBarrierType());
     gmlBarrier.setHeight(barrier.getHeight());

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/Source2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/Source2GML.java
@@ -30,6 +30,7 @@ import nl.overheid.aerius.shared.domain.Substance;
 import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.geojson.IsFeature;
 import nl.overheid.aerius.shared.domain.v2.geojson.Point;
+import nl.overheid.aerius.shared.domain.v2.source.ADMSRoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceVisitor;
@@ -174,6 +175,12 @@ final class Source2GML implements EmissionSourceVisitor<nl.overheid.aerius.gml.v
 
   @Override
   public nl.overheid.aerius.gml.v5_0.source.EmissionSource visit(final SRM2RoadEmissionSource emissionSource, final IsFeature feature)
+      throws AeriusException {
+    return new Road2GML().convert(emissionSource);
+  }
+
+  @Override
+  public nl.overheid.aerius.gml.v5_0.source.EmissionSource visit(final ADMSRoadEmissionSource emissionSource, final IsFeature feature)
       throws AeriusException {
     return new Road2GML().convert(emissionSource);
   }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/schematron/EmissionSourceSchematronVisitor.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/schematron/EmissionSourceSchematronVisitor.java
@@ -24,6 +24,7 @@ import java.util.List;
 import com.helger.commons.io.stream.StringInputStream;
 
 import nl.overheid.aerius.shared.domain.v2.geojson.IsFeature;
+import nl.overheid.aerius.shared.domain.v2.source.ADMSRoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceVisitor;
 import nl.overheid.aerius.shared.domain.v2.source.FarmLodgingEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.FarmlandEmissionSource;
@@ -87,6 +88,12 @@ public class EmissionSourceSchematronVisitor implements EmissionSourceVisitor<Vo
   @Override
   public Void visit(final SRM2RoadEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
     validate(validators.getSrm2RoadValidator());
+    return null;
+  }
+
+  @Override
+  public Void visit(final ADMSRoadEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    //NO-OP
     return null;
   }
 

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/ADMSRoadEmissionSource.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/ADMSRoadEmissionSource.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.shared.domain.v2.source;
+
+import nl.overheid.aerius.shared.domain.v2.geojson.IsFeature;
+import nl.overheid.aerius.shared.domain.v2.source.road.ADMSRoadSideBarrier;
+import nl.overheid.aerius.shared.exception.AeriusException;
+
+public class ADMSRoadEmissionSource extends RoadEmissionSource {
+
+  private static final long serialVersionUID = 1L;
+
+  private double width;
+  private double elevation;
+  private double gradient;
+  private double coverage;
+
+  private ADMSRoadSideBarrier barrierLeft;
+  private ADMSRoadSideBarrier barrierRight;
+
+  public double getWidth() {
+    return width;
+  }
+
+  public void setWidth(final double width) {
+    this.width = width;
+  }
+
+  public double getElevation() {
+    return elevation;
+  }
+
+  public void setElevation(final double elevation) {
+    this.elevation = elevation;
+  }
+
+  public double getGradient() {
+    return gradient;
+  }
+
+  public void setGradient(final double gradient) {
+    this.gradient = gradient;
+  }
+
+  public double getCoverage() {
+    return coverage;
+  }
+
+  public void setCoverage(final double coverage) {
+    this.coverage = coverage;
+  }
+
+  public ADMSRoadSideBarrier getBarrierLeft() {
+    return barrierLeft;
+  }
+
+  public void setBarrierLeft(final ADMSRoadSideBarrier barrierLeft) {
+    this.barrierLeft = barrierLeft;
+  }
+
+  public ADMSRoadSideBarrier getBarrierRight() {
+    return barrierRight;
+  }
+
+  public void setBarrierRight(final ADMSRoadSideBarrier barrierRight) {
+    this.barrierRight = barrierRight;
+  }
+
+  @Override
+  <T> T accept(final EmissionSourceVisitor<T> visitor, final IsFeature feature) throws AeriusException {
+    return visitor.visit(this, feature);
+  }
+
+}

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/EmissionSource.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/EmissionSource.java
@@ -41,6 +41,7 @@ import nl.overheid.aerius.shared.exception.AeriusException;
     @Type(value = OffRoadMobileEmissionSource.class, name = EmissionSourceType.Names.OFFROAD_MOBILE),
     @Type(value = SRM1RoadEmissionSource.class, name = EmissionSourceType.Names.SRM1_ROAD),
     @Type(value = SRM2RoadEmissionSource.class, name = EmissionSourceType.Names.SRM2_ROAD),
+    @Type(value = ADMSRoadEmissionSource.class, name = EmissionSourceType.Names.ADMS_ROAD),
     @Type(value = InlandShippingEmissionSource.class, name = EmissionSourceType.Names.SHIPPING_INLAND),
     @Type(value = MooringInlandShippingEmissionSource.class, name = EmissionSourceType.Names.SHIPPING_INLAND_DOCKED),
     @Type(value = InlandMaritimeShippingEmissionSource.class, name = EmissionSourceType.Names.SHIPPING_MARITIME_INLAND),

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/EmissionSourceVisitor.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/EmissionSourceVisitor.java
@@ -37,6 +37,8 @@ public interface EmissionSourceVisitor<T> {
 
   T visit(SRM2RoadEmissionSource emissionSource, IsFeature feature) throws AeriusException;
 
+  T visit(ADMSRoadEmissionSource emissionSource, IsFeature feature) throws AeriusException;
+
   T visit(InlandShippingEmissionSource emissionSource, IsFeature feature) throws AeriusException;
 
   T visit(MooringInlandShippingEmissionSource emissionSource, IsFeature feature) throws AeriusException;

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/SRM2RoadEmissionSource.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/SRM2RoadEmissionSource.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import nl.overheid.aerius.shared.domain.v2.geojson.IsFeature;
 import nl.overheid.aerius.shared.domain.v2.source.road.RoadElevation;
-import nl.overheid.aerius.shared.domain.v2.source.road.RoadSideBarrier;
+import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrier;
 import nl.overheid.aerius.shared.domain.v2.source.road.SRM2LinearReference;
 import nl.overheid.aerius.shared.exception.AeriusException;
 
@@ -31,8 +31,8 @@ public class SRM2RoadEmissionSource extends RoadEmissionSource {
   private RoadElevation elevation = RoadElevation.NORMAL;
   private int elevationHeight;
 
-  private RoadSideBarrier barrierLeft;
-  private RoadSideBarrier barrierRight;
+  private SRM2RoadSideBarrier barrierLeft;
+  private SRM2RoadSideBarrier barrierRight;
 
   private List<SRM2LinearReference> partialChanges;
 
@@ -52,19 +52,19 @@ public class SRM2RoadEmissionSource extends RoadEmissionSource {
     this.elevationHeight = elevationHeight;
   }
 
-  public RoadSideBarrier getBarrierLeft() {
+  public SRM2RoadSideBarrier getBarrierLeft() {
     return barrierLeft;
   }
 
-  public void setBarrierLeft(final RoadSideBarrier barrierLeft) {
+  public void setBarrierLeft(final SRM2RoadSideBarrier barrierLeft) {
     this.barrierLeft = barrierLeft;
   }
 
-  public RoadSideBarrier getBarrierRight() {
+  public SRM2RoadSideBarrier getBarrierRight() {
     return barrierRight;
   }
 
-  public void setBarrierRight(final RoadSideBarrier barrierRight) {
+  public void setBarrierRight(final SRM2RoadSideBarrier barrierRight) {
     this.barrierRight = barrierRight;
   }
 

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/road/ADMSRoadSideBarrier.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/road/ADMSRoadSideBarrier.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.shared.domain.v2.source.road;
+
+import java.io.Serializable;
+
+public class ADMSRoadSideBarrier implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Type of the barrier.
+   */
+  private ADMSRoadSideBarrierType barrierType;
+  /**
+   * Width of the barrier (along the road?).
+   */
+  private double width;
+  /**
+   * Maximum height of the barrier.
+   */
+  private double maximumHeight;
+  /**
+   * Average height of the barrier.
+   */
+  private double averageHeight;
+  /**
+   * Minimum height of the barrier.
+   */
+  private double minimumHeight;
+  /**
+   * The porosity of the barrier
+   */
+  private double porosity;
+
+  public ADMSRoadSideBarrierType getBarrierType() {
+    return barrierType;
+  }
+
+  public void setBarrierType(final ADMSRoadSideBarrierType barrierType) {
+    this.barrierType = barrierType;
+  }
+
+  public double getWidth() {
+    return width;
+  }
+
+  public void setWidth(final double width) {
+    this.width = width;
+  }
+
+  public double getMaximumHeight() {
+    return maximumHeight;
+  }
+
+  public void setMaximumHeight(final double maximumHeight) {
+    this.maximumHeight = maximumHeight;
+  }
+
+  public double getAverageHeight() {
+    return averageHeight;
+  }
+
+  public void setAverageHeight(final double averageHeight) {
+    this.averageHeight = averageHeight;
+  }
+
+  public double getMinimumHeight() {
+    return minimumHeight;
+  }
+
+  public void setMinimumHeight(final double minimumHeight) {
+    this.minimumHeight = minimumHeight;
+  }
+
+  public double getPorosity() {
+    return porosity;
+  }
+
+  public void setPorosity(final double porosity) {
+    this.porosity = porosity;
+  }
+
+}

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/road/ADMSRoadSideBarrierType.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/road/ADMSRoadSideBarrierType.java
@@ -14,16 +14,16 @@
  * You should have received a copy of the GNU Affero General Public License
  * along with this program.  If not, see http://www.gnu.org/licenses/.
  */
-package nl.overheid.aerius.gml.base.source.road;
+package nl.overheid.aerius.shared.domain.v2.source.road;
 
-import nl.overheid.aerius.shared.domain.v2.source.road.SRM2RoadSideBarrierType;
-
-public interface IsGmlRoadSideBarrier {
-
-  SRM2RoadSideBarrierType getBarrierType();
-
-  double getHeight();
-
-  double getDistance();
-
+/**
+ * The type of a barrier on the side of a road.
+ */
+public enum ADMSRoadSideBarrierType {
+  NONE,
+  NOISE_BARRIER,
+  STREET_CANYON_TERRACED_HOUSES,
+  STREET_CANYON_DETACHED_HOUSES,
+  TREE_BARRIER,
+  OTHER;
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/road/SRM2LinearReference.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/road/SRM2LinearReference.java
@@ -25,8 +25,8 @@ public class SRM2LinearReference extends LinearReference {
   private Double tunnelFactor;
   private RoadElevation elevation;
   private Integer elevationHeight;
-  private RoadSideBarrier barrierLeft;
-  private RoadSideBarrier barrierRight;
+  private SRM2RoadSideBarrier barrierLeft;
+  private SRM2RoadSideBarrier barrierRight;
 
   public Double getTunnelFactor() {
     return tunnelFactor;
@@ -52,19 +52,19 @@ public class SRM2LinearReference extends LinearReference {
     this.elevationHeight = elevationHeight;
   }
 
-  public RoadSideBarrier getBarrierLeft() {
+  public SRM2RoadSideBarrier getBarrierLeft() {
     return barrierLeft;
   }
 
-  public void setBarrierLeft(final RoadSideBarrier barrierLeft) {
+  public void setBarrierLeft(final SRM2RoadSideBarrier barrierLeft) {
     this.barrierLeft = barrierLeft;
   }
 
-  public RoadSideBarrier getBarrierRight() {
+  public SRM2RoadSideBarrier getBarrierRight() {
     return barrierRight;
   }
 
-  public void setBarrierRight(final RoadSideBarrier barrierRight) {
+  public void setBarrierRight(final SRM2RoadSideBarrier barrierRight) {
     this.barrierRight = barrierRight;
   }
 

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/road/SRM2RoadSideBarrier.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/road/SRM2RoadSideBarrier.java
@@ -18,14 +18,14 @@ package nl.overheid.aerius.shared.domain.v2.source.road;
 
 import java.io.Serializable;
 
-public class RoadSideBarrier implements Serializable {
+public class SRM2RoadSideBarrier implements Serializable {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   /**
    * Type of the barrier.
    */
-  private RoadSideBarrierType barrierType;
+  private SRM2RoadSideBarrierType barrierType;
   /**
    * Height of the barrier.
    */
@@ -35,11 +35,11 @@ public class RoadSideBarrier implements Serializable {
    */
   private double distance;
 
-  public RoadSideBarrierType getBarrierType() {
+  public SRM2RoadSideBarrierType getBarrierType() {
     return barrierType;
   }
 
-  public void setBarrierType(final RoadSideBarrierType barrierType) {
+  public void setBarrierType(final SRM2RoadSideBarrierType barrierType) {
     this.barrierType = barrierType;
   }
 

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/road/SRM2RoadSideBarrierType.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/road/SRM2RoadSideBarrierType.java
@@ -19,7 +19,7 @@ package nl.overheid.aerius.shared.domain.v2.source.road;
 /**
  * The type of a barrier on the side of a road.
  */
-public enum RoadSideBarrierType {
+public enum SRM2RoadSideBarrierType {
 
   /**
    * The barrier is a screen (example: 'Geluidsscherm').
@@ -33,7 +33,7 @@ public enum RoadSideBarrierType {
 
   private final double heightFactor;
 
-  RoadSideBarrierType(final double heightFactor) {
+  SRM2RoadSideBarrierType(final double heightFactor) {
     this.heightFactor = heightFactor;
   }
 

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/emissions/EmissionsCalculator.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/emissions/EmissionsCalculator.java
@@ -20,6 +20,7 @@ import java.util.Map;
 
 import nl.overheid.aerius.shared.domain.Substance;
 import nl.overheid.aerius.shared.domain.v2.geojson.IsFeature;
+import nl.overheid.aerius.shared.domain.v2.source.ADMSRoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceVisitor;
 import nl.overheid.aerius.shared.domain.v2.source.FarmLodgingEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.FarmlandEmissionSource;
@@ -98,6 +99,11 @@ class EmissionsCalculator implements EmissionSourceVisitor<Map<Substance, Double
 
   @Override
   public Map<Substance, Double> visit(final SRM2RoadEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return roadEmissionsCalculator.calculateEmissions(emissionSource, feature.getGeometry());
+  }
+
+  @Override
+  public Map<Substance, Double> visit(final ADMSRoadEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
     return roadEmissionsCalculator.calculateEmissions(emissionSource, feature.getGeometry());
   }
 

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ValidationVisitor.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ValidationVisitor.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import nl.overheid.aerius.shared.domain.v2.geojson.IsFeature;
+import nl.overheid.aerius.shared.domain.v2.source.ADMSRoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceVisitor;
 import nl.overheid.aerius.shared.domain.v2.source.FarmLodgingEmissionSource;
@@ -122,6 +123,11 @@ public class ValidationVisitor implements EmissionSourceVisitor<Boolean> {
 
   @Override
   public Boolean visit(final SRM2RoadEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return new RoadValidator(errors, warnings, validationHelper.roadValidation()).validate(emissionSource, feature);
+  }
+
+  @Override
+  public Boolean visit(final ADMSRoadEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
     return new RoadValidator(errors, warnings, validationHelper.roadValidation()).validate(emissionSource, feature);
   }
 


### PR DESCRIPTION
New RoadEmissionSource specialization for ADMS. Properties are based on what UI has at the moment.
Renamed RoadSideBarrier to SRM2RoadSideBarrier (and -Type) to reflect that these are specific for SRM2.
Because of the rename, and since the EmissionSourceVisitor has been changed, this will probably require an update in projects using this library.