### PR TITLE
Generate a sane id by removing the 0. part of the generated number.

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/ScenarioSituation.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/ScenarioSituation.java
@@ -38,7 +38,8 @@ public class ScenarioSituation implements Serializable {
 
   private static final long serialVersionUID = 3L;
 
-  private String id = String.valueOf(Math.random());
+  // Initialize with random number, and strip first '0.' to make a dot-less number.
+  private String id = String.valueOf(Math.random()).substring(2);
   private int year;
   private String name;
   private SituationType type;


### PR DESCRIPTION
Getting a string id with "0." feels weird therefor remove that part.