### PR TITLE
Simplified EPSG by introducing an new enum variant

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/importer/ImaerImporter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/importer/ImaerImporter.java
@@ -34,7 +34,6 @@ import org.slf4j.LoggerFactory;
 import com.github.rwitzel.streamflyer.core.ModifyingReader;
 import com.github.rwitzel.streamflyer.regex.RegexModifier;
 
-import nl.overheid.aerius.geo.shared.EPSG;
 import nl.overheid.aerius.gml.GMLMetaDataReader;
 import nl.overheid.aerius.gml.GMLReader;
 import nl.overheid.aerius.gml.GMLReaderFactory;
@@ -59,6 +58,7 @@ import nl.overheid.aerius.shared.domain.v2.scenario.ScenarioSituationResults;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
+import nl.overheid.aerius.shared.geo.EPSG;
 import nl.overheid.aerius.validation.BuildingValidator;
 import nl.overheid.aerius.validation.EmissionSourceValidator;
 
@@ -74,7 +74,7 @@ public class ImaerImporter {
 
   public ImaerImporter(final GMLHelper gmlHelper) throws AeriusException {
     factory = GMLReaderFactory.getFactory(gmlHelper);
-    epsg = gmlHelper.getReceptorGridSettings().getEpsg();
+    epsg = gmlHelper.getReceptorGridSettings().getEPSG();
   }
 
   /**

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/base/Geo2GeometryUtilTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/base/Geo2GeometryUtilTest.java
@@ -36,20 +36,20 @@ import net.opengis.gml.v_3_2_1.ObjectFactory;
 import net.opengis.gml.v_3_2_1.PointType;
 import net.opengis.gml.v_3_2_1.PolygonType;
 
-import nl.overheid.aerius.geo.shared.RDNew;
 import nl.overheid.aerius.gml.base.geo.Geo2GeometryUtil;
 import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.domain.v2.geojson.Point;
 import nl.overheid.aerius.shared.domain.v2.geojson.Polygon;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
+import nl.overheid.aerius.shared.geo.EPSG;
 
 /**
  * Test class for {@link Geo2GeometryUtil}.
  */
 public class Geo2GeometryUtilTest {
 
-  private final Geo2GeometryUtil geo2GeometryUtil = new Geo2GeometryUtil(RDNew.SRID);
+  private final Geo2GeometryUtil geo2GeometryUtil = new Geo2GeometryUtil(EPSG.RDNEW.getSrid());
 
   @Test
   public void testPoint() throws AeriusException {

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/test/GMLTestDomain.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/test/GMLTestDomain.java
@@ -21,8 +21,6 @@ import java.util.List;
 import java.util.Optional;
 
 import nl.overheid.aerius.geo.shared.BBox;
-import nl.overheid.aerius.geo.shared.EPSG;
-import nl.overheid.aerius.geo.shared.EPSGProxy;
 import nl.overheid.aerius.gml.ReferenceGenerator;
 import nl.overheid.aerius.shared.domain.Substance;
 import nl.overheid.aerius.shared.domain.geo.HexagonZoomLevel;
@@ -36,6 +34,7 @@ import nl.overheid.aerius.shared.domain.v2.geojson.Point;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.domain.v2.source.GenericEmissionSource;
+import nl.overheid.aerius.shared.geo.EPSG;
 
 /**
  * Convenience class to avoid having to write the same test code over and over again.
@@ -134,14 +133,13 @@ public class GMLTestDomain {
   }
 
   public static ReceptorGridSettings getExampleGridSettings() {
-    final EPSG epsg = EPSGProxy.getEPSG(28992);
     final BBox bbox = new BBox(3604.0, 287959.0, 296800.0, 629300.0);
     final ArrayList<HexagonZoomLevel> zoomLevels = new ArrayList<HexagonZoomLevel>();
     for (int i = 1; i <= 5; i++) {
       zoomLevels.add(new HexagonZoomLevel(i, 10000));
     }
     final int hexHor = 1529;
-    return new ReceptorGridSettings(bbox, epsg, hexHor, zoomLevels);
+    return new ReceptorGridSettings(bbox, EPSG.RDNEW, hexHor, zoomLevels);
   }
 
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/geo/ReceptorGridSettings.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/geo/ReceptorGridSettings.java
@@ -23,7 +23,8 @@ import java.util.List;
 import jsinterop.annotations.JsProperty;
 
 import nl.overheid.aerius.geo.shared.BBox;
-import nl.overheid.aerius.geo.shared.EPSG;
+import nl.overheid.aerius.geo.shared.EPSGProxy;
+import nl.overheid.aerius.shared.geo.EPSG;
 
 /**
  * Application settings related to the variables of the receptor grid used as basis of the application.
@@ -42,6 +43,25 @@ public final class ReceptorGridSettings implements Serializable {
   private int hexHor;
   private @JsProperty List<HexagonZoomLevel> hexagonZoomLevels;
 
+  /**
+   * Constructor.
+   *
+   * @deprecated EPSG class will be replaced by the EPSG enum.
+   */
+  @Deprecated
+  public ReceptorGridSettings(final BBox boundingBox, final nl.overheid.aerius.geo.shared.EPSG epsg, final int hexagonHorizontal,
+      final ArrayList<HexagonZoomLevel> hexagonZoomLevels) {
+    this(boundingBox, EPSG.getEnumBySrid(epsg.getSrid()), hexagonHorizontal, hexagonZoomLevels);
+  }
+
+  /**
+   * Constructor
+   *
+   * @param boundingBox Bounding box of the receptor grid
+   * @param epsg EPSG code of the receptor grid
+   * @param hexagonHorizontal Number of horizontal hexagons
+   * @param hexagonZoomLevels Number of hexagon zoom levels
+   */
   public ReceptorGridSettings(final BBox boundingBox, final EPSG epsg, final int hexagonHorizontal,
       final ArrayList<HexagonZoomLevel> hexagonZoomLevels) {
     this.boundingBox = boundingBox;
@@ -63,8 +83,17 @@ public final class ReceptorGridSettings implements Serializable {
 
   /**
    * The geometric settings used for the receptor grid.
+   * @deprecated will be replaced by {@link #getEPSG()}
    */
-  public EPSG getEpsg() {
+  @Deprecated
+  public nl.overheid.aerius.geo.shared.EPSG getEpsg() {
+    return EPSGProxy.getEPSG(epsg.getSrid());
+  }
+
+  /**
+   * The geometric settings used for the receptor grid.
+   */
+  public EPSG getEPSG() {
     return epsg;
   }
 

--- a/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/geometry/ReceptorUtilTest.java
+++ b/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/geometry/ReceptorUtilTest.java
@@ -29,12 +29,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import nl.overheid.aerius.geo.shared.BBox;
-import nl.overheid.aerius.geo.shared.EPSGProxy;
 import nl.overheid.aerius.shared.domain.geo.HexagonZoomLevel;
 import nl.overheid.aerius.shared.domain.geo.ReceptorGridSettings;
 import nl.overheid.aerius.shared.domain.v2.geojson.Point;
 import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
 import nl.overheid.aerius.shared.domain.v2.point.ReceptorPoint;
+import nl.overheid.aerius.shared.geo.EPSG;
 
 /**
  * Test class for {@link ReceptorUtil}.
@@ -58,7 +58,7 @@ class ReceptorUtilTest {
   private static final BBox RECEPTOR_BBOX = new BBox(3604, 296800, 287959, 629300);
 
   private static final ArrayList<HexagonZoomLevel> hexagonZoomLevels = createZoomLevels();
-  private static final ReceptorGridSettings RGS = new ReceptorGridSettings(RECEPTOR_BBOX, EPSGProxy.defaultEpsg(), 1529, hexagonZoomLevels);
+  private static final ReceptorGridSettings RGS = new ReceptorGridSettings(RECEPTOR_BBOX, EPSG.RDNEW, 1529, hexagonZoomLevels);
   private static final ReceptorUtil RECEPTOR_UTIL = new ReceptorUtil(RGS);
 
   @Test

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/util/GeometryUtilTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/util/GeometryUtilTest.java
@@ -29,7 +29,6 @@ import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.locationtech.jts.geom.Geometry;
 
-import nl.overheid.aerius.geo.shared.RDNew;
 import nl.overheid.aerius.geo.shared.WKTGeometry;
 import nl.overheid.aerius.shared.domain.v2.geojson.GeometryType;
 import nl.overheid.aerius.shared.domain.v2.geojson.LineString;
@@ -37,6 +36,7 @@ import nl.overheid.aerius.shared.domain.v2.geojson.Point;
 import nl.overheid.aerius.shared.domain.v2.geojson.Polygon;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
+import nl.overheid.aerius.shared.geo.EPSG;
 import nl.overheid.aerius.shared.geometry.GeometryCalculator;
 
 /**
@@ -141,7 +141,7 @@ class GeometryUtilTest {
   @Test
   void testToConvexHull() throws AeriusException {
     final Polygon geometry = (Polygon) GeometryUtil.getAeriusGeometry(GeometryUtil.getGeometry("POLYGON ((0 0, 0 100, 20 100, 15 50, 20 0, 0 0))"));
-    final Polygon convexHull = GeometryUtil.toConvexHull(geometry, RDNew.SRID);
+    final Polygon convexHull = GeometryUtil.toConvexHull(geometry, EPSG.RDNEW.getSrid());
     final Polygon expectedGeometry = (Polygon) GeometryUtil.getAeriusGeometry(GeometryUtil.getGeometry("POLYGON ((0 0, 0 100, 20 100, 20 0, 0 0))"));
 
     assertEquals(expectedGeometry, convexHull, "Should be expected convex geometry");

--- a/source/shared-geo/src/main/java/nl/overheid/aerius/geo/shared/EPSG.java
+++ b/source/shared-geo/src/main/java/nl/overheid/aerius/geo/shared/EPSG.java
@@ -22,7 +22,10 @@ import nl.overheid.aerius.shared.domain.v2.geojson.Point;
 
 /**
  * EPSG map constants.
+ *
+ * @deprecated will be replaced by {@link nl.overheid.aerius.shared.geo.EPSG}.
  */
+@Deprecated
 public abstract class EPSG implements Serializable {
 
   private static final long serialVersionUID = 1L;

--- a/source/shared-geo/src/main/java/nl/overheid/aerius/geo/shared/EPSGProxy.java
+++ b/source/shared-geo/src/main/java/nl/overheid/aerius/geo/shared/EPSGProxy.java
@@ -22,7 +22,9 @@ import java.util.Map;
 
 /**
  * Proxy class to get an EPSG object.
+ * @deprecated Will be replaced by {@link nl.overheid.aerius.shared.geo.EPSG} enum.
  */
+@Deprecated
 public final class EPSGProxy {
 
   private static final Map<Integer, EPSG> MAP;

--- a/source/shared-geo/src/main/java/nl/overheid/aerius/shared/geo/EPSG.java
+++ b/source/shared-geo/src/main/java/nl/overheid/aerius/shared/geo/EPSG.java
@@ -41,7 +41,7 @@ public enum EPSG {
    */
   TM75(29903);
 
-  private static final String EPSG_PRE_TEXT = "EPSG:";
+  private static final String EPSG_PREFIX = "EPSG:";
 
   private int srid;
 
@@ -71,6 +71,6 @@ public enum EPSG {
   }
 
   public String getEpsgCode() {
-    return EPSG_PRE_TEXT + srid;
+    return EPSG_PREFIX + srid;
   }
 }

--- a/source/shared-geo/src/main/java/nl/overheid/aerius/shared/geo/EPSG.java
+++ b/source/shared-geo/src/main/java/nl/overheid/aerius/shared/geo/EPSG.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.shared.geo;
+
+/**
+ * Enum representing the web mercator projections supported by the application
+ */
+public enum EPSG {
+  /**
+   * WGS84 (EPSG::4326).
+   */
+  WGS84(4326),
+  /**
+   * British National Grid -- United Kingdom (EPSG:27700).
+   */
+  BNG(27700),
+  /**
+   * RD New grid (EPSG:28992).
+   */
+  RDNEW(28992),
+  /**
+   * Irish grid (EPSG:29902).
+   */
+  TM65(29902),
+  /**
+   * Northern Irish grid (EPSG:29903).
+   */
+  TM75(29903);
+
+  private static final String EPSG_PRE_TEXT = "EPSG:";
+
+  private int srid;
+
+  EPSG(final int srid) {
+    this.srid = srid;
+  }
+
+  public static EPSG getEnumBySrid(final int srid) {
+    for (final EPSG epsg: EPSG.values()) {
+      if (epsg.srid == srid) {
+        return epsg;
+      }
+    }
+    return null;
+  }
+
+  public static EPSG safeValueOf(final String epsg) {
+    try {
+      return "".equals(epsg) ? null : valueOf(epsg);
+    } catch (final IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  public int getSrid() {
+    return srid;
+  }
+
+  public String getEpsgCode() {
+    return EPSG_PRE_TEXT + srid;
+  }
+}


### PR DESCRIPTION
EPSG only needed to contain the SRID code. The other properties are specific for the UI and not needed here. Kept backward compatible for now. When this change is added the depending code can start using the new enum