### PR TITLE
AER-709 Update BNGrid bounds

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/geo/shared/BNGrid.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/geo/shared/BNGrid.java
@@ -30,17 +30,11 @@ public class BNGrid extends EPSG {
 
   private static final long serialVersionUID = 1L;
 
-  private static final double[] RESOLUTIONS = {2500, 1000, 500, 200, 100, 50, 25, 10, 5, 2, 1, 0.5, 0.25};
-  private static final float MAX_RESOLUTION = 0;
   private static final int ZOOM_LEVEL = 15;
-  private static final String UNIT = "km";
-  /**
-   * Official boundaries of the BN grid extent of the map.
-   */
-  private static final BBox BOUNDS = new BBox(1393.0196, 13494.9764, 671196.3657, 1230275.0454);
+  private static final BBox BOUNDS = new BBox(-4000, 4000, 660000, 1222000);
   private static final Point CENTER = new Point(308188.48, 608846.16);
 
   BNGrid() {
-    super(SRID, BOUNDS, CENTER, RESOLUTIONS, MAX_RESOLUTION, UNIT, ZOOM_LEVEL);
+    super(SRID, BOUNDS, CENTER, ZOOM_LEVEL);
   }
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/geo/shared/EPSG.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/geo/shared/EPSG.java
@@ -31,9 +31,6 @@ public abstract class EPSG implements Serializable {
 
   private int srid;
   private BBox bounds;
-  private double[] resolutions;
-  private float maxResolution;
-  private String unit;
   private int zoomLevel;
 
   private Point center;
@@ -43,19 +40,12 @@ public abstract class EPSG implements Serializable {
    * @param srid The SRID to set.
    * @param bounds The bounds to set.
    * @param center The center of the map
-   * @param resolutions The resolutions to set.
-   * @param maxResolution The max resolution to set.
-   * @param unit The unit to set.
    * @param zoomLevel The zoomLevel to set.
    */
-  public EPSG(final int srid, final BBox bounds, final Point center, final double[] resolutions, final float maxResolution, final String unit,
-      final int zoomLevel) {
+  public EPSG(final int srid, final BBox bounds, final Point center, final int zoomLevel) {
     this.srid = srid;
     this.bounds = bounds;
     this.center = center;
-    this.resolutions = resolutions;
-    this.maxResolution = maxResolution;
-    this.unit = unit;
     this.zoomLevel = zoomLevel;
   }
 
@@ -73,18 +63,6 @@ public abstract class EPSG implements Serializable {
 
   public Point getCenter() {
     return center;
-  }
-
-  public double[] getResolutions() {
-    return resolutions;
-  }
-
-  public float getMaxResolution() {
-    return maxResolution;
-  }
-
-  public String getUnit() {
-    return unit;
   }
 
   public int getZoomLevel() {

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/geo/shared/RDNew.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/geo/shared/RDNew.java
@@ -29,15 +29,11 @@ public final class RDNew extends EPSG {
 
   private static final long serialVersionUID = 1L;
 
-  private static final double[] RESOLUTIONS = {3440.64, 1720.32, 860.16, 430.08, 215.04, 107.52, 53.76, 26.88, 13.44, 6.72, 3.36, 1.68, 0.84, 0.42,
-      0.21,};
-  private static final float MAX_RESOLUTION = 0;
   private static final int ZOOM_LEVEL = 14;
-  private static final String UNIT = "km";
   private static final BBox BOUNDS = new BBox(-285401.920, 22598.080, 595401.920, 903401.920);
   private static final Point CENTER = new Point(155000, 463000);
 
   RDNew() {
-    super(SRID, BOUNDS, CENTER, RESOLUTIONS, MAX_RESOLUTION, UNIT, ZOOM_LEVEL);
+    super(SRID, BOUNDS, CENTER, ZOOM_LEVEL);
   }
 }


### PR DESCRIPTION
Apparently the BNGrid bounds specified here do not contain the entire of Northern Ireland. Updated the bounds to match the calculation boundary. The bounds are only used in OpenLayers. I also removed some settings that we no longer used in AERIUS (and not sure if those are still the correct values...)