### PR TITLE
Diurnal variation adjustments

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLScenarioHelper.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLScenarioHelper.java
@@ -62,6 +62,7 @@ public final class GMLScenarioHelper {
         .nslDispersionLines(situation.getNslDispersionLinesList())
         .nslCorrections(situation.getNslCorrections())
         .nslMeasures(situation.getNslMeasuresList())
+        .definitions(situation.getDefinitions())
         .build();
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/GML2ADMSRoad.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/GML2ADMSRoad.java
@@ -22,6 +22,8 @@ import java.util.function.Supplier;
 import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.IsGmlProperty;
 import nl.overheid.aerius.gml.base.util.DiurnalVariationUtil;
+import nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.adms.SourceType;
 import nl.overheid.aerius.shared.domain.v2.source.ADMSRoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.road.ADMSRoadSideBarrier;
 import nl.overheid.aerius.shared.exception.AeriusException;
@@ -77,9 +79,12 @@ public class GML2ADMSRoad<T extends IsGmlADMSRoad> extends GML2Road<T, ADMSRoadE
   }
 
   private void setDiurnalVariation(final T source, final ADMSRoadEmissionSource emissionSource) {
+    final ADMSSourceCharacteristics characteristics = new ADMSSourceCharacteristics();
+    characteristics.setSourceType(SourceType.ROAD);
     DiurnalVariationUtil.setDiurnalVariation(source.getDiurnalVariation(),
-        emissionSource::setStandardDiurnalVariationCode,
-        emissionSource::setCustomDiurnalVariationId);
+        characteristics::setStandardDiurnalVariationCode,
+        characteristics::setCustomDiurnalVariationId);
+    emissionSource.setCharacteristics(characteristics);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/Road2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/Road2GML.java
@@ -37,6 +37,7 @@ import nl.overheid.aerius.gml.v5_0.source.road.SpecificVehicle;
 import nl.overheid.aerius.gml.v5_0.source.road.StandardVehicle;
 import nl.overheid.aerius.gml.v5_0.source.road.VehiclesProperty;
 import nl.overheid.aerius.shared.domain.Substance;
+import nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.source.ADMSRoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.SRM1RoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.SRM2RoadEmissionSource;
@@ -198,10 +199,13 @@ class Road2GML extends SpecificSource2GML<nl.overheid.aerius.shared.domain.v2.so
   }
 
   private void handleDiurnalVariation(final ADMSRoadEmissionSource emissionSource, final ADMSRoad returnSource) {
-    final AbstractDiurnalVariation diurnalVariation = ToGMLUtil.determineDiurnalVariation(
-        emissionSource::getCustomDiurnalVariationId,
-        emissionSource::getStandardDiurnalVariationCode);
-    returnSource.setDiurnalVariation(diurnalVariation);
+    if (emissionSource.getCharacteristics() instanceof ADMSSourceCharacteristics) {
+      final ADMSSourceCharacteristics characteristics = (ADMSSourceCharacteristics) emissionSource.getCharacteristics();
+      final AbstractDiurnalVariation diurnalVariation = ToGMLUtil.determineDiurnalVariation(
+          characteristics::getCustomDiurnalVariationId,
+          characteristics::getStandardDiurnalVariationCode);
+      returnSource.setDiurnalVariation(diurnalVariation);
+    }
   }
 
   private ADMSRoadSideBarrierProperty toGMLRoadSideBarrier(final ADMSRoadSideBarrier barrier) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/Source2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/Source2GML.java
@@ -121,7 +121,10 @@ final class Source2GML implements EmissionSourceVisitor<nl.overheid.aerius.gml.v
         ((EmissionSourceCharacteristics) returnSource.getCharacteristics()).setDiurnalVariation(null);
       }
     }
-    if (source.getCharacteristics() instanceof ADMSSourceCharacteristics) {
+    // For ADMS, don't export characteristics for road.
+    // It does not really use any characteristic but the diurnal variation, and that's specified directly on the object.
+    if (source.getCharacteristics() instanceof ADMSSourceCharacteristics
+        && !(source instanceof ADMSRoadEmissionSource)) {
       returnSource.setCharacteristics(SourceCharacteristics2GML.toGML((ADMSSourceCharacteristics) source.getCharacteristics()));
     }
   }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/ADMSRoadEmissionSource.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/ADMSRoadEmissionSource.java
@@ -32,9 +32,6 @@ public class ADMSRoadEmissionSource extends RoadEmissionSource {
   private ADMSRoadSideBarrier barrierLeft;
   private ADMSRoadSideBarrier barrierRight;
 
-  private String standardDiurnalVariationCode;
-  private String customDiurnalVariationId;
-
   public double getWidth() {
     return width;
   }
@@ -81,22 +78,6 @@ public class ADMSRoadEmissionSource extends RoadEmissionSource {
 
   public void setBarrierRight(final ADMSRoadSideBarrier barrierRight) {
     this.barrierRight = barrierRight;
-  }
-
-  public String getStandardDiurnalVariationCode() {
-    return standardDiurnalVariationCode;
-  }
-
-  public void setStandardDiurnalVariationCode(final String standardDiurnalVariationCode) {
-    this.standardDiurnalVariationCode = standardDiurnalVariationCode;
-  }
-
-  public String getCustomDiurnalVariationId() {
-    return customDiurnalVariationId;
-  }
-
-  public void setCustomDiurnalVariationId(final String customDiurnalVariationId) {
-    this.customDiurnalVariationId = customDiurnalVariationId;
   }
 
   @Override


### PR DESCRIPTION
The definitions (and thus the custom diurnal variation profiles) weren't properly exported yet when using `GMLScenarioHelper`.

Also ensured that the main domain ADMS road object uses the properties for diurnal variation available in `ADMSSourceCharacteristics`.