### PR TITLE
No reuse in tests causing objects to be cached

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/importer/ImaerImporter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/importer/ImaerImporter.java
@@ -70,11 +70,7 @@ public class ImaerImporter {
   private final EPSG epsg;
 
   public ImaerImporter(final GMLHelper gmlHelper) throws AeriusException {
-    this(gmlHelper, GMLReaderFactory.getFactory(gmlHelper));
-  }
-
-  public ImaerImporter(final GMLHelper gmlHelper, final GMLReaderFactory factory) throws AeriusException {
-    this.factory = factory;
+    factory = GMLReaderFactory.getFactory(gmlHelper);
     epsg = gmlHelper.getReceptorGridSettings().getEpsg();
   }
 

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
@@ -143,7 +143,7 @@ public final class AssertGML {
       throws IOException, AeriusException {
     final File file = getFile(relativePath, fileName);
     final GMLHelper mockGMLHelper = AssertGML.mockGMLHelper();
-    final ImaerImporter importer = new ImaerImporter(mockGMLHelper, new GMLReaderFactory(mockGMLHelper));
+    final ImaerImporter importer = new ImaerImporter(mockGMLHelper);
     final ImportParcel result = new ImportParcel();
     try (final InputStream inputStream = new BufferedInputStream(new FileInputStream(file))) {
       importer.importStream(inputStream, ImportOption.getDefaultOptions(), result);

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLRoundtripTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLRoundtripTest.java
@@ -40,7 +40,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import nl.overheid.aerius.gml.base.AeriusGMLVersion;
-import nl.overheid.aerius.gml.base.GMLHelper;
 import nl.overheid.aerius.gml.base.MetaDataInput;
 import nl.overheid.aerius.importer.ImaerImporter;
 import nl.overheid.aerius.importer.ImportOption;
@@ -257,8 +256,7 @@ public class GMLRoundtripTest {
       throws IOException, AeriusException {
     final String relativePath = getRelativePath(versionString, testFolder);
     final AtomicReference<String> readVersion = new AtomicReference<>();
-    final GMLHelper mockGMLHelper = AssertGML.mockGMLHelper();
-    final ImaerImporter importer = new ImaerImporter(mockGMLHelper, new GMLReaderFactory(mockGMLHelper)) {
+    final ImaerImporter importer = new ImaerImporter(AssertGML.mockGMLHelper()) {
       @Override
       protected GMLReader createGMLReader(final InputStream inputStream, final Set<ImportOption> importOptions, final ImportParcel result)
           throws AeriusException {

--- a/source/pom.xml
+++ b/source/pom.xml
@@ -65,7 +65,8 @@
     <jackson.version>2.11.3</jackson.version>
     <org.codehaus.mojo.gwtmavenplugin.version>${com.google.gwt.version}</org.codehaus.mojo.gwtmavenplugin.version>
 
-    <aerius-tools.version>1.1.0-SNAPSHOT</aerius-tools.version>
+    <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
+    <aerius-tools.version>1.1.0</aerius-tools.version>
     <spotless.version>2.5.0</spotless.version>
     <docker.maven.plugin.version>0.30.0</docker.maven.plugin.version>
 
@@ -141,7 +142,10 @@
       <plugins>
         <plugin>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
+          <version>${maven.surefire.plugin.version}</version>
+          <configuration>
+            <reuseForks>false</reuseForks>
+          </configuration>
         </plugin>
         <plugin>
           <artifactId>maven-jar-plugin</artifactId>


### PR DESCRIPTION
This reuse of forks in the surefire plugin causes objects to be reused over tests.
However these objects can change between tests leading to test to fail if they use the cached version.