### PR TITLE
AER-941 gml reference per situation

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLMetaDataReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLMetaDataReader.java
@@ -47,10 +47,17 @@ public class GMLMetaDataReader {
         smd.setPostcode(metaData.getFacilityLocation().getPostcode());
         smd.setCity(metaData.getFacilityLocation().getCity());
       }
-      smd.setReference(metaData.getReference());
       smd.setDescription(metaData.getDescription());
     }
     return smd;
+  }
+
+  /**
+   * Reference specified in the GML data.
+   * @return reference
+   */
+  public String readReference() {
+    return checkFeatureCollection(featureCollection) ? featureCollection.getMetaData().getReference() : null;
   }
 
   /**

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLScenarioHelper.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLScenarioHelper.java
@@ -49,6 +49,7 @@ public final class GMLScenarioHelper {
     metaData.setDatabaseVersion(databaseVersion);
     metaData.setOptions(scenario.getOptions());
     metaData.setResultsIncluded(resultsIncluded.getAsBoolean());
+    metaData.setReference(situation.getReference());
     scenario.getSituations().stream()
         .filter(x -> situation != x)
         .map(GMLScenarioHelper::otherSituation)

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLScenarioHelper.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLScenarioHelper.java
@@ -58,12 +58,11 @@ public final class GMLScenarioHelper {
 
   private static OtherSituationMetaData otherSituation(final ScenarioSituation situation) {
     return OtherSituationMetaData.Builder
-        // TODO: get the correct reference from situation.
         // Reference and name might be null at this point, in that case, use empty string as a fallback as they are required fields in IMAER.
         .create(
             Optional.ofNullable(situation.getName()).orElse(""),
             situation.getType(),
-            "")
+            Optional.ofNullable(situation.getReference()).orElse(""))
         .build();
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLValidator.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLValidator.java
@@ -59,7 +59,6 @@ public final class GMLValidator {
     }
     validateMetaDataElement(metaData.getProjectName(), "projectName", exceptions);
     validateMetaDataElement(metaData.getCorporation(), "corporation", exceptions);
-    validateMetaDataElement(metaData.getReference(), "reference", exceptions);
     validateMetaDataElement(metaData.getDescription(), "description", exceptions);
     validateMetaDataElement(metaData.getStreetAddress(), "streetAddress", exceptions);
     validateMetaDataElement(metaData.getPostcode(), "postcode", exceptions);

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/InternalGMLWriter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/InternalGMLWriter.java
@@ -159,9 +159,9 @@ final class InternalGMLWriter {
     metaDataInput.setSituationType(scenario.getSituationType());
     metaDataInput.setNettingFactor(scenario.getNettingFactor());
     final MetaData metaDataImpl = writer.metaData2GML(metaDataInput);
-    referenceGenerator.updateReferenceIfNeeded(metaDataImpl.getReference()).ifPresent(newReference -> {
+    referenceGenerator.updateReferenceIfNeeded(metaDataInput.getReference()).ifPresent(newReference -> {
       metaDataImpl.setReference(newReference);
-      metaDataInput.getScenarioMetaData().setReference(newReference);
+      metaDataInput.setReference(newReference);
     });
     final Definitions definitions = writer.definitions2GML(scenario.getDefinitions());
     toXMLString(outputStream, featureMembers, metaDataImpl, definitions);

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/MetaDataInput.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/MetaDataInput.java
@@ -33,6 +33,7 @@ public class MetaDataInput {
   private Theme theme;
   private int year;
   private String name;
+  private String reference;
   private SituationType situationType;
   private Double nettingFactor;
   private String version;
@@ -71,6 +72,14 @@ public class MetaDataInput {
 
   public void setName(final String name) {
     this.name = name;
+  }
+
+  public String getReference() {
+    return reference;
+  }
+
+  public void setReference(final String reference) {
+    this.reference = reference;
   }
 
   public SituationType getSituationType() {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/GMLVersionWriterV50.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/GMLVersionWriterV50.java
@@ -119,7 +119,7 @@ public class GMLVersionWriterV50 implements GMLVersionWriter {
       ensureSituationType(input);
       situation = new SituationMetadata();
       situation.setName(input.getName());
-      situation.setReference(input.getScenarioMetaData().getReference());
+      situation.setReference(input.getReference());
       situation.setSituationType(input.getSituationType());
       situation.setNettingFactor(input.getNettingFactor());
     }
@@ -144,7 +144,7 @@ public class GMLVersionWriterV50 implements GMLVersionWriter {
   }
 
   private boolean isEmptySituationData(final MetaDataInput input) {
-    return StringUtils.isEmpty(input.getName()) && StringUtils.isEmpty(input.getScenarioMetaData().getReference())
+    return StringUtils.isEmpty(input.getName()) && StringUtils.isEmpty(input.getReference())
         && input.getSituationType() == null;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/GMLVersionWriterV51.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/GMLVersionWriterV51.java
@@ -122,7 +122,7 @@ public class GMLVersionWriterV51 implements GMLVersionWriter {
       ensureSituationType(input);
       situation = new SituationMetadata();
       situation.setName(input.getName());
-      situation.setReference(input.getScenarioMetaData().getReference());
+      situation.setReference(input.getReference());
       situation.setSituationType(input.getSituationType());
       situation.setNettingFactor(input.getNettingFactor());
     }
@@ -147,7 +147,7 @@ public class GMLVersionWriterV51 implements GMLVersionWriter {
   }
 
   private boolean isEmptySituationData(final MetaDataInput input) {
-    return StringUtils.isEmpty(input.getName()) && StringUtils.isEmpty(input.getScenarioMetaData().getReference())
+    return StringUtils.isEmpty(input.getName()) && StringUtils.isEmpty(input.getReference())
         && input.getSituationType() == null;
   }
 

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLReaderTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLReaderTest.java
@@ -152,7 +152,7 @@ public class GMLReaderTest {
     assertEquals(expectedMetaData.getTemporaryPeriod(), metaDataReader.readTemporaryProjectPeriodYear(), "Metadata temporary period");
     final ScenarioMetaData MetaData = metaDataReader.readMetaData();
     assertEquals(expectedMetaData.getProjectName(), MetaData.getProjectName(), "Metadata name");
-    assertEquals(expectedMetaData.getReference(), MetaData.getReference(), "Metadata reference");
+    assertEquals(expectedMetaData.getReference(), metaDataReader.readReference(), "Metadata reference");
     assertEquals(expectedMetaData.getCorporation(), MetaData.getCorporation(), "Metadata corporation");
     assertEquals(expectedMetaData.getDescription(), MetaData.getDescription(), "Metadata description");
     assertTrue(errors.isEmpty(), "Expected no errors");
@@ -207,7 +207,6 @@ public class GMLReaderTest {
 
   private static MetaData getMetaData() throws AeriusException {
     final ScenarioMetaData metaData = new ScenarioMetaData();
-    metaData.setReference("SomeReference001");
     metaData.setCorporation("Big Corp");
     metaData.setProjectName("SomeProject");
     metaData.setDescription("SomeFunkyDescription");
@@ -215,6 +214,7 @@ public class GMLReaderTest {
     metaDataInput.setScenarioMetaData(metaData);
     metaDataInput.setYear(GML_YEAR);
     metaDataInput.setName(SITUATION_NAME);
+    metaDataInput.setReference("SomeReference001");
     metaDataInput.setSituationType(SITUATION_TYPE);
     metaDataInput.setVersion(VERSION);
     metaDataInput.setDatabaseVersion(DATABASE_VERSION);

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterTest.java
@@ -81,6 +81,7 @@ public class GMLWriterTest {
   private static final String VERSION = "V1.1";
   private static final String DATABASE_VERSION = "SomeDBVersion";
   private static final String SITUATION_NAME = "Situatie 1";
+  private static final String SITUATION_REFERENCE = "SomeReference001";
   private static final SituationType SITUATION_TYPE = SituationType.PROPOSED;
 
   private static final ReceptorGridSettings RECEPTOR_GRID_SETTINGS = GMLTestDomain.getExampleGridSettings();
@@ -125,23 +126,24 @@ public class GMLWriterTest {
   void testConvertMetaData() throws IOException, AeriusException {
     final GMLWriter writer = new GMLWriter(RECEPTOR_GRID_SETTINGS, r -> Optional.of("test"));
     final ScenarioMetaData metaData = getScenarioMetaData();
-    final String originalReference = metaData.getReference();
+    final String originalReference = SITUATION_REFERENCE;
     final List<EmissionSourceFeature> sourceList = new ArrayList<>();
     final GMLScenario scenario = GMLScenario.Builder.create(SITUATION_NAME, SituationType.PROPOSED)
         .sources(sourceList)
         .build();
     String result;
+    final MetaDataInput metaDataInput = getMetaDataInput(metaData);
     try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
-      final MetaDataInput metaDataInput = getMetaDataInput(metaData);
 
       writer.write(bos, scenario, metaDataInput);
       result = bos.toString(StandardCharsets.UTF_8.name());
+
     }
     validateDefaultMetaDataFields(result, metaData);
     assertFalse(result.contains("<imaer:temporaryPeriod>"), "Shouldn't contain temporaryPeriod");
     assertFalse(result.contains("<imaer:permitCalculationRadiusType>"), "Shouldn't contain PermitCalculationRadiusType");
-    assertNotEquals(originalReference, metaData.getReference(), "Reference should be overwritten");
-    assertTrue(result.contains(getExpectedElement("reference", metaData.getReference())), "Should contain new generated reference");
+    assertNotEquals(originalReference, metaDataInput.getReference(), "Reference should be overwritten");
+    assertTrue(result.contains(getExpectedElement("reference", metaDataInput.getReference())), "Should contain new generated reference");
   }
 
   private void validateDefaultMetaDataFields(final String result, final ScenarioMetaData metaData) {
@@ -167,6 +169,7 @@ public class GMLWriterTest {
     metaDataInput.setScenarioMetaData(scenarioMetaData);
     metaDataInput.setYear(GML_YEAR);
     metaDataInput.setName(SITUATION_NAME);
+    metaDataInput.setReference(SITUATION_REFERENCE);
     metaDataInput.setSituationType(SITUATION_TYPE);
     metaDataInput.setVersion(VERSION);
     metaDataInput.setDatabaseVersion(DATABASE_VERSION);
@@ -228,6 +231,7 @@ public class GMLWriterTest {
     final ArrayList<CalculationPointFeature> receptors = getExampleAeriusPoints(includeDeposition, includeConcentration, includeOverlapping);
     final MetaDataInput metaDataInput = getMetaDataInput(new ScenarioMetaData());
     metaDataInput.setName(null);
+    metaDataInput.setReference(null);
     metaDataInput.setSituationType(null);
     metaDataInput.setResultsIncluded(true);
     final GMLWriter writer = new GMLWriter(RECEPTOR_GRID_SETTINGS, GMLTestDomain.TEST_REFERENCE_GENERATOR);
@@ -356,7 +360,6 @@ public class GMLWriterTest {
 
   private ScenarioMetaData getScenarioMetaData() {
     final ScenarioMetaData metaData = new ScenarioMetaData();
-    metaData.setReference("SomeReference001");
     metaData.setCorporation("Big Corp");
     metaData.setProjectName("SomeProject");
     metaData.setDescription("SomeFunkyDescription");

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/Scenario.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/Scenario.java
@@ -90,4 +90,9 @@ public class Scenario implements Serializable {
     return customPoints.getFeatures();
   }
 
+  @JsonIgnore
+  public String getReference() {
+    return situations != null && !situations.isEmpty() ? situations.get(0).getReference() : null;
+  }
+
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/ScenarioMetaData.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/ScenarioMetaData.java
@@ -37,6 +37,10 @@ public class ScenarioMetaData implements Serializable {
     return corporation;
   }
 
+  /**
+   * @Deprecated use ScenarioSituation.getReference instead
+   */
+  @Deprecated
   public String getReference() {
     return reference;
   }
@@ -77,6 +81,10 @@ public class ScenarioMetaData implements Serializable {
     this.corporation = corporation;
   }
 
+  /**
+   * @Deprecated use ScenarioSituation.setReference instead
+   */
+  @Deprecated
   public void setReference(final String reference) {
     this.reference = reference;
   }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/ScenarioSituation.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/ScenarioSituation.java
@@ -42,6 +42,7 @@ public class ScenarioSituation implements Serializable {
   private String id = String.valueOf(Math.random()).substring(2);
   private int year;
   private String name;
+  private String reference;
   private SituationType type;
   private Double nettingFactor;
   private Definitions definitions = new Definitions();
@@ -73,6 +74,14 @@ public class ScenarioSituation implements Serializable {
 
   public void setName(final String name) {
     this.name = name;
+  }
+
+  public String getReference() {
+    return reference;
+  }
+
+  public void setReference(final String reference) {
+    this.reference = reference;
   }
 
   public SituationType getType() {


### PR DESCRIPTION
Moved reference from ScenarioMetaData to ScenarioSituation, and using that reference to set the references in GML.

Kept the old location in a deprecated state for easier transition.