### PR TITLE
AER-449 Updated temperature range for ADMS

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/adms/ADMSLimits.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/adms/ADMSLimits.java
@@ -43,7 +43,7 @@ public final class ADMSLimits implements BuildingLimits {
   public static final double SOURCE_VERTICAL_VELOCITY_DEFAULT = 15;
 
   public static final int SOURCE_TEMPERATURE_MINIMUM = -100;
-  public static final int SOURCE_TEMPERATURE_MAXIMUM = 60;
+  public static final int SOURCE_TEMPERATURE_MAXIMUM = 5000;
   public static final double SOURCE_TEMPERATURE_PRECISION = 0.1;
   public static final int SOURCE_TEMPERATURE_DEFAULT = 15;
 


### PR DESCRIPTION
Requested by Jess: The temperature range should be updated - it currently allows a range from -100 to 60 C but that should be a range from -100 to 5000 C