### PR TITLE
GitHub Action: GITHUB_TOKEN is required for Sonar

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,11 +40,12 @@ jobs:
       - if: github.event_name == 'push'
         name: Build and analyze (push)
         env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn --no-transfer-progress -f source/pom.xml -P sonar verify sonar:sonar
       - if: github.event_name == 'pull_request_target'
         name: Build and analyze (pull_request_target)
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn --no-transfer-progress -f source/pom.xml -P sonar verify sonar:sonar -Dsonar.pullrequest.key=${{ github.event.pull_request.number }} -Dsonar.pullrequest.branch=${{ github.event.pull_request.head.ref }} -Dsonar.pullrequest.base=${{ github.event.pull_request.base.ref }}


### PR DESCRIPTION
I have been lied to. The comment made me think it was only needed for PR information.
Well it needs it regardless.