### PR TITLE
AER-418 ADMS diurnal variation IMAER, pt 1

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GML2Definitions.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GML2Definitions.java
@@ -81,8 +81,8 @@ public class GML2Definitions {
           String.valueOf(customType.getExpectedNumberOfValues()),
           String.valueOf(values.size()));
     }
-    final int valuesSum = values.stream().mapToInt(x -> x).sum();
-    final int expectedSum = CustomDiurnalVariation.AVERAGE_VALUE * customType.getExpectedNumberOfValues();
+    final int valuesSum = customType.sum(values);
+    final int expectedSum = CustomDiurnalVariation.AVERAGE_VALUE * customType.getExpectedTotalNumberOfValues();
     if (valuesSum != expectedSum) {
       throw new AeriusException(ImaerExceptionReason.CUSTOM_DIURNAL_VARIATION_INVALID_SUM,
           String.valueOf(expectedSum),

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GML2Definitions.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GML2Definitions.java
@@ -18,6 +18,7 @@ package nl.overheid.aerius.gml.base;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import nl.overheid.aerius.gml.base.characteristics.IsGmlCustomDiurnalVariation;
 import nl.overheid.aerius.shared.domain.v2.characteristics.CustomDiurnalVariation;
@@ -67,7 +68,7 @@ public class GML2Definitions {
     diurnalVariation.setGmlId(gmlCustomDiurnalVariation.getId());
     diurnalVariation.setLabel(gmlCustomDiurnalVariation.getLabel());
     diurnalVariation.setType(customType);
-    diurnalVariation.setValues(gmlCustomDiurnalVariation.getValues());
+    diurnalVariation.setValues(gmlCustomDiurnalVariation.getValues().stream().map(x -> (double) x).collect(Collectors.toList()));
     return diurnalVariation;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/GMLVersionWriterV40.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/togml/GMLVersionWriterV40.java
@@ -225,7 +225,7 @@ public class GMLVersionWriterV40 implements GMLVersionWriter {
     gmlCustomVariation.setId(customVariation.getGmlId());
     gmlCustomVariation.setLabel(customVariation.getLabel());
     gmlCustomVariation.setCustomType(customVariation.getType().name());
-    gmlCustomVariation.setValues(customVariation.getValues());
+    gmlCustomVariation.setValues(customVariation.getValues().stream().map(x -> (int) Math.round(x)).collect(Collectors.toList()));
     return gmlCustomVariation;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/GMLVersionWriterV50.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/GMLVersionWriterV50.java
@@ -225,7 +225,7 @@ public class GMLVersionWriterV50 implements GMLVersionWriter {
     gmlCustomVariation.setId(customVariation.getGmlId());
     gmlCustomVariation.setLabel(customVariation.getLabel());
     gmlCustomVariation.setCustomType(customVariation.getType().name());
-    gmlCustomVariation.setValues(customVariation.getValues());
+    gmlCustomVariation.setValues(customVariation.getValues().stream().map(x -> (int) Math.round(x)).collect(Collectors.toList()));
     return gmlCustomVariation;
   }
 

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateErrorsTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateErrorsTest.java
@@ -245,7 +245,7 @@ public class GMLValidateErrorsTest {
         ImaerExceptionReason.CUSTOM_DIURNAL_VARIATION_INVALID_SUM,
         e -> {
           assertEquals(2, e.getArgs().length, "Number of arguments");
-          assertEquals("2400", e.getArgs()[0], "Expected count");
+          assertEquals("240000", e.getArgs()[0], "Expected count");
           assertEquals("240", e.getArgs()[1], "Found count");
         });
   }

--- a/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/industry_with_custom_diurnal_variation.gml
+++ b/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/industry_with_custom_diurnal_variation.gml
@@ -84,30 +84,30 @@
                 <imaer:CustomDiurnalVariation gml:id="Custom_DV.1">
                     <imaer:label>Voorbeeld eigen spec</imaer:label>
                     <imaer:customType>DAY</imaer:customType>
-                    <imaer:value>70</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>130</imaer:value>
-                    <imaer:value>120</imaer:value>
-                    <imaer:value>120</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>60</imaer:value>
+                    <imaer:value>7000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>13000</imaer:value>
+                    <imaer:value>12000</imaer:value>
+                    <imaer:value>12000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>6000</imaer:value>
                 </imaer:CustomDiurnalVariation>
             </imaer:customDiurnalVariation>
         </imaer:Definitions>

--- a/source/imaer-gml/src/test/resources/gml/v5_0/roundtrip/industry_with_custom_diurnal_variation.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_0/roundtrip/industry_with_custom_diurnal_variation.gml
@@ -84,30 +84,30 @@
                 <imaer:CustomDiurnalVariation gml:id="Custom_DV.1">
                     <imaer:label>Voorbeeld eigen spec</imaer:label>
                     <imaer:customType>DAY</imaer:customType>
-                    <imaer:value>70</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>130</imaer:value>
-                    <imaer:value>120</imaer:value>
-                    <imaer:value>120</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>100</imaer:value>
-                    <imaer:value>60</imaer:value>
+                    <imaer:value>7000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>13000</imaer:value>
+                    <imaer:value>12000</imaer:value>
+                    <imaer:value>12000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>10000</imaer:value>
+                    <imaer:value>6000</imaer:value>
                 </imaer:CustomDiurnalVariation>
             </imaer:customDiurnalVariation>
         </imaer:Definitions>

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/CustomDiurnalVariation.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/CustomDiurnalVariation.java
@@ -23,7 +23,7 @@ public class CustomDiurnalVariation implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  public static final int AVERAGE_VALUE = 100;
+  public static final int AVERAGE_VALUE = 10000;
 
   private String gmlId;
   private String label;

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/CustomDiurnalVariation.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/CustomDiurnalVariation.java
@@ -28,7 +28,7 @@ public class CustomDiurnalVariation implements Serializable {
   private String gmlId;
   private String label;
   private CustomDiurnalVariationType type;
-  private List<Integer> values;
+  private List<Double> values;
 
   public String getGmlId() {
     return gmlId;
@@ -54,11 +54,11 @@ public class CustomDiurnalVariation implements Serializable {
     this.type = type;
   }
 
-  public List<Integer> getValues() {
+  public List<Double> getValues() {
     return values;
   }
 
-  public void setValues(final List<Integer> values) {
+  public void setValues(final List<Double> values) {
     this.values = values;
   }
 

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/OPSSourceCharacteristics.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/OPSSourceCharacteristics.java
@@ -82,8 +82,6 @@ public class OPSSourceCharacteristics extends SourceCharacteristics {
    */
   private DiurnalVariation diurnalVariation;
 
-  private String customDiurnalVariationId;
-
   /**
    * particleSizeDistribution - code for distribution of particle sizes (0 for gasses, > 0 for particulate matter)
    */
@@ -183,14 +181,6 @@ public class OPSSourceCharacteristics extends SourceCharacteristics {
 
   public void setDiurnalVariation(final DiurnalVariation diurnalVariation) {
     this.diurnalVariation = diurnalVariation;
-  }
-
-  public String getCustomDiurnalVariationId() {
-    return customDiurnalVariationId;
-  }
-
-  public void setCustomDiurnalVariationId(final String customDiurnalVariationId) {
-    this.customDiurnalVariationId = customDiurnalVariationId;
   }
 
   @JsonIgnore

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/SourceCharacteristics.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/SourceCharacteristics.java
@@ -34,9 +34,11 @@ public abstract class SourceCharacteristics implements Serializable {
   private static final long serialVersionUID = 2L;
 
   private String buildingId;
+  private String customDiurnalVariationId;
 
   public <E extends SourceCharacteristics> E copyTo(final E copy) {
     copy.setBuildingId(buildingId);
+    copy.setCustomDiurnalVariationId(customDiurnalVariationId);
     return copy;
   }
 
@@ -47,4 +49,13 @@ public abstract class SourceCharacteristics implements Serializable {
   public void setBuildingId(final String buildingId) {
     this.buildingId = buildingId;
   }
+
+  public String getCustomDiurnalVariationId() {
+    return customDiurnalVariationId;
+  }
+
+  public void setCustomDiurnalVariationId(final String customDiurnalVariationId) {
+    this.customDiurnalVariationId = customDiurnalVariationId;
+  }
+
 }

--- a/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/domain/JsonRoundTripTest.java
+++ b/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/domain/JsonRoundTripTest.java
@@ -70,6 +70,7 @@ class JsonRoundTripTest {
   @ParameterizedTest(name = "{0}")
   @ValueSource(strings = {
       "GenericEmissionSource.json",
+      "GenericADMSEmissionSource.json",
       "FarmLodgingEmissionSource.json",
       "FarmlandEmissionSource.json",
       "PlanEmissionSource.json",
@@ -79,6 +80,7 @@ class JsonRoundTripTest {
       "SRM1RoadEmissionSource_dynamicSegmentation.json",
       "SRM2RoadEmissionSource.json",
       "SRM2RoadEmissionSource_dynamicSegmentation.json",
+      "ADMSRoadEmissionSource.json",
       "InlandShippingEmissionSource.json",
       "MooringInlandShippingEmissionSource.json",
       "InlandMaritimeShippingEmissionSource.json",

--- a/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/domain/v2/characteristics/CustomDiurnalVariationTypeTest.java
+++ b/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/domain/v2/characteristics/CustomDiurnalVariationTypeTest.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.shared.domain.v2.characteristics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ *
+ */
+class CustomDiurnalVariationTypeTest {
+
+  @Test
+  void testSumDay() {
+    final CustomDiurnalVariationType testingType = CustomDiurnalVariationType.DAY;
+    final List<Integer> values = IntStream.range(100, 124).boxed().collect(Collectors.toList());
+    final int expected = IntStream.range(100, 124).sum();
+    assertEquals(expected, testingType.sum(values), "Should use normal summation");
+  }
+
+  @Test
+  void testSumThreeDay() {
+    final CustomDiurnalVariationType testingType = CustomDiurnalVariationType.THREE_DAY;
+    final List<Integer> values = IntStream.range(100, 172).boxed().collect(Collectors.toList());
+    final int expected = IntStream.range(100, 124).map(x -> x * 5).sum() + IntStream.range(124, 172).sum();
+    assertEquals(expected, testingType.sum(values), "Should use special case summation");
+  }
+
+}

--- a/source/imaer-shared/src/test/resources/json/ADMSRoadEmissionSource.json
+++ b/source/imaer-shared/src/test/resources/json/ADMSRoadEmissionSource.json
@@ -1,0 +1,81 @@
+{
+  "type" : "Feature",
+  "id" : "ES.2",
+  "geometry" : {
+    "type" : "LineString",
+    "coordinates" : [ [ 136558.0, 455251.0 ], [ 208413.0, 474162.0 ] ]
+  },
+  "properties" : {
+    "emissionSourceType" : "ADMS_ROAD",
+    "sectorId" : 3100,
+    "label" : "SomeRoadSource",
+    "characteristics" : {
+      "type" : "OPS",
+      "heatContent" : 0.28,
+      "emissionHeight" : 0.0
+    },
+    "emissions" : {
+      "NH3" : 1042.1482509823302,
+      "NOX" : 32843.505487667666,
+      "PM10" : 1353.463403522267,
+      "NO2" : 4972.615007349745
+    },
+    "subSources" : [ {
+      "vehicleType" : "STANDARD",
+      "timeUnit" : "DAY",
+      "maximumSpeed" : 100,
+      "strictEnforcement" : false,
+      "valuesPerVehicleTypes" : {
+        "LIGHT_TRAFFIC" : {
+          "vehiclesPerTimeUnit" : 980.0,
+          "stagnationFraction" : 0.2
+        },
+        "HEAVY_FREIGHT" : {
+          "vehiclesPerTimeUnit" : 400.0,
+          "stagnationFraction" : 0.0
+        }
+      }
+    }, {
+      "vehicleType" : "STANDARD",
+      "timeUnit" : "DAY",
+      "maximumSpeed" : 80,
+      "strictEnforcement" : false,
+      "valuesPerVehicleTypes" : {
+        "HEAVY_FREIGHT" : {
+          "vehiclesPerTimeUnit" : 200.0,
+          "stagnationFraction" : 0.0
+        }
+      }
+    }, {
+      "vehicleType" : "CUSTOM",
+      "timeUnit" : "YEAR",
+      "vehiclesPerTimeUnit" : 3000.0,
+      "description" : "Oude eenden",
+      "emissionFactors" : {
+        "NOX" : 4.2,
+        "NH3" : 0.2
+      }
+    }, {
+      "vehicleType" : "SPECIFIC",
+      "timeUnit" : "MONTH",
+      "vehiclesPerTimeUnit" : 500.0,
+      "vehicleCode" : "BA-B-E3"
+    } ],
+    "roadAreaCode" : "NL",
+    "roadTypeCode" : "FREEWAY",
+    "tunnelFactor" : 1.0,
+    "trafficDirection" : "A_TO_B",
+    "width" : 3.2,
+    "elevation" : 1.4,
+    "gradient" : 0.2,
+    "coverage" : 0.8,
+    "barrierLeft" : {
+      "barrierType" : "BRICK_WALL",
+      "width" : 3.2,
+      "maximumHeight" : 3.2,
+      "averageHeight" : 2.6,
+      "minimumHeight" : 1.7,
+      "porosity" : 0.7
+    }
+  }
+}

--- a/source/imaer-shared/src/test/resources/json/GenericADMSEmissionSource.json
+++ b/source/imaer-shared/src/test/resources/json/GenericADMSEmissionSource.json
@@ -1,0 +1,40 @@
+{
+  "type" : "Feature",
+  "id" : "1",
+  "geometry" : {
+    "type" : "Point",
+    "coordinates" : [ 130.12, -123.99 ]
+  },
+  "properties" : {
+    "emissionSourceType" : "GENERIC",
+    "sectorId" : 4600,
+    "label" : "Label 4600",
+    "characteristics" : {
+      "type" : "ADMS",
+      "buildingId" : "SomeBuildingId",
+      "customDiurnalVariationId" : "SomeDiurnalVariation",
+      "sourceType" : "POINT",
+      "buoyancyType" : "DENSITY",
+      "effluxType" : "MOMENTUM",
+      "height" : 5.0,
+      "diameter" : 2.0,
+      "width" : 4.0,
+      "temperature" : 273.13,
+      "density" : 83.4,
+      "verticalVelocity" : 23.1,
+      "volumetricFlowRate" : 8.1,
+      "specificHeatCapacity" : 9.2,
+      "percentNOxAsNO2" : 22.8,
+      "verticalDimension" : 2.9,
+      "elevationAngle" : 5.6,
+      "horizontalAngle" : 4.7,
+      "momentumFlux" : 94.03,
+      "buoyancyFlux" : 303.11,
+      "massFlux" : 92.1
+    },
+    "emissions" : {
+      "NH3" : 10.0,
+      "NOX" : 11.0
+    }
+  }
+}

--- a/source/imaer-shared/src/test/resources/json/GenericEmissionSource.json
+++ b/source/imaer-shared/src/test/resources/json/GenericEmissionSource.json
@@ -11,6 +11,8 @@
     "label" : "Label 4600",
     "characteristics" : {
       "type" : "OPS",
+      "buildingId" : "SomeBuildingId",
+      "customDiurnalVariationId" : "SomeDiurnalVariation",
       "heatContent" : 123.45,
       "emissionHeight" : 5.0
     },


### PR DESCRIPTION
Moved custom diurnal variation field to `SourceCharacteristics` so ADMS version can use it as well.
Introduced new type for custom diurnal variation for the 3-day profile.
Changed the average value as we expect it to 10000.
Changed the domain object to use doubles instead of integers (as discussed).

TODO in next PR: change IMAER to use doubles and incorporate custom diurnal variation in ADMS source characteristics and road objects.