### PR TITLE
AER-308 - Use a default porosity for OTHER

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/road/ADMSRoadSideBarrierType.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/road/ADMSRoadSideBarrierType.java
@@ -28,7 +28,7 @@ public enum ADMSRoadSideBarrierType {
   STREET_CANYON_DETACHED_HOUSES(50D),
   TREE_BARRIER_OPEN(80D),
   TREE_BARRIER_DENSE(90D),
-  OTHER;
+  OTHER(0D);
 
   private Double defaultPorosity;
 


### PR DESCRIPTION
> "The type ‘other’ should always have the porosity 0%. At the moment it is 0% when you fill it in immediately, but when you choose another type and then change is to 'other', it keeps the porosity of the previous type. This is confusing for the user."