### PR TITLE
AER-1047 Add subreceptors options

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/SubReceptorsMode.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/SubReceptorsMode.java
@@ -20,9 +20,24 @@ package nl.overheid.aerius.shared.domain.calculation;
  * Different modes we support for calculations with subreceptors.
  */
 public enum SubReceptorsMode {
+
+  /**
+   * Never use subreceptors
+   */
   DISABLED(false, false, true),
+  /**
+   * Always use subreceptors
+   */
   ENABLED(true, false, true),
+  /**
+   * Use subreceptors only when calculating receptors
+   * Do not use subreceptors when calculating custom points
+   */
   ENABLED_RECEPTORS_ONLY(true, true, true),
+  /**
+   * Always use subreceptors
+   * Also include subreceptors outside relevant habitat areas
+   */
   ENABLED_OUTSIDE_HABITATS(true, false, false);
 
   private final boolean enabled;

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/SubReceptorsMode.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/SubReceptorsMode.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.shared.domain.calculation;
+
+/**
+ * Different modes we support for calculations with subreceptors.
+ */
+public enum SubReceptorsMode {
+  DISABLED(false, false, true),
+  ENABLED(true, false, true),
+  ENABLED_RECEPTORS_ONLY(true, true, true),
+  ENABLED_OUTSIDE_HABITATS(true, false, false);
+
+  private final boolean enabled;
+  private final boolean receptorsOnly;
+  private final boolean onlyInsideHabitats;
+
+  SubReceptorsMode(final boolean enabled, final boolean receptorsOnly, final boolean onlyInsideHabitats) {
+    this.enabled = enabled;
+    this.receptorsOnly = receptorsOnly;
+    this.onlyInsideHabitats = onlyInsideHabitats;
+  }
+
+  /**
+   * Whether subreceptors should be used
+   * @return true if subreceptors are to be used
+   */
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  /**
+   * Whether subreceptors should be used
+   * @return true if subreceptors should not be used
+   */
+  public boolean isDisabled() {
+    return !isEnabled();
+  }
+
+  /**
+   * Whether subreceptors should be used on points
+   * @return true if subreceptors are to be used on points
+   */
+  public boolean isEnabledForPoints() {
+    return enabled && !receptorsOnly;
+  }
+
+  /**
+   * Whether subreceptors should only be placed inside habitats
+   * @return true if subreceptors should only be placed inside habitats
+   */
+  public boolean isOnlyInsideHabitats() {
+    return onlyInsideHabitats;
+  }
+}

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/WNBCalculationOptions.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/WNBCalculationOptions.java
@@ -41,7 +41,8 @@ public class WNBCalculationOptions implements Serializable {
   private String opsVersion;
   private String srmVersion;
 
-  private boolean disableSubReceptors;
+  private SubReceptorsMode subReceptorsMode;
+  private Integer subReceptorZoomLevel;
 
   /**
    * @return Returns true if WNB maximum distance calculation is to be applied.
@@ -89,12 +90,20 @@ public class WNBCalculationOptions implements Serializable {
     this.useReceptorHeights = useReceptorHeights;
   }
 
-  public boolean isDisableSubReceptors() {
-    return disableSubReceptors;
+  public SubReceptorsMode getSubReceptorsMode() {
+    return subReceptorsMode;
   }
 
-  public void setDisableSubReceptors(final boolean disableSubReceptors) {
-    this.disableSubReceptors = disableSubReceptors;
+  public void setSubReceptorsMode(final SubReceptorsMode subReceptorsMode) {
+    this.subReceptorsMode = subReceptorsMode;
+  }
+
+  public Integer getSubReceptorZoomLevel() {
+    return subReceptorZoomLevel;
+  }
+
+  public void setSubReceptorZoomLevel(final Integer subReceptorsZoomLevel) {
+    this.subReceptorZoomLevel = subReceptorsZoomLevel;
   }
 
   public OPSOptions getOpsOptions() {

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/util/OptionsMetadataUtil.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/util/OptionsMetadataUtil.java
@@ -50,7 +50,8 @@ public final class OptionsMetadataUtil {
     USE_RECEPTOR_HEIGHT,
     MONITOR_SRM2_YEAR,
     WITH_WNB_MAX_DISTANCE,
-    DISABLE_SUB_RECEPTORS,
+    SUB_RECEPTORS_MODE,
+    SUB_RECEPTOR_ZOOM_LEVEL,
 
     /* ConnectSuppliedOptions related */
     CALCULATION_YEAR,
@@ -143,7 +144,8 @@ public final class OptionsMetadataUtil {
     addBooleanValue(mapToAddTo, Option.FORCED_AGGREGATION, options.isForceAggregation(), addDefaults);
     addBooleanValue(mapToAddTo, Option.USE_RECEPTOR_HEIGHT, options.isUseReceptorHeights(), addDefaults);
     addBooleanValue(mapToAddTo, Option.WITH_WNB_MAX_DISTANCE, options.isUseWNBMaxDistance(), addDefaults);
-    addBooleanValue(mapToAddTo, Option.DISABLE_SUB_RECEPTORS, options.isDisableSubReceptors(), addDefaults);
+    addValue(mapToAddTo, Option.SUB_RECEPTORS_MODE, options.getSubReceptorsMode(), addDefaults);
+    addValue(mapToAddTo, Option.SUB_RECEPTOR_ZOOM_LEVEL, options.getSubReceptorZoomLevel(), addDefaults);
     opsOptionsToMap(options.getOpsOptions(), mapToAddTo, addDefaults);
   }
 

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/util/OptionsMetadataUtilTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/util/OptionsMetadataUtilTest.java
@@ -36,6 +36,7 @@ import nl.overheid.aerius.shared.domain.calculation.ConnectSuppliedOptions;
 import nl.overheid.aerius.shared.domain.calculation.NCACalculationOptions;
 import nl.overheid.aerius.shared.domain.calculation.OPSOptions;
 import nl.overheid.aerius.shared.domain.calculation.RoadLocalFractionNO2Option;
+import nl.overheid.aerius.shared.domain.calculation.SubReceptorsMode;
 import nl.overheid.aerius.shared.domain.calculation.WNBCalculationOptions;
 import nl.overheid.aerius.shared.domain.meteo.Meteo;
 
@@ -44,7 +45,7 @@ import nl.overheid.aerius.shared.domain.meteo.Meteo;
  */
 class OptionsMetadataUtilTest {
 
-  private static final int BASIC_OPTIONS = 8;
+  private static final int BASIC_OPTIONS = 9;
   private static final int CONNECT_OPTIONS = 2;
   private static final int OPS_OPTIONS = 11;
 
@@ -84,7 +85,8 @@ class OptionsMetadataUtilTest {
     options.setForceAggregation(true);
     options.setUseWnbMaxDistance(true);
     options.setUseReceptorHeights(true);
-    options.setDisableSubReceptors(true);
+    options.setSubReceptorsMode(SubReceptorsMode.ENABLED);
+    options.setSubReceptorZoomLevel(1);
     cso.getRblCalculationOptions().setMonitorSrm2Year(2023);
 
     final Map<String, String> result = OptionsMetadataUtil.optionsToMap(Theme.WNB, cso, false);
@@ -95,7 +97,8 @@ class OptionsMetadataUtilTest {
     assertEquals("OPS_ROAD", result.get("ops_road"));
     assertEquals("true", result.get("forced_aggregation"));
     assertEquals("true", result.get("use_receptor_height"));
-    assertEquals("true", result.get("disable_sub_receptors"));
+    assertEquals("ENABLED", result.get("sub_receptors_mode"));
+    assertEquals("1", result.get("sub_receptor_zoom_level"));
     assertEquals("2023", result.get("monitor_srm2_year"));
   }
 


### PR DESCRIPTION
- Removed disableSubreceptors
- Added subReceptorsMode with ENABLED_RECEPTORS_ONLY (wnb default, not selectable in Analysis), ENABLED, ENABLED_OUTSIDE_HABITATS, DISABLED (analysis default)
- Added subReceptorZoomLevel to determine the zoom level