### PR TITLE
AER-1065 duplicate coordinate check

### DIFF
--- a/source/imaer-util/src/main/java/nl/overheid/aerius/util/GeometryUtil.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/util/GeometryUtil.java
@@ -36,7 +36,6 @@ import org.locationtech.jts.geom.util.AffineTransformation;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.locationtech.jts.linearref.LengthIndexedLine;
-import org.locationtech.jts.operation.IsSimpleOp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -237,12 +236,8 @@ public final class GeometryUtil {
    * @return true if invalid, false if not.
    */
   public static boolean hasIntersections(final Geometry geometry) {
-    final IsSimpleOp isSimpleOp = new IsSimpleOp(geometry);
-    //isSimple implementation for polygons always returns true because if
-    //isValid returns true it's by definition simple. Therefore both test are
-    //done here, as isSimple is needed for checking lines.
     return (geometry instanceof Polygon || geometry instanceof MultiPolygon)
-        && (!isSimpleOp.isSimple() || !geometry.isValid());
+        && !geometry.isValid();
   }
 
   /**

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/util/GeometryUtil.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/util/GeometryUtil.java
@@ -36,12 +36,12 @@ import org.locationtech.jts.geom.util.AffineTransformation;
 import org.locationtech.jts.io.ParseException;
 import org.locationtech.jts.io.WKTReader;
 import org.locationtech.jts.linearref.LengthIndexedLine;
-import org.locationtech.jts.operation.valid.IsSimpleOp;
+import org.locationtech.jts.operation.IsSimpleOp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import nl.overheid.aerius.shared.domain.v2.geojson.Point;
 import nl.overheid.aerius.shared.domain.geo.OrientedEnvelope;
+import nl.overheid.aerius.shared.domain.v2.geojson.Point;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/util/GeometryUtilTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/util/GeometryUtilTest.java
@@ -68,6 +68,11 @@ class GeometryUtilTest {
     final String normalPolygonWKT = "POLYGON((0 0," + side + " 0," + side + " " + side + ",0 " + side + ",0 0))";
     assertFalse(GeometryUtil.hasIntersections(normalPolygonWKT), "Normal polygon geometry shouldn't count as intersected");
 
+    //create normal polygon with a duplicate coordinate (0,0), (0,4000), (4000,4000), (4000,4000), (0,4000), (0,0)
+    final String normalPolygonDuplicatePointsWKT =
+        "POLYGON((0 0," + side + " 0," + side + " " + side + "," + side + " " + side + ",0 " + side + ",0 0))";
+    assertFalse(GeometryUtil.hasIntersections(normalPolygonDuplicatePointsWKT), "Polygon with a duplicate coordinate shouldn't count as intersected");
+
     //create Bow-Tie linestring with points (0,0), (4000,4000), (4000,0), (0,4000)
     final String bowtieLineStringWKT = "LINESTRING(0 0," + side + " " + side + "," + side + " 0,0 " + side + ")";
     assertFalse(GeometryUtil.hasIntersections(bowtieLineStringWKT), "Bowtie linestring geometry should not count as intersected");
@@ -187,14 +192,15 @@ class GeometryUtilTest {
 
     final LineString lineStringWithoutCoords = new LineString();
     lineStringWithoutCoords.setCoordinates(new double[][] {{}});
-    final AeriusException exceptionOnLineStringWithoutCoords = assertThrows(AeriusException.class, () -> GeometryUtil.getGeometry(lineStringWithoutCoords));
+    final AeriusException exceptionOnLineStringWithoutCoords =
+        assertThrows(AeriusException.class, () -> GeometryUtil.getGeometry(lineStringWithoutCoords));
     assertEquals(ImaerExceptionReason.GEOMETRY_INVALID, exceptionOnLineStringWithoutCoords.getReason(), "Reason for linestring with 1 coord");
 
     final LineString lineStringWithIncorrectCoord = new LineString();
     lineStringWithIncorrectCoord.setCoordinates(new double[][] {{939, 32423, 234}});
-    final AeriusException exceptionOnLineStringWithIncorrectCoord = assertThrows(AeriusException.class, () -> GeometryUtil.getGeometry(lineStringWithIncorrectCoord));
+    final AeriusException exceptionOnLineStringWithIncorrectCoord =
+        assertThrows(AeriusException.class, () -> GeometryUtil.getGeometry(lineStringWithIncorrectCoord));
     assertEquals(ImaerExceptionReason.GEOMETRY_INVALID, exceptionOnLineStringWithIncorrectCoord.getReason(), "Reason for linestring with 1 coord");
-
 
     final Polygon polygonWithoutCoords = new Polygon();
     polygonWithoutCoords.setCoordinates(new double[][][] {});


### PR DESCRIPTION
As it turns out, the intersection check implementation was changed with the switch to a newer JTS version. This caused duplicate-points-within-a-polygon to trigger the invalid geometry due to intersections error.

This change reverts that behaviour: duplicate-points-within-a-polygon will no longer be seen as invalid.