### PR TITLE
AER-690 Properly handling subpoints on import

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/result/GML2Result.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/result/GML2Result.java
@@ -34,6 +34,7 @@ import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
 import nl.overheid.aerius.shared.domain.v2.point.CustomCalculationPoint;
 import nl.overheid.aerius.shared.domain.v2.point.NSLCalculationPoint;
 import nl.overheid.aerius.shared.domain.v2.point.ReceptorPoint;
+import nl.overheid.aerius.shared.domain.v2.point.SubPoint;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 import nl.overheid.aerius.shared.geometry.ReceptorUtil;
@@ -93,13 +94,11 @@ public class GML2Result {
   private CalculationPoint determineSpecificType(final IsGmlCalculationPoint calculationPoint) throws AeriusException {
     final CalculationPoint returnPoint;
     if (calculationPoint instanceof IsGmlReceptorPoint) {
-      final ReceptorPoint receptor = new ReceptorPoint();
-      fillReceptorPoint((IsGmlReceptorPoint) calculationPoint, receptor);
-      returnPoint = receptor;
+      returnPoint = createReceptorPoint((IsGmlReceptorPoint) calculationPoint);
+    } else if (calculationPoint instanceof IsGmlSubPoint) {
+      returnPoint = createSubPoint((IsGmlSubPoint) calculationPoint);
     } else if (calculationPoint instanceof IsGmlNSLCalculationPoint) {
-      final NSLCalculationPoint nslPoint = new NSLCalculationPoint();
-      fillNSLCalculationPoint((IsGmlNSLCalculationPoint) calculationPoint, nslPoint);
-      returnPoint = nslPoint;
+      returnPoint = createNSLCalculationPoint((IsGmlNSLCalculationPoint) calculationPoint);
     } else if (calculationPoint instanceof IsGmlCustomCalculationPoint) {
       returnPoint = new CustomCalculationPoint();
     } else {
@@ -147,13 +146,25 @@ public class GML2Result {
     target.setJurisdictionId(origin.getJurisdictionId());
   }
 
-  private void fillReceptorPoint(final IsGmlReceptorPoint origin, final ReceptorPoint target) {
+  private ReceptorPoint createReceptorPoint(final IsGmlReceptorPoint origin) {
+    final ReceptorPoint target = new ReceptorPoint();
     target.setReceptorId(origin.getReceptorPointId());
+    return target;
   }
 
-  private void fillNSLCalculationPoint(final IsGmlNSLCalculationPoint origin, final NSLCalculationPoint target) {
+  private SubPoint createSubPoint(final IsGmlSubPoint origin) {
+    final SubPoint target = new SubPoint();
+    target.setSubPointId(origin.getSubPointId());
+    target.setReceptorId(origin.getReceptorPointId());
+    target.setLevel(origin.getLevel());
+    return target;
+  }
+
+  private NSLCalculationPoint createNSLCalculationPoint(final IsGmlNSLCalculationPoint origin) {
+    final NSLCalculationPoint target = new NSLCalculationPoint();
     target.setRejectionGrounds(origin.getRejectionGrounds());
     target.setMonitorSubstance(origin.getMonitorSubstance());
+    return target;
   }
 
   /**

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/result/IsGmlSubPoint.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/result/IsGmlSubPoint.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.gml.base.result;
+
+public interface IsGmlSubPoint extends IsGmlCalculationPoint {
+
+  int getSubPointId();
+
+  int getReceptorPointId();
+
+  int getLevel();
+
+}

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/result/SubPoint.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/result/SubPoint.java
@@ -20,18 +20,20 @@ import javax.xml.bind.annotation.XmlAttribute;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
+import nl.overheid.aerius.gml.base.result.IsGmlSubPoint;
 import nl.overheid.aerius.gml.v5_0.base.CalculatorSchema;
 
 /**
  *
  */
 @XmlType(name = "SubPointType", namespace = CalculatorSchema.NAMESPACE)
-public class SubPoint extends AbstractCalculationPoint {
+public class SubPoint extends AbstractCalculationPoint implements IsGmlSubPoint {
 
   private int subPointId;
   private int receptorPointId;
   private int level;
 
+  @Override
   @XmlAttribute
   public int getSubPointId() {
     return subPointId;
@@ -41,6 +43,7 @@ public class SubPoint extends AbstractCalculationPoint {
     this.subPointId = subPointId;
   }
 
+  @Override
   @XmlAttribute
   public int getReceptorPointId() {
     return receptorPointId;
@@ -50,6 +53,7 @@ public class SubPoint extends AbstractCalculationPoint {
     this.receptorPointId = receptorPointId;
   }
 
+  @Override
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
   public int getLevel() {
     return level;


### PR DESCRIPTION
As it was, an error would occur when reading a GML containing SubPoints.
Updated GMLReaderTest so it should pick up on errors in the reader during tests from now on.