### PR TITLE
Added validations to replace schematron

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/importer/ImportOption.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/importer/ImportOption.java
@@ -89,7 +89,10 @@ public enum ImportOption {
   VALIDATE_SOURCES,
   /**
    * If set, the input will be validated with Schematron.
+   *
+   * @deprecated as schematron validation is up for removal.
    */
+  @Deprecated(forRemoval = true)
   VALIDATE_WITH_SCHEMATRON,
   /**
    * If set, the GML file(s) warnings will be forced as exceptions. If not set, this check will do nothing and returns warnings and

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/schematron/EmissionSourceSchematronVisitor.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/schematron/EmissionSourceSchematronVisitor.java
@@ -41,6 +41,10 @@ import nl.overheid.aerius.shared.domain.v2.source.SRM2RoadEmissionSource;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 
+/**
+ * @deprecated schematron usage is up for removal. Normal validation in imaer-util should suffice.
+ */
+@Deprecated(forRemoval = true)
 public class EmissionSourceSchematronVisitor implements EmissionSourceVisitor<Void> {
 
   private final String gml;

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/schematron/ImaerSchematronValidator.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/schematron/ImaerSchematronValidator.java
@@ -43,7 +43,10 @@ import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 
 /**
  * Schematron based validator for IMAER GML files.
+ *
+ * @deprecated schematron usage is up for removal. Normal validation in imaer-util should suffice.
  */
+@Deprecated(forRemoval = true)
 public class ImaerSchematronValidator {
   private static final Logger LOG = LoggerFactory.getLogger(ImaerSchematronValidator.class);
 

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/exception/ImaerExceptionReason.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/exception/ImaerExceptionReason.java
@@ -429,6 +429,13 @@ public enum ImaerExceptionReason implements Reason {
    */
   GML_UNKNOWN_MANURE_STORAGE_CODE(5237),
 
+  /**
+   * Error that strict enforcement is used on a SRM1 source.
+   *
+   * @param 0 the id of the object containing the error.
+   */
+  SRM1_SOURCE_WITH_STRICT_ENFORCEMENT(5238),
+
   // Cohesion (between files) errors.
 
   /**
@@ -503,6 +510,19 @@ public enum ImaerExceptionReason implements Reason {
    * @param 0 Label of the building that has height <= 0.
    */
   BUILDING_HEIGHT_TOO_LOW(5241),
+
+  /**
+   * Value is <= 0.
+   *
+   * @param 0 Label of the object that has an unexpected negative value.
+   */
+  UNEXPECTED_NEGATIVE_VALUE(5251),
+  /**
+   * Fraction value is unexpected: it is either negative or higher than 1.
+   *
+   * @param 0 Label of the object that has an unexpected fraction value.
+   */
+  UNEXPECTED_FRACTION_VALUE(5252),
 
   // SRM related errors.
 

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/NSLMeasureValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/NSLMeasureValidator.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.validation;
+
+import java.util.List;
+import java.util.Optional;
+
+import nl.overheid.aerius.shared.domain.v2.base.EmissionReduction;
+import nl.overheid.aerius.shared.domain.v2.nsl.NSLMeasure;
+import nl.overheid.aerius.shared.domain.v2.nsl.NSLMeasureFeature;
+import nl.overheid.aerius.shared.exception.AeriusException;
+import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
+
+/**
+ *
+ */
+public final class NSLMeasureValidator {
+
+  NSLMeasureValidator() {
+    // Util class
+  }
+
+  public static void validateMeasures(final List<NSLMeasureFeature> measures, final List<AeriusException> exceptions,
+      final List<AeriusException> warnings) {
+    checkNegativeFactors(measures, exceptions);
+  }
+
+  private static void checkNegativeFactors(final List<NSLMeasureFeature> measureFeatures, final List<AeriusException> exceptions) {
+    for (final NSLMeasureFeature feature : measureFeatures) {
+      final NSLMeasure measure = feature.getProperties();
+      final Optional<Double> negativeValue = measure.getVehicleMeasures().stream()
+          .flatMap(x -> x.getEmissionReductions().stream())
+          .map(EmissionReduction::getFactor)
+          .filter(x -> x < 0)
+          .findFirst();
+      if (negativeValue.isPresent()) {
+        exceptions.add(new AeriusException(ImaerExceptionReason.UNEXPECTED_NEGATIVE_VALUE, measure.getLabel(), String.valueOf(negativeValue.get())));
+      }
+    }
+  }
+
+}

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/NSLMeasureValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/NSLMeasureValidator.java
@@ -17,7 +17,6 @@
 package nl.overheid.aerius.validation;
 
 import java.util.List;
-import java.util.Optional;
 
 import nl.overheid.aerius.shared.domain.v2.base.EmissionReduction;
 import nl.overheid.aerius.shared.domain.v2.nsl.NSLMeasure;
@@ -42,14 +41,13 @@ public final class NSLMeasureValidator {
   private static void checkNegativeFactors(final List<NSLMeasureFeature> measureFeatures, final List<AeriusException> exceptions) {
     for (final NSLMeasureFeature feature : measureFeatures) {
       final NSLMeasure measure = feature.getProperties();
-      final Optional<Double> negativeValue = measure.getVehicleMeasures().stream()
+      measure.getVehicleMeasures().stream()
           .flatMap(x -> x.getEmissionReductions().stream())
           .map(EmissionReduction::getFactor)
           .filter(x -> x < 0)
-          .findFirst();
-      if (negativeValue.isPresent()) {
-        exceptions.add(new AeriusException(ImaerExceptionReason.UNEXPECTED_NEGATIVE_VALUE, measure.getLabel(), String.valueOf(negativeValue.get())));
-      }
+          .findFirst()
+          .ifPresent(negativeValue -> exceptions
+              .add(new AeriusException(ImaerExceptionReason.UNEXPECTED_NEGATIVE_VALUE, measure.getLabel(), String.valueOf(negativeValue))));
     }
   }
 

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/NSLMeasureValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/NSLMeasureValidatorTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.validation;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import nl.overheid.aerius.shared.domain.Substance;
+import nl.overheid.aerius.shared.domain.v2.base.EmissionReduction;
+import nl.overheid.aerius.shared.domain.v2.nsl.NSLMeasure;
+import nl.overheid.aerius.shared.domain.v2.nsl.NSLMeasureFeature;
+import nl.overheid.aerius.shared.domain.v2.source.road.StandardVehicleMeasure;
+import nl.overheid.aerius.shared.exception.AeriusException;
+import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
+
+/**
+ *
+ */
+class NSLMeasureValidatorTest {
+
+  private static final String SOURCE_ID = "OurSourceId";
+  private static final String MEASURE_LABEL = "Some kind of measure";
+
+  @Test
+  void testValidMeasure() {
+    final NSLMeasureFeature measureFeature = new NSLMeasureFeature();
+
+    final NSLMeasure measure = new NSLMeasure();
+    measure.setGmlId(SOURCE_ID);
+    measure.setLabel(MEASURE_LABEL);
+    final StandardVehicleMeasure standardMeasure = new StandardVehicleMeasure();
+    final EmissionReduction reduction1 = new EmissionReduction();
+    reduction1.setFactor(0.4);
+    reduction1.setSubstance(Substance.NOX);
+    final EmissionReduction reduction2 = new EmissionReduction();
+    reduction2.setFactor(1.1);
+    reduction2.setSubstance(Substance.NH3);
+    standardMeasure.addEmissionReduction(reduction1);
+    standardMeasure.addEmissionReduction(reduction2);
+    measure.getVehicleMeasures().add(standardMeasure);
+    measureFeature.setProperties(measure);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+
+    NSLMeasureValidator.validateMeasures(List.of(measureFeature), errors, warnings);
+
+    assertTrue(errors.isEmpty(), "No errors");
+    assertTrue(warnings.isEmpty(), "No warnings");
+  }
+
+  @Test
+  void testNegativeFactor() {
+    final NSLMeasureFeature measureFeature = new NSLMeasureFeature();
+
+    final NSLMeasure measure = new NSLMeasure();
+    measure.setGmlId(SOURCE_ID);
+    measure.setLabel(MEASURE_LABEL);
+    final StandardVehicleMeasure standardMeasure = new StandardVehicleMeasure();
+    final EmissionReduction reduction1 = new EmissionReduction();
+    reduction1.setFactor(-0.4);
+    reduction1.setSubstance(Substance.NOX);
+    final EmissionReduction reduction2 = new EmissionReduction();
+    reduction2.setFactor(1.1);
+    reduction2.setSubstance(Substance.NH3);
+    standardMeasure.addEmissionReduction(reduction1);
+    standardMeasure.addEmissionReduction(reduction2);
+    measure.getVehicleMeasures().add(standardMeasure);
+    measureFeature.setProperties(measure);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+
+    NSLMeasureValidator.validateMeasures(List.of(measureFeature), errors, warnings);
+
+    assertEquals(1, errors.size(), "Number of errors");
+    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(ImaerExceptionReason.UNEXPECTED_NEGATIVE_VALUE, errors.get(0).getReason(), "Error reason");
+    assertArrayEquals(new Object[] {MEASURE_LABEL, String.valueOf(-0.4)}, errors.get(0).getArgs(), "Arguments");
+  }
+
+}


### PR DESCRIPTION
These are validations that are currently handled by schematron. If we want to remove schematron, we better make sure those validations are still around.

Also deprecated the classes that are most likely used outside of the library when it comes to schematron use.

This is step 1 when it comes to removing schematron.