### PR TITLE
Changed error codes to be more consistent

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/lodging/GML2Farm.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/lodging/GML2Farm.java
@@ -88,7 +88,7 @@ public class GML2Farm<T extends IsGmlFarmLodgingEmissionSource> extends Abstract
     }
     final FarmEmissionFactorType type = FarmEmissionFactorType.safeValueOf(gmlEmissionFactorType);
     if (type == null) {
-      throw new AeriusException(ImaerExceptionReason.GML_UNKNOWN_FARMLAND_ACTIVITY_CODE, sourceId, gmlEmissionFactorType);
+      throw new AeriusException(ImaerExceptionReason.GML_UNKNOWN_FARM_EMISSION_FACTOR_TYPE, sourceId, gmlEmissionFactorType);
     }
 
     return type;

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/exception/ImaerExceptionReason.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/exception/ImaerExceptionReason.java
@@ -138,6 +138,20 @@ public enum ImaerExceptionReason implements Reason {
    */
   MOBILE_SOURCE_HIGH_ADBLUE_FUEL_RATIO(1029),
 
+  /**
+   * Number of animals was missing on an object.
+   *
+   * @param 0 the id of the object containing the error.
+   */
+  MISSING_NUMBER_OF_ANIMALS(1031),
+
+  /**
+   * Number of days was missing on an object.
+   *
+   * @param 0 the id of the object containing the error.
+   */
+  MISSING_NUMBER_OF_DAYS(1032),
+
   // Import GML file errors/warnings.
   /**
    * Uploaded file should contain no calculation points.
@@ -373,24 +387,12 @@ public enum ImaerExceptionReason implements Reason {
    */
   GML_MISSING_NETTING_FACTOR(5235),
   /**
-   * GML contains a unknown farm emission factor type code.
+   * GML contains unknown farm emission factor type code.
    *
    * @param 0 the id of the object containing the error.
    * @param 1 The code that is unknown.
    */
   GML_UNKNOWN_FARM_EMISSION_FACTOR_TYPE(5236),
-  /**
-   * Number of animals was missing on an object.
-   *
-   * @param 0 the id of the object containing the error.
-   */
-  GML_MISSING_NUMBER_OF_ANIMALS(5237),
-  /**
-   * Number of days was missing on an object.
-   *
-   * @param 0 the id of the object containing the error.
-   */
-  GML_MISSING_NUMBER_OF_DAYS(5238),
 
   // Cohesion (between files) errors.
 

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/FarmLodgingValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/FarmLodgingValidator.java
@@ -53,7 +53,7 @@ class FarmLodgingValidator extends SourceValidator<FarmLodgingEmissionSource> {
     if (validationHelper.isValidFarmLodgingCode(code)) {
       if (validationHelper.expectsFarmLodgingNumberOfDays(code)) {
         if (subSource.getNumberOfDays() == null) {
-          getErrors().add(new AeriusException(ImaerExceptionReason.GML_MISSING_NUMBER_OF_DAYS, sourceId));
+          getErrors().add(new AeriusException(ImaerExceptionReason.MISSING_NUMBER_OF_DAYS, sourceId));
           valid = false;
         }
       } else {

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/FarmlandValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/FarmlandValidator.java
@@ -62,7 +62,7 @@ class FarmlandValidator extends SourceValidator<FarmlandEmissionSource> {
     if (validationHelper.isValidFarmlandStandardActivityCode(standardCode)) {
       if (validationHelper.expectsFarmlandNumberOfAnimals(standardCode)) {
         if (activity.getNumberOfAnimals() == null) {
-          getErrors().add(new AeriusException(ImaerExceptionReason.GML_MISSING_NUMBER_OF_ANIMALS, sourceId));
+          getErrors().add(new AeriusException(ImaerExceptionReason.MISSING_NUMBER_OF_ANIMALS, sourceId));
           valid = false;
         }
       } else {
@@ -70,7 +70,7 @@ class FarmlandValidator extends SourceValidator<FarmlandEmissionSource> {
       }
       if (validationHelper.expectsFarmlandNumberOfDays(standardCode)) {
         if (activity.getNumberOfDays() == null) {
-          getErrors().add(new AeriusException(ImaerExceptionReason.GML_MISSING_NUMBER_OF_DAYS, sourceId));
+          getErrors().add(new AeriusException(ImaerExceptionReason.MISSING_NUMBER_OF_DAYS, sourceId));
           valid = false;
         }
       } else {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/FarmLodgingValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/FarmLodgingValidatorTest.java
@@ -337,7 +337,7 @@ class FarmLodgingValidatorTest {
 
     assertFalse(valid, "Invalid test case");
     assertEquals(1, errors.size(), "Number of errors");
-    assertEquals(ImaerExceptionReason.GML_MISSING_NUMBER_OF_DAYS, errors.get(0).getReason(), "Error reason");
+    assertEquals(ImaerExceptionReason.MISSING_NUMBER_OF_DAYS, errors.get(0).getReason(), "Error reason");
     assertArrayEquals(new Object[] {
         SOURCE_ID
     }, errors.get(0).getArgs(), "Arguments");

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/FarmlandValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/FarmlandValidatorTest.java
@@ -193,7 +193,7 @@ class FarmlandValidatorTest {
 
     assertFalse(valid, "Invalid test case");
     assertEquals(1, errors.size(), "Number of errors");
-    assertEquals(ImaerExceptionReason.GML_MISSING_NUMBER_OF_ANIMALS, errors.get(0).getReason(), "Error reason");
+    assertEquals(ImaerExceptionReason.MISSING_NUMBER_OF_ANIMALS, errors.get(0).getReason(), "Error reason");
     assertArrayEquals(new Object[] {
         SOURCE_ID
     }, errors.get(0).getArgs(), "Arguments");
@@ -222,7 +222,7 @@ class FarmlandValidatorTest {
 
     assertFalse(valid, "Invalid test case");
     assertEquals(1, errors.size(), "Number of errors");
-    assertEquals(ImaerExceptionReason.GML_MISSING_NUMBER_OF_DAYS, errors.get(0).getReason(), "Error reason");
+    assertEquals(ImaerExceptionReason.MISSING_NUMBER_OF_DAYS, errors.get(0).getReason(), "Error reason");
     assertArrayEquals(new Object[] {
         SOURCE_ID
     }, errors.get(0).getArgs(), "Arguments");


### PR DESCRIPTION
The unknown farm emission factor type is purely something that can occur when importing GML (in our domain code it's already an enum, so harder to get wrong). The other reasons are triggered during normal validation, and can also occur on wrong input within our application (unexpected UI behaviour).

Also turns out the wrong reason was used...