### PR TITLE
AER-619 - Add MEDIUM_COMBUSTION_PLANT emission source type

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/EmissionSourceType.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/EmissionSourceType.java
@@ -33,6 +33,10 @@ public enum EmissionSourceType {
    */
   GENERIC(Names.GENERIC),
   /**
+   * Medium combustion plant values.
+   */
+  MEDIUM_COMBUSTION_PLANT(Names.MEDIUM_COMBUSTION_PLANT),
+  /**
    * Mobile off road emission values.
    */
   OFFROAD_MOBILE(Names.OFFROAD_MOBILE),
@@ -77,6 +81,7 @@ public enum EmissionSourceType {
     public static final String FARM_LODGE = "FARM_LODGE";
     public static final String FARMLAND = "FARMLAND";
     public static final String GENERIC = "GENERIC";
+    public static final String MEDIUM_COMBUSTION_PLANT = "MEDIUM_COMBUSTION_PLANT";
     public static final String OFFROAD_MOBILE = "OFFROAD_MOBILE";
     public static final String PLAN = "PLAN";
     public static final String SRM1_ROAD = "SRM1_ROAD";


### PR DESCRIPTION
AER-619 implements a preview component for "Medium Combustion Plants", this emission source type, which may be changed in some way later, adds a source type for it.