### PR TITLE
AER-685 move building validation outside validate_sources test

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/importer/ImaerImporter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/importer/ImaerImporter.java
@@ -178,6 +178,7 @@ public class ImaerImporter {
             factory.createValidationHelper());
         BuildingValidator.validateBuildings(buildings, result.getExceptions(), result.getWarnings());
       }
+      BuildingValidator.validateBuildings(buildings, result.getExceptions(), result.getWarnings());
       reader.enforceEmissions(sources, importYear.orElse(result.getSituation().getYear()));
       if (ImportOption.VALIDATE_SOURCES.in(importOptions)) {
         EmissionSourceValidator.validateSourcesWithEmissions(sources, result.getExceptions(), result.getWarnings());


### PR DESCRIPTION
when importing a PDF the validation of sources is skipped
and we also want a building warning when importing a PDF