### PR TITLE
Add option to get return default sector when importing GML when sector code unknown

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/AbstractGML2Source.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/AbstractGML2Source.java
@@ -20,7 +20,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import nl.overheid.aerius.gml.base.GMLLegacyCodeConverter.GMLLegacyCodeType;
 import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.base.geo.GML2Geometry;
 import nl.overheid.aerius.gml.base.source.IsGmlEmissionSource;
@@ -119,7 +118,8 @@ public abstract class AbstractGML2Source<T extends IsGmlEmissionSource, S extend
     returnSource.setLabel(source.getLabel());
     returnSource.setDescription(source.getDescription());
     returnSource.setJurisdictionId(source.getJurisdictionId());
-    final int sectorId = Integer.parseInt(conversionData.getCode(GMLLegacyCodeType.SECTOR, String.valueOf(source.getSectorId()), source.getLabel()));
+    final int sectorId = conversionData.getSectorId(source.getSectorId(), source.getLabel());
+
     returnSource.setSectorId(sectorId);
     if (!(returnSource instanceof InlandShippingEmissionSource
         || returnSource instanceof MooringInlandShippingEmissionSource

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLHelper.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLHelper.java
@@ -27,7 +27,7 @@ import nl.overheid.aerius.validation.ValidationHelper;
 /**
  * Helper interface for retrieving data or operations that were done in the database.
  */
-public interface GMLHelper extends GMLInlandShippingSupplier, GMLLegacyCodesSupplier, GMLCharacteristicsSupplier {
+public interface GMLHelper extends GMLInlandShippingSupplier, GMLLegacyCodesSupplier, GMLCharacteristicsSupplier, GMLSectorSupplier {
 
   /**
    * Recalculates the emissions on all given emission sources for the given emission keys.

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLSectorSupplier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLSectorSupplier.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.gml.base;
+
+import nl.overheid.aerius.shared.domain.sector.Sector;
+
+/**
+ * Helper class to check if sector is valid or to get the default sector.
+ */
+public interface GMLSectorSupplier {
+
+  /**
+   * @return Returns true if the give sector Id is a unknown sector id
+   */
+  default boolean isValidSectorId(final Integer sectorId) {
+    return true;
+  }
+
+  /**
+   * @return Returns the default sector that will can used when an unknown sector is given
+   */
+  default Sector getDefaultSector() {
+    return Sector.SECTOR_DEFAULT;
+  }
+}

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v31/GML2OffRoad.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v31/GML2OffRoad.java
@@ -95,8 +95,7 @@ public class GML2OffRoad<T extends IsGmlOffRoadMobileEmissionSource> extends Abs
   private void convert(final T source, final IsGmlCustomOffRoadMobileSource customMobileSource, final int index) throws AeriusException {
     final GenericEmissionSource newSource = new GenericEmissionSource();
     newSource.setGmlId(source.getId() + "_" + index);
-    final int sectorId = Integer.parseInt(
-        getConversionData().getCode(GMLLegacyCodeType.SECTOR, String.valueOf(source.getSectorId()), source.getLabel()));
+    final int sectorId = getConversionData().getSectorId(source.getSectorId(), source.getLabel());
     newSource.setSectorId(sectorId);
     newSource.setLabel(constructLabel(source.getLabel(), customMobileSource.getDescription()));
     newSource.setCharacteristics(gml2SourceCharacteristics.fromGML(customMobileSource.getCharacteristics(),

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v40/GML2OffRoad.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v40/GML2OffRoad.java
@@ -21,7 +21,6 @@ import org.slf4j.LoggerFactory;
 
 import nl.overheid.aerius.gml.base.AbstractGML2Specific;
 import nl.overheid.aerius.gml.base.GMLConversionData;
-import nl.overheid.aerius.gml.base.GMLLegacyCodeConverter.GMLLegacyCodeType;
 import nl.overheid.aerius.gml.base.IsGmlProperty;
 import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.base.geo.GML2Geometry;
@@ -89,8 +88,7 @@ public class GML2OffRoad<T extends IsGmlOffRoadMobileEmissionSource> extends Abs
   private void convert(final T source, final IsGmlCustomOffRoadMobileSource customMobileSource, final int index) throws AeriusException {
     final GenericEmissionSource newSource = new GenericEmissionSource();
     newSource.setGmlId(source.getId() + "_" + index);
-    final int sectorId = Integer.parseInt(
-        getConversionData().getCode(GMLLegacyCodeType.SECTOR, String.valueOf(source.getSectorId()), source.getLabel()));
+    final int sectorId = getConversionData().getSectorId(source.getSectorId(), source.getLabel());
     newSource.setSectorId(sectorId);
     newSource.setLabel(constructLabel(source.getLabel(), customMobileSource.getDescription()));
     newSource.setCharacteristics(gml2SourceCharacteristics.fromGML(customMobileSource.getCharacteristics(),

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
@@ -47,6 +47,8 @@ import nl.overheid.aerius.importer.ImportOption;
 import nl.overheid.aerius.shared.domain.Substance;
 import nl.overheid.aerius.shared.domain.geo.ReceptorGridSettings;
 import nl.overheid.aerius.shared.domain.scenario.SituationType;
+import nl.overheid.aerius.shared.domain.sector.Sector;
+import nl.overheid.aerius.shared.domain.sector.SectorGroup;
 import nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.characteristics.CharacteristicsType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
@@ -210,6 +212,8 @@ public final class AssertGML {
     when(gmlHelper.getLegacyPlanConversions()).thenReturn(TestValidationAndEmissionHelper.legacyPlanConversions());
     when(gmlHelper.determineDefaultCharacteristicsBySectorId(anyInt())).thenAnswer((i) -> determineDefaultCharacteristics());
     when(gmlHelper.getValidationHelper()).thenReturn(valiationAndEmissionHelper);
+    when(gmlHelper.getDefaultSector()).thenReturn(new Sector(GMLTestDomain.DEFAULT_SECTOR_ID, SectorGroup.INDUSTRY, ""));
+    when(gmlHelper.isValidSectorId(anyInt())).thenReturn(true);
     return gmlHelper;
   }
 

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/test/GMLTestDomain.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/test/GMLTestDomain.java
@@ -29,7 +29,6 @@ import nl.overheid.aerius.shared.domain.geo.HexagonZoomLevel;
 import nl.overheid.aerius.shared.domain.geo.ReceptorGridSettings;
 import nl.overheid.aerius.shared.domain.ops.DiurnalVariation;
 import nl.overheid.aerius.shared.domain.result.EmissionResultKey;
-import nl.overheid.aerius.shared.domain.sector.Sector;
 import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
@@ -73,6 +72,11 @@ public class GMLTestDomain {
 
   public static final ReferenceGenerator TEST_REFERENCE_GENERATOR = r -> Optional.empty();
 
+  /**
+   * Sector default is the sector in case no specific sector is specified, because it's unknown. Therefore the sector industry generic can be used.
+   */
+  public static final int DEFAULT_SECTOR_ID = 1800;
+
   public static GenericEmissionSource getGenericEmissionSource() {
     return getGenericEmissionSource(new GenericEmissionSource());
   }
@@ -88,7 +92,7 @@ public class GMLTestDomain {
     feature.setId(String.valueOf(id));
     feature.setGeometry(geometry);
     source.setLabel(label);
-    source.setSectorId(Sector.SECTOR_DEFAULT.getSectorId());
+    source.setSectorId(DEFAULT_SECTOR_ID);
     //default characteristics for this sector.
     source.setCharacteristics(getDefaultCharacteristics());
     feature.setProperties(source);

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/OPSSourceCharacteristics.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/OPSSourceCharacteristics.java
@@ -192,21 +192,26 @@ public class OPSSourceCharacteristics extends SourceCharacteristics {
     this.particleSizeDistribution = particleSizeDistribution;
   }
 
-  public <E extends OPSSourceCharacteristics> E copyTo(final E copy) {
+  @Override
+  public <E extends SourceCharacteristics> E copyTo(final E copy) {
     super.copyTo(copy);
-    copy.setHeatContentType(heatContentType);
-    copy.setHeatContent(heatContent);
-    copy.setEmissionHeight(emissionHeight);
-    copy.setDiameter(diameter);
-    copy.setSpread(spread);
-    copy.setDiurnalVariation(diurnalVariation);
-    copy.setParticleSizeDistribution(particleSizeDistribution);
-    copy.setHeatContentType(getHeatContentType());
-    copy.setEmissionTemperature(emissionTemperature);
-    copy.setOutflowDiameter(outflowDiameter);
-    copy.setOutflowDirection(outflowDirection);
-    copy.setOutflowVelocity(outflowVelocity);
-    copy.setOutflowVelocityType(outflowVelocityType);
+    if (copy instanceof OPSSourceCharacteristics) {
+      final OPSSourceCharacteristics copyOPS = (OPSSourceCharacteristics) copy;
+
+      copyOPS.setHeatContentType(heatContentType);
+      copyOPS.setHeatContent(heatContent);
+      copyOPS.setEmissionHeight(emissionHeight);
+      copyOPS.setDiameter(diameter);
+      copyOPS.setSpread(spread);
+      copyOPS.setDiurnalVariation(diurnalVariation);
+      copyOPS.setParticleSizeDistribution(particleSizeDistribution);
+      copyOPS.setHeatContentType(getHeatContentType());
+      copyOPS.setEmissionTemperature(emissionTemperature);
+      copyOPS.setOutflowDiameter(outflowDiameter);
+      copyOPS.setOutflowDirection(outflowDirection);
+      copyOPS.setOutflowVelocity(outflowVelocity);
+      copyOPS.setOutflowVelocityType(outflowVelocityType);
+    }
     return copy;
   }
 


### PR DESCRIPTION
Default implementation of isValidSector is true to be compatible with current usages of this library.