### PR TITLE
Ensuring definitions get created for ScenarioSituation

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/ScenarioSituation.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/ScenarioSituation.java
@@ -43,7 +43,7 @@ public class ScenarioSituation implements Serializable {
   private String name;
   private SituationType type;
   private Double nettingFactor;
-  private Definitions definitions;
+  private Definitions definitions = new Definitions();
   private final FeatureCollection<EmissionSourceFeature> sources = new FeatureCollection<>();
   private final FeatureCollection<NSLDispersionLineFeature> nslDispersionLines = new FeatureCollection<>();
   private final FeatureCollection<NSLMeasureFeature> nslMeasures = new FeatureCollection<>();

--- a/source/imaer-shared/src/test/resources/json/ScenarioSituationMooringShipping.json
+++ b/source/imaer-shared/src/test/resources/json/ScenarioSituationMooringShipping.json
@@ -3,6 +3,7 @@
   "year" : 2030,
   "name" : "Voorbeeld situatie",
   "type" : "PROPOSED",
+  "definitions" : { },
   "buildings" : {
     "type" : "FeatureCollection",
     "crs" : {

--- a/source/imaer-shared/src/test/resources/json/ScenarioSituationNSL.json
+++ b/source/imaer-shared/src/test/resources/json/ScenarioSituationNSL.json
@@ -3,6 +3,7 @@
   "year" : 2030,
   "name" : "Voorbeeld situatie",
   "type" : "PROPOSED",
+  "definitions" : { },
   "buildings" : {
     "type" : "FeatureCollection",
     "crs" : {

--- a/source/imaer-shared/src/test/resources/json/ScenarioSituationSourcesOnly.json
+++ b/source/imaer-shared/src/test/resources/json/ScenarioSituationSourcesOnly.json
@@ -3,6 +3,7 @@
   "year" : 2030,
   "name" : "Voorbeeld situatie",
   "type" : "PROPOSED",
+  "definitions" : { },
   "buildings" : {
     "type" : "FeatureCollection",
     "crs" : {


### PR DESCRIPTION
This should prevent the need for nullpointer checks (though the object could still be set to null explicitly somewhere, or be absent when deserializing json).