### PR TITLE
Update version to 5.0.0-2-SNAPSHOT

### DIFF
--- a/source/imaer-gml/pom.xml
+++ b/source/imaer-gml/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>imaer-parent</artifactId>
-    <version>5.0.0-1</version>
+    <version>5.0.0-2-SNAPSHOT</version>
   </parent>
 
   <artifactId>imaer-gml</artifactId>

--- a/source/imaer-shared/pom.xml
+++ b/source/imaer-shared/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>imaer-parent</artifactId>
-    <version>5.0.0-1</version>
+    <version>5.0.0-2-SNAPSHOT</version>
   </parent>
 
   <artifactId>imaer-shared</artifactId>

--- a/source/imaer-sonar-report/pom.xml
+++ b/source/imaer-sonar-report/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>nl.aerius</groupId>
         <artifactId>imaer-parent</artifactId>
-        <version>5.0.0-1</version>
+        <version>5.0.0-2-SNAPSHOT</version>
       </parent>
 
     <artifactId>imaer-sonar-report</artifactId>

--- a/source/imaer-util/pom.xml
+++ b/source/imaer-util/pom.xml
@@ -22,7 +22,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>imaer-parent</artifactId>
-    <version>5.0.0-1</version>
+    <version>5.0.0-2-SNAPSHOT</version>
   </parent>
 
   <artifactId>imaer-util</artifactId>

--- a/source/imaer-xsd-server-standalone/pom.xml
+++ b/source/imaer-xsd-server-standalone/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>imaer-parent</artifactId>
-    <version>5.0.0-1</version>
+    <version>5.0.0-2-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/source/imaer-xsd-server/pom.xml
+++ b/source/imaer-xsd-server/pom.xml
@@ -20,7 +20,7 @@
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>imaer-parent</artifactId>
-    <version>5.0.0-1</version>
+    <version>5.0.0-2-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/source/pom.xml
+++ b/source/pom.xml
@@ -21,7 +21,7 @@
 
   <groupId>nl.aerius</groupId>
   <artifactId>imaer-parent</artifactId>
-  <version>5.0.0-1</version>
+  <version>5.0.0-2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>IMAER-java</name>


### PR DESCRIPTION
In preparation of future development.
This version does assume that there won't be actual IMAER changes. If that is the case, the new version might well be something like 5.1 or 5.0.1, as IMAER-java version is tightly connected to the actual IMAER version.