### PR TITLE
AER-333 Throw correct exception when polygon is not closed

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/geo/Geo2GeometryUtil.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/geo/Geo2GeometryUtil.java
@@ -98,7 +98,13 @@ public final class Geo2GeometryUtil {
     final JAXBElement<LinearRingType> exteriorRing = (JAXBElement<LinearRingType>) polygonType.getExterior().getAbstractRing();
     final List<Double> values = exteriorRing.getValue().getPosList().getValue();
     final Coordinate[] shellCoordinates = lineString2Coordinates(values);
-    final LinearRing shell = geometryFactory.createLinearRing(shellCoordinates);
+    LinearRing shell;
+    try {
+      shell = geometryFactory.createLinearRing(shellCoordinates);
+      // can occur when the polygon is not closed
+    } catch (final IllegalArgumentException e) {
+      throw new AeriusException(ImaerExceptionReason.GML_GEOMETRY_INVALID);
+    }
 
     final List<LinearRing> holes = new ArrayList<>();
     final List<Coordinate[]> holesCoordinates = new ArrayList<>();

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateErrorsTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateErrorsTest.java
@@ -140,7 +140,7 @@ public class GMLValidateErrorsTest {
 
   @Test
   public void testGMLGeometryInvalid_5215() throws IOException {
-    assertResult("fout_5215_invalid_geometry", "GML Geometry invalid", ImaerExceptionReason.GEOMETRY_INVALID, IllegalArgumentException.class);
+    assertResult("fout_5215_invalid_geometry", "GML Geometry invalid", ImaerExceptionReason.GML_GEOMETRY_INVALID);
   }
 
   @Test

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/base/Geo2GeometryUtilTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/base/Geo2GeometryUtilTest.java
@@ -24,15 +24,23 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.math.BigInteger;
 import java.util.Arrays;
 
+import javax.xml.bind.JAXBElement;
+
 import org.junit.jupiter.api.Test;
 
+import net.opengis.gml.v_3_2_1.AbstractRingPropertyType;
+import net.opengis.gml.v_3_2_1.DirectPositionListType;
 import net.opengis.gml.v_3_2_1.DirectPositionType;
+import net.opengis.gml.v_3_2_1.LinearRingType;
+import net.opengis.gml.v_3_2_1.ObjectFactory;
 import net.opengis.gml.v_3_2_1.PointType;
+import net.opengis.gml.v_3_2_1.PolygonType;
 
 import nl.overheid.aerius.geo.shared.RDNew;
 import nl.overheid.aerius.gml.base.geo.Geo2GeometryUtil;
 import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.domain.v2.geojson.Point;
+import nl.overheid.aerius.shared.domain.v2.geojson.Polygon;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 
@@ -48,6 +56,41 @@ public class Geo2GeometryUtilTest {
     final PointType pointType = createPoint();
     final Geometry geometry = geo2GeometryUtil.fromXMLPoint(pointType);
     assertTrue(geometry instanceof Point, "Not a point");
+  }
+
+  @Test
+  public void testPolygon() throws AeriusException {
+    final DirectPositionListType coordList = new DirectPositionListType();
+
+    // this polygon is closed
+    coordList.getValue().add(100.0); // X
+    coordList.getValue().add(20.0); // Y
+    coordList.getValue().add(400.0);
+    coordList.getValue().add(50.0);
+    coordList.getValue().add(600.0);
+    coordList.getValue().add(70.0);
+    coordList.getValue().add(100.0);
+    coordList.getValue().add(20.0);
+
+    final PolygonType polygonType = createPolygon(coordList);
+    final Geometry geometry = geo2GeometryUtil.fromXMLPolygon(polygonType);
+    assertTrue(geometry instanceof Polygon, "Not a polygon");
+  }
+
+  @Test
+  public void testPolygonNotClosed() {
+    final DirectPositionListType coordList = new DirectPositionListType();
+
+    // this polygon is not closed
+    coordList.getValue().add(100.0); // X
+    coordList.getValue().add(20.0); // Y
+    coordList.getValue().add(400.0);
+    coordList.getValue().add(50.0);
+    coordList.getValue().add(600.0);
+    coordList.getValue().add(70.0);
+
+    final PolygonType polygonType = createPolygon(coordList);
+    assertThrows(AeriusException.class, () -> geo2GeometryUtil.fromXMLPolygon(polygonType));
   }
 
   @Test
@@ -78,5 +121,18 @@ public class Geo2GeometryUtilTest {
     value.setValue(Arrays.asList(new Double[] {1.0, 1.0}));
     pointType.setPos(value);
     return pointType;
+  }
+
+  private PolygonType createPolygon(final DirectPositionListType directPositionListType) {
+    final ObjectFactory factory = new ObjectFactory();
+
+    final PolygonType polygonType = new PolygonType();
+    final AbstractRingPropertyType abstractRingPropertyType = factory.createAbstractRingPropertyType();
+    final JAXBElement<LinearRingType> linearRingType = factory.createLinearRing(factory.createLinearRingType());
+
+    linearRingType.getValue().setPosList(directPositionListType);
+    abstractRingPropertyType.setAbstractRing(linearRingType);
+    polygonType.setExterior(abstractRingPropertyType);
+    return polygonType;
   }
 }

--- a/source/imaer-gml/src/test/resources/gml/latest/validate/errors/fout_666_unknown_error.gml
+++ b/source/imaer-gml/src/test/resources/gml/latest/validate/errors/fout_666_unknown_error.gml
@@ -24,15 +24,12 @@
             </imaer:emissionSourceCharacteristics>
             <imaer:geometry>
                 <imaer:EmissionSourceGeometry>
-                    <imaer:GM_Surface>
-                        <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="ES.1.SURFACE">
-                            <gml:exterior>
-								<gml:LinearRing> <!-- test with closing coordinate missing (e666) -->
-									<gml:posList>101053.18000000002 449287.4400000002 105031.41999999997 449179.92 107181.81999999998 445094.1599999998 104923.89999999998 441115.91999999987 101160.69999999998 441223.44000000006 98902.78000000001 445094.16 </gml:posList>
-								</gml:LinearRing>
-                            </gml:exterior>
-                        </gml:Polygon>
-                    </imaer:GM_Surface>
+                    <imaer:GM_Curve>
+                        <gml:LineString srsName="urn:ogc:def:crs:EPSG::28992" gml:id="ES.1.CURVE">
+                            <!-- test with invalid number of coordinates (e666) -->
+                            <gml:posList>449287.4400000002 105031.41999999997</gml:posList>
+                        </gml:LineString>
+                    </imaer:GM_Curve>
                 </imaer:EmissionSourceGeometry>
             </imaer:geometry>
             <imaer:emission>


### PR DESCRIPTION
When a polygon is not closed, an `IllegalArgumentException` is thrown by JTS which is converted to a AeriusException with reason Internal Error. This change catches the IllegalArgumentException and converts it to a AeriusException with reason "The GML contains an invalid geometry", and includes the offending emission source ID.