### PR TITLE
AER-795 serialize the list of NSL corrections so they can be included in the calculation.

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/ScenarioSituation.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/ScenarioSituation.java
@@ -128,7 +128,6 @@ public class ScenarioSituation implements Serializable {
     return nslMeasures.getFeatures();
   }
 
-  @JsonIgnore
   public List<NSLCorrection> getNslCorrections() {
     return nslCorrections;
   }

--- a/source/imaer-shared/src/test/resources/json/ScenarioSituationNSL.json
+++ b/source/imaer-shared/src/test/resources/json/ScenarioSituationNSL.json
@@ -4,6 +4,15 @@
   "name" : "Voorbeeld situatie",
   "type" : "PROPOSED",
   "definitions" : { },
+  "nslCorrections" : [ {
+    "label" : "Leiden_WT",
+    "jurisdictionId" : 546,
+    "calculationPointGmlId" : "CP.15851291",
+    "substance" : "PM10",
+    "resultType" : "CONCENTRATION",
+    "value" : -0.480923,
+    "description" : "2 99528 POLYGON((92955.5 464370.5,92956.5 464370.5,92956.5 464369.5,92955.5 464369.5,92955.5 464370.5))"
+  } ],
   "buildings" : {
     "type" : "FeatureCollection",
     "crs" : {


### PR DESCRIPTION
The corrections are needed when serializing because the scenario is stored as a file when sending the calculation task. 