### PR TITLE
Remove more deprecated stuff

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLMetaDataReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLMetaDataReader.java
@@ -16,9 +16,10 @@
  */
 package nl.overheid.aerius.gml;
 
+import java.time.LocalDate;
+
 import nl.overheid.aerius.gml.base.FeatureCollection;
 import nl.overheid.aerius.gml.base.MetaData;
-import nl.overheid.aerius.shared.ImaerConstants;
 import nl.overheid.aerius.shared.domain.v2.scenario.ScenarioMetaData;
 
 /**
@@ -67,7 +68,7 @@ public class GMLMetaDataReader {
   public int readYear() {
     return checkFeatureCollection(featureCollection) && featureCollection.getMetaData().getYear() != null
         ? featureCollection.getMetaData().getYear()
-        : ImaerConstants.getCurrentYear();
+        : LocalDate.now().getYear();
   }
 
   /**

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLWriter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLWriter.java
@@ -61,16 +61,6 @@ public class GMLWriter {
    * Mimetype to be used for GML.
    */
   public static final String GML_MIMETYPE = "application/gml+xml";
-  /**
-   * @deprecated name of GML file should be determined base on context not a generic name.
-   */
-  @Deprecated
-  public static final String CURRENT_GML = "Huidige_Situatie.gml";
-  /**
-   * @deprecated name of GML file should be determined base on context not a generic name.
-   */
-  @Deprecated
-  public static final String PROPOSED_GML = "Nieuwe_Situatie.gml";
 
   /**
    * Current GML version data is exported to.

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/ImaerConstants.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/ImaerConstants.java
@@ -16,8 +16,6 @@
  */
 package nl.overheid.aerius.shared;
 
-import java.util.Date;
-
 /**
  * Global constants used in the IM AERIUS.
  */
@@ -93,19 +91,8 @@ public class ImaerConstants {
    */
   public static final int PERCENTAGE_TO_FRACTION = 100;
 
-  private static final int YEAR_OFFSET = 1900;
-
   protected ImaerConstants() {
     // Constants class
   }
 
-  /**
-   * Returns current year.
-   *
-   * Must use Date's deprecated .getYear() method because Calendar is not supported in GWT and GWT's SimpleDateFormat equivalent is not supported
-   * in GWT.
-   */
-  public static int getCurrentYear() {
-    return YEAR_OFFSET + new Date().getYear();
-  }
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationSetOptions.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationSetOptions.java
@@ -22,7 +22,6 @@ import java.util.HashSet;
 import java.util.Set;
 
 import nl.overheid.aerius.shared.domain.Substance;
-import nl.overheid.aerius.shared.domain.meteo.Meteo;
 import nl.overheid.aerius.shared.domain.result.EmissionResultKey;
 
 /**
@@ -68,19 +67,6 @@ public class CalculationSetOptions implements Serializable {
     return substances;
   }
 
-  @Deprecated
-  public void setUseWnbMaxDistance(final boolean uswWNBMaxDistance) {
-    wnbCalculationOptions.setUseWnbMaxDistance(uswWNBMaxDistance);
-  }
-
-  /**
-   * @return Returns true if WNB maximum distance calculation is to be applied.
-   */
-  @Deprecated
-  public boolean isUseWNBMaxDistance() {
-    return wnbCalculationOptions.isUseWNBMaxDistance();
-  }
-
   public boolean isStacking() {
     return stacking;
   }
@@ -116,83 +102,12 @@ public class CalculationSetOptions implements Serializable {
     this.calculateMaximumRange = calculateMaximumRange;
   }
 
-  @Deprecated
-  public boolean isForceAggregation() {
-    return wnbCalculationOptions.isForceAggregation();
-  }
-
-  /**
-   * By default some sectors are exempt from aggregation. This forces aggregation even for those sectors.
-   */
-  @Deprecated
-  public void setForceAggregation(final boolean forceAggregation) {
-    wnbCalculationOptions.setForceAggregation(forceAggregation);
-  }
-
-  @Deprecated
-  public CalculationRoadOPS getRoadOPS() {
-    if (calculationType != CalculationType.CUSTOM_POINTS) {
-      return CalculationRoadOPS.DEFAULT;
-    }
-    return wnbCalculationOptions.getRoadOPS();
-  }
-
-  @Deprecated
-  public void setRoadOPS(final CalculationRoadOPS roadOPS) {
-    wnbCalculationOptions.setRoadOPS(roadOPS);
-  }
-
-  @Deprecated
-  public boolean isIncludeMonitorSrm2Network() {
-    return rblCalculationOptions.isIncludeMonitorSrm2Network();
-  }
-
-  @Deprecated
-  public int getMonitorSrm2Year() {
-    return rblCalculationOptions.getMonitorSrm2Year();
-  }
-
-  @Deprecated
-  public void setMonitorSrm2Year(final int monitorSrm2Year) {
-    rblCalculationOptions.setMonitorSrm2Year(monitorSrm2Year);
-  }
-
-  @Deprecated
-  public Meteo getMeteo() {
-    return wnbCalculationOptions.getMeteo();
-  }
-
-  @Deprecated
-  public void setMeteo(final Meteo meteo) {
-    wnbCalculationOptions.setMeteo(meteo);
-  }
-
-  @Deprecated
-  public boolean isUseReceptorHeights() {
-    return wnbCalculationOptions.isUseReceptorHeights();
-  }
-
-  @Deprecated
-  public void setUseReceptorHeights(final boolean useReceptorHeights) {
-    wnbCalculationOptions.setUseReceptorHeights(useReceptorHeights);
-  }
-
   public ConnectSuppliedOptions getConnectSuppliedOptions() {
     return connectSuppliedOptions;
   }
 
   public void setConnectSuppliedOptions(final ConnectSuppliedOptions connectSuppliedOptions) {
     this.connectSuppliedOptions = connectSuppliedOptions;
-  }
-
-  @Deprecated
-  public OPSOptions getOpsOptions() {
-    return wnbCalculationOptions.getOpsOptions();
-  }
-
-  @Deprecated
-  public void setOpsOptions(final OPSOptions opsOptions) {
-    wnbCalculationOptions.setOpsOptions(opsOptions);
   }
 
   public WNBCalculationOptions getWnbCalculationOptions() {

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/scenario/SituationType.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/scenario/SituationType.java
@@ -16,8 +16,6 @@
  */
 package nl.overheid.aerius.shared.domain.scenario;
 
-import java.util.Arrays;
-
 /**
  * Enum indicating the type of a situation.
  */
@@ -57,14 +55,6 @@ public enum SituationType {
    * Baseline situation
    */
   BASELINE;
-
-  /**
-   * All the {@link SituationType} values, except for {@link #UNKNOWN}.
-   *
-   * @deprecated kept in so old client will/might continue to compile, to be removed soon.
-   */
-  @Deprecated
-  public static final SituationType[] KNOWN_VALUES = Arrays.copyOfRange(values(), 1, values().length);
 
   /**
    * Returns the {@link SituationType} from the given string or {@link #UNKNOWN} if null or invalid input.

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/ADMSSourceCharacteristics.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/ADMSSourceCharacteristics.java
@@ -197,11 +197,19 @@ public class ADMSSourceCharacteristics extends SourceCharacteristics {
     this.buoyancyFlux = buoyancyFlux;
   }
 
+  /**
+   * @Deprecated because not implemented in IMAER right now.
+   * Need to decide if we want to keep this or if we can safely remove it.
+   */
   @Deprecated
   public double getMassFlux() {
     return massFlux;
   }
 
+  /**
+   * @Deprecated because not implemented in IMAER right now.
+   * Need to decide if we want to keep this or if we can safely remove it.
+   */
   @Deprecated
   public void setMassFlux(final double massFlux) {
     this.massFlux = massFlux;

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/ScenarioMetaData.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/scenario/ScenarioMetaData.java
@@ -37,14 +37,6 @@ public class ScenarioMetaData implements Serializable {
     return corporation;
   }
 
-  /**
-   * @Deprecated use ScenarioSituation.getReference instead
-   */
-  @Deprecated
-  public String getReference() {
-    return reference;
-  }
-
   public String getProjectName() {
     return projectName;
   }
@@ -79,14 +71,6 @@ public class ScenarioMetaData implements Serializable {
 
   public void setCorporation(final String corporation) {
     this.corporation = corporation;
-  }
-
-  /**
-   * @Deprecated use ScenarioSituation.setReference instead
-   */
-  @Deprecated
-  public void setReference(final String reference) {
-    this.reference = reference;
   }
 
   public void setProjectName(final String projectName) {

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/FarmLodgingValidationHelper.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/FarmLodgingValidationHelper.java
@@ -30,14 +30,6 @@ public interface FarmLodgingValidationHelper {
 
   boolean canFodderApplyToLodging(String fodderMeasureCode, String lodgingCode);
 
-  /**
-   * @Deprecated Candidate for removal, should no longer be used.
-   */
-  @Deprecated(forRemoval = true)
-  default boolean expectsFarmLodgingNumberOfDays(final String systemCode) {
-    return false;
-  }
-
   FarmEmissionFactorType getLodgingEmissionFactorType(final String lodgingCode);
 
 }

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/FarmlandValidationHelper.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/FarmlandValidationHelper.java
@@ -24,22 +24,6 @@ public interface FarmlandValidationHelper {
 
   boolean isValidFarmlandStandardActivityCode(String activityCode);
 
-  /**
-   * @Deprecated Candidate for removal, should no longer be used.
-   */
-  @Deprecated(forRemoval = true)
-  default boolean expectsFarmlandNumberOfAnimals(final String activityCode) {
-    return false;
-  }
-
-  /**
-   * @Deprecated Candidate for removal, should no longer be used.
-   */
-  @Deprecated(forRemoval = true)
-  default boolean expectsFarmlandNumberOfDays(final String activityCode) {
-    return false;
-  }
-
   FarmEmissionFactorType getFarmSourceEmissionFactorType(String farmSourceCategoryCode);
 
 }


### PR DESCRIPTION
With recent release, it's time to clean up a bit.

Leftovers:
- AeriusGMLVersion (needs a decision if we want to remove these at some point)
- MassFlux in ADMSSourceCharacteristics (still used in live code, needs a proper decision)
- EmissionValueKey (still used in live code, but perhaps can limit how it's used some more)