### PR TITLE
GitHub Action: Allow PRs to properly run workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - master
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened]
 
 jobs:


### PR DESCRIPTION
By using the new `pull_request_target` the workflow files from the base branch will be used,
 making sure secrets won't be leaked.