### PR TITLE
FarmlandActivity emission calculations and bugfix

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/farmland/AbstractFarmlandActivity.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/farmland/AbstractFarmlandActivity.java
@@ -50,5 +50,5 @@ public abstract class AbstractFarmlandActivity extends AbstractSubSource {
     this.activityCode = activityCode;
   }
 
-  public abstract <T> void accept(FarmlandActivityVisitor<T> visitor, T summedEmissions) throws AeriusException;
+  public abstract <T> T accept(FarmlandActivityVisitor<T> visitor) throws AeriusException;
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/farmland/CustomFarmlandActivity.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/farmland/CustomFarmlandActivity.java
@@ -21,7 +21,7 @@ public class CustomFarmlandActivity extends AbstractFarmlandActivity {
   private static final long serialVersionUID = 1L;
 
   @Override
-  public <T> void accept(FarmlandActivityVisitor<T> visitor, T summedEmissions) {
-    visitor.visit(this, summedEmissions);
+  public <T> T accept(final FarmlandActivityVisitor<T> visitor) {
+    return visitor.visit(this);
   }
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/farmland/FarmlandActivityVisitor.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/farmland/FarmlandActivityVisitor.java
@@ -20,8 +20,8 @@ import nl.overheid.aerius.shared.exception.AeriusException;
 
 public interface FarmlandActivityVisitor<T> {
 
-  void visit(CustomFarmlandActivity activity, T summedEmissions);
+  T visit(CustomFarmlandActivity activity);
 
-  void visit(StandardFarmlandActivity activity, T summedEmissions) throws AeriusException;
+  T visit(StandardFarmlandActivity activity) throws AeriusException;
 
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/farmland/StandardFarmlandActivity.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/farmland/StandardFarmlandActivity.java
@@ -50,7 +50,7 @@ public class StandardFarmlandActivity extends AbstractFarmlandActivity {
   }
 
   @Override
-  public <T> void accept(final FarmlandActivityVisitor<T> visitor, final T summedEmissions) throws AeriusException {
-    visitor.visit(this, summedEmissions);
+  public <T> T accept(final FarmlandActivityVisitor<T> visitor) throws AeriusException {
+    return visitor.visit(this);
   }
 }

--- a/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/emissions/FarmlandEmissionsCalculatorTest.java
+++ b/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/emissions/FarmlandEmissionsCalculatorTest.java
@@ -73,6 +73,7 @@ class FarmlandEmissionsCalculatorTest {
     final Map<Substance, Double> results = emissionsCalculator.updateEmissions(emissionSource);
 
     assertEquals(200, results.get(Substance.NOX), "Emissions should be calculated based on factor, number of animals, and number of days.");
+    assertEquals(200, emissionSource.getSubSources().get(0).getEmissions().get(Substance.NOX), "Emissions should be set on subsource as well");
   }
 
   @Test
@@ -84,6 +85,7 @@ class FarmlandEmissionsCalculatorTest {
     final Map<Substance, Double> results = emissionsCalculator.updateEmissions(emissionSource);
 
     assertEquals(2, results.get(Substance.NOX), "Emissions should be calculated based on factor, number of animals, and number of days.");
+    assertEquals(2, emissionSource.getSubSources().get(0).getEmissions().get(Substance.NOX), "Emissions should be set on subsource as well");
   }
 
   @Test

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/FarmLodgingValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/FarmLodgingValidator.java
@@ -51,9 +51,11 @@ class FarmLodgingValidator extends SourceValidator<FarmLodgingEmissionSource> {
     final String code = subSource.getFarmLodgingCode();
     boolean valid = true;
     if (validationHelper.isValidFarmLodgingCode(code)) {
-      if (validationHelper.expectsFarmLodgingNumberOfDays(code) && subSource.getNumberOfDays() == null) {
-        getErrors().add(new AeriusException(ImaerExceptionReason.GML_MISSING_NUMBER_OF_DAYS, sourceId));
-        valid = false;
+      if (validationHelper.expectsFarmLodgingNumberOfDays(code)) {
+        if (subSource.getNumberOfDays() == null) {
+          getErrors().add(new AeriusException(ImaerExceptionReason.GML_MISSING_NUMBER_OF_DAYS, sourceId));
+          valid = false;
+        }
       } else {
         subSource.setNumberOfDays(null);
       }


### PR DESCRIPTION
* Emissions weren't set for the Farmland subsources (FarmlandActivity).
* `numberOfDays ` were erased when they were expected and specified. Now only erased when they're not expected.


AER-868, AER-873, AER-876