### PR TITLE
Read missing calculation metadata as null

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLCalculationSetOptionsReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLCalculationSetOptionsReader.java
@@ -49,7 +49,7 @@ public class GMLCalculationSetOptionsReader {
   public CalculationSetOptions readCalculationSetOptions(final Theme theme) {
     final Optional<IsCalculationMetaData> optionalCheck = Optional.ofNullable(featureCollection.getMetaData()).map(MetaData::getCalculation);
     if (optionalCheck.isEmpty()) {
-      return new CalculationSetOptions();
+      return null;
     }
 
     final IsCalculationMetaData calculationMetaData = optionalCheck.get();

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLCalculationSetOptionsReaderTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLCalculationSetOptionsReaderTest.java
@@ -55,7 +55,7 @@ class GMLCalculationSetOptionsReaderTest {
     final GMLCalculationSetOptionsReader reader = new GMLCalculationSetOptionsReader(featureCollection);
 
     final CalculationSetOptions options = reader.readCalculationSetOptions(Theme.NCA);
-    assertNotNull(options, "Null metadata field should be read as empty options object");
+    assertNull(options, "Null metadata field should be read as null options object");
   }
 
   @Test
@@ -68,7 +68,7 @@ class GMLCalculationSetOptionsReaderTest {
     final GMLCalculationSetOptionsReader reader = new GMLCalculationSetOptionsReader(featureCollection);
 
     final CalculationSetOptions options = reader.readCalculationSetOptions(Theme.NCA);
-    assertNotNull(options, "Null calculation metadata field should be read as empty options object");
+    assertNull(options, "Null calculation metadata field should be read as null options object");
   }
 
   @Test

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLRoundtripTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLRoundtripTest.java
@@ -46,6 +46,7 @@ import nl.overheid.aerius.importer.ImaerImporter;
 import nl.overheid.aerius.importer.ImportOption;
 import nl.overheid.aerius.shared.domain.Substance;
 import nl.overheid.aerius.shared.domain.Theme;
+import nl.overheid.aerius.shared.domain.calculation.CalculationSetOptions;
 import nl.overheid.aerius.shared.domain.result.EmissionResultKey;
 import nl.overheid.aerius.shared.domain.result.EmissionResultType;
 import nl.overheid.aerius.shared.domain.scenario.SituationType;
@@ -260,7 +261,7 @@ public class GMLRoundtripTest {
     input.setYear(result.getSituation().getYear());
     input.setVersion("DEV");
     input.setDatabaseVersion(result.getDatabaseVersion());
-    input.setOptions(result.getCalculationSetOptions());
+    input.setOptions(result.getCalculationSetOptions() == null ? new CalculationSetOptions() : result.getCalculationSetOptions());
     input.getOptions().getSubstances().addAll(SUBSTANCES);
     input.getOptions().getEmissionResultKeys()
         .addAll(EmissionResultKey.getEmissionResultKeys(SUBSTANCES, EmissionResultType.CONCENTRATION));


### PR DESCRIPTION
Slight change in contract here, that this method can now return null instead of a new object. Benefit of this is that it's now clear when the imported parcel did not have any calculation metadata to begin with.