### PR TITLE
Allow emission factor type PER_YEAR for manure storage

### DIFF
--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ManureStorageValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ManureStorageValidator.java
@@ -33,7 +33,8 @@ class ManureStorageValidator extends SourceValidator<ManureStorageEmissionSource
   private static final Set<FarmEmissionFactorType> EXPECTED_EMISSION_FACTOR_TYPES = EnumSet.of(
       FarmEmissionFactorType.PER_TONNES_PER_YEAR,
       FarmEmissionFactorType.PER_METERS_SQUARED_PER_YEAR,
-      FarmEmissionFactorType.PER_METERS_SQUARED_PER_DAY);
+      FarmEmissionFactorType.PER_METERS_SQUARED_PER_DAY,
+      FarmEmissionFactorType.PER_YEAR);
 
   private final ManureStorageValidationHelper validationHelper;
 

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/ManureStorageValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/ManureStorageValidatorTest.java
@@ -45,12 +45,44 @@ class ManureStorageValidatorTest {
   @Mock ManureStorageValidationHelper validationHelper;
 
   @Test
-  void testValidCustom() {
+  void testValidCustomMetersSquaredDay() {
     final ManureStorageEmissionSource source = constructSource();
     final CustomManureStorage subSource = new CustomManureStorage();
     subSource.setFarmEmissionFactorType(FarmEmissionFactorType.PER_METERS_SQUARED_PER_DAY);
     subSource.setMetersSquared(3.2);
     subSource.setNumberOfDays(40);
+    source.getSubSources().add(subSource);
+
+    assertCorrectCase(source);
+  }
+
+  @Test
+  void testValidCustomMetersSquared() {
+    final ManureStorageEmissionSource source = constructSource();
+    final CustomManureStorage subSource = new CustomManureStorage();
+    subSource.setFarmEmissionFactorType(FarmEmissionFactorType.PER_METERS_SQUARED_PER_YEAR);
+    subSource.setMetersSquared(3.2);
+    source.getSubSources().add(subSource);
+
+    assertCorrectCase(source);
+  }
+
+  @Test
+  void testValidCustomTonnes() {
+    final ManureStorageEmissionSource source = constructSource();
+    final CustomManureStorage subSource = new CustomManureStorage();
+    subSource.setFarmEmissionFactorType(FarmEmissionFactorType.PER_TONNES_PER_YEAR);
+    subSource.setTonnes(3.2);
+    source.getSubSources().add(subSource);
+
+    assertCorrectCase(source);
+  }
+
+  @Test
+  void testValidCustom() {
+    final ManureStorageEmissionSource source = constructSource();
+    final CustomManureStorage subSource = new CustomManureStorage();
+    subSource.setFarmEmissionFactorType(FarmEmissionFactorType.PER_YEAR);
     source.getSubSources().add(subSource);
 
     assertCorrectCase(source);


### PR DESCRIPTION
For custom manure storage it should be possible to specify a kg/y emission factor (in which case it's also directly the total kg/y emission).