### PR TITLE
AER-361 Deprecated massflux property in IMAER-java

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2ADMSSourceCharacteristics.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2ADMSSourceCharacteristics.java
@@ -103,7 +103,6 @@ public class GML2ADMSSourceCharacteristics
       returnCharacteristics.setVolumetricFlowRate(gmlADMSCharacteristics.getVolumetricFlowRate());
       break;
     case MASS:
-      returnCharacteristics.setMassFlux(gmlADMSCharacteristics.getMassFlux());
       break;
     case MOMENTUM:
       // Not (yet) supported

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/IsGmlADMSSourceCharacteristics.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/IsGmlADMSSourceCharacteristics.java
@@ -44,6 +44,5 @@ public interface IsGmlADMSSourceCharacteristics extends IsGmlSourceCharacteristi
   EffluxType getEffluxType();
   Double getVerticalVelocity();
   Double getVolumetricFlowRate();
-  Double getMassFlux();
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/source/characteristics/ADMSSourceCharacteristics.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/source/characteristics/ADMSSourceCharacteristics.java
@@ -33,7 +33,7 @@ import nl.overheid.aerius.shared.domain.v2.characteristics.adms.SourceType;
 @XmlRootElement(name = "ADMSSourceCharacteristics", namespace = CalculatorSchema.NAMESPACE)
 @XmlType(name = "ADMSSourceCharacteristicsType", namespace = CalculatorSchema.NAMESPACE, propOrder = {"height", "specificHeatCapacity",
     "sourceType", "diameter", "elevationAngle", "horizontalAngle", "width", "verticalDimension", "buoyancyType", "density",
-    "temperature", "effluxType", "verticalVelocity", "volumetricFlowRate", "massFlux", "diurnalVariationProperty"})
+    "temperature", "effluxType", "verticalVelocity", "volumetricFlowRate", "diurnalVariationProperty"})
 public class ADMSSourceCharacteristics extends AbstractSourceCharacteristics implements IsGmlADMSSourceCharacteristics {
 
   private double height;
@@ -50,7 +50,6 @@ public class ADMSSourceCharacteristics extends AbstractSourceCharacteristics imp
   private EffluxType effluxType;
   private Double verticalVelocity;
   private Double volumetricFlowRate;
-  private Double massFlux;
   private AbstractDiurnalVariation diurnalVariation;
 
   @Override
@@ -191,16 +190,6 @@ public class ADMSSourceCharacteristics extends AbstractSourceCharacteristics imp
 
   public void setVolumetricFlowRate(final Double volumetricFlowRate) {
     this.volumetricFlowRate = volumetricFlowRate;
-  }
-
-  @Override
-  @XmlElement(namespace = CalculatorSchema.NAMESPACE)
-  public Double getMassFlux() {
-    return massFlux;
-  }
-
-  public void setMassFlux(final Double massFlux) {
-    this.massFlux = massFlux;
   }
 
   @XmlElement(name = "diurnalVariation", namespace = CalculatorSchema.NAMESPACE)

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/SourceCharacteristics2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/SourceCharacteristics2GML.java
@@ -148,7 +148,6 @@ final class SourceCharacteristics2GML {
       returnCharacteristics.setVolumetricFlowRate(characteristics.getVolumetricFlowRate());
       break;
     case MASS:
-      returnCharacteristics.setMassFlux(characteristics.getMassFlux());
       break;
     case MOMENTUM:
       // Not (yet) supported

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/ADMSSourceCharacteristics.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/ADMSSourceCharacteristics.java
@@ -197,10 +197,12 @@ public class ADMSSourceCharacteristics extends SourceCharacteristics {
     this.buoyancyFlux = buoyancyFlux;
   }
 
+  @Deprecated
   public double getMassFlux() {
     return massFlux;
   }
 
+  @Deprecated
   public void setMassFlux(final double massFlux) {
     this.massFlux = massFlux;
   }


### PR DESCRIPTION
Never added this property to actual IMAER, so any GML that would be exported with the massFlux property would be invalid w.r.t. the XSD. As we're not supporting the mass efflux type any more, we might as well get rid of the property while we're still in 5.0 territory.

The field in the domain object ADMSSourceCharacteristics itself hasn't been removed but deprecated, so this shouldn't pose any compatibility issues.