### PR TITLE
AER-1619 heat content (and heat capacity) validation

### DIFF
--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/test/TestValidationAndEmissionHelper.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/test/TestValidationAndEmissionHelper.java
@@ -30,6 +30,7 @@ import nl.overheid.aerius.gml.base.conversion.MobileSourceOffRoadConversion;
 import nl.overheid.aerius.gml.base.conversion.PlanConversion;
 import nl.overheid.aerius.shared.domain.Substance;
 import nl.overheid.aerius.shared.domain.ops.DiurnalVariation;
+import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.domain.v2.source.road.RoadStandardEmissionFactorsKey;
@@ -470,6 +471,7 @@ public class TestValidationAndEmissionHelper implements ValidationHelper, Emissi
     characteristics.setEmissionHeight(index * 2.0);
     characteristics.setSpread(index * 1.0);
     characteristics.setHeatContent(index * 10.0);
+    characteristics.setHeatContentType(HeatContentType.NOT_FORCED);
     characteristics.setParticleSizeDistribution(index);
     characteristics.setDiurnalVariation(DiurnalVariation.INDUSTRIAL_ACTIVITY);
     return characteristics;

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/ops/OPSLimits.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/ops/OPSLimits.java
@@ -92,8 +92,14 @@ public final class OPSLimits implements BuildingLimits {
   /**
    *  source heat content (hc): fortran notation: F7.3 -> -99.999 min.
    *  RIVM: negative heat content would make no sense
+   *  However, -999 is used when heat content is derived from other properties like emission temperature.
    */
   public static final int SOURCE_HEAT_CONTENT_MINIMUM = -999;
+
+  /**
+   *  RIVM: negative heat content would make no sense
+   */
+  public static final int SOURCE_HEAT_CONTENT_SENSIBLE_MINIMUM = 0;
 
   /**
    *  source heat content (hc): fortran notation: F7.3 -> 999.999 max.

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/exception/ImaerExceptionReason.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/exception/ImaerExceptionReason.java
@@ -180,6 +180,33 @@ public enum ImaerExceptionReason implements Reason {
    */
   MISSING_METERS_SQUARED(1036),
 
+  /**
+   * Heat content was missing on an object.
+   *
+   * @param 0 the id of the object containing the error.
+   */
+  MISSING_HEAT_CONTENT(1037),
+
+  /**
+   * Heat content was out of range on an object.
+   *
+   * @param 0 the id of the object containing the error.
+   * @param 1 the value causing the problem
+   * @param 2 the minimum value allowed
+   * @param 3 the maximum value allowed
+   */
+  HEAT_CONTENT_OUT_OF_RANGE(1038),
+
+  /**
+   * Heat capacity was out of range on an object.
+   *
+   * @param 0 the id of the object containing the error.
+   * @param 1 the value causing the problem
+   * @param 2 the minimum value allowed
+   * @param 3 the maximum value allowed
+   */
+  HEAT_CAPACITY_OUT_OF_RANGE(1039),
+
   // Import GML file errors/warnings.
   /**
    * Uploaded file should contain no calculation points.

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ADMSCharacteristicsValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ADMSCharacteristicsValidator.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.validation;
+
+import java.util.List;
+
+import nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.adms.ADMSLimits;
+import nl.overheid.aerius.shared.domain.v2.characteristics.adms.SourceType;
+import nl.overheid.aerius.shared.exception.AeriusException;
+import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
+
+/**
+ * Class to validate ADMS source characteristics
+ */
+class ADMSCharacteristicsValidator extends CharacteristicsValidator<ADMSSourceCharacteristics> {
+
+  ADMSCharacteristicsValidator(final List<AeriusException> errors, final List<AeriusException> warnings, final String sourceId) {
+    super(errors, warnings, sourceId);
+  }
+
+  @Override
+  boolean validate(final ADMSSourceCharacteristics characteristics) {
+    boolean valid = true;
+    if (characteristics.getSourceType() != SourceType.VOLUME && characteristics.getSourceType() != SourceType.ROAD) {
+      valid = validateADMSHeatContent(characteristics);
+    }
+    return valid;
+  }
+
+  private boolean validateADMSHeatContent(final ADMSSourceCharacteristics characteristics) {
+    boolean valid = true;
+    if (characteristics.getSpecificHeatCapacity() < ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM
+        || characteristics.getSpecificHeatCapacity() > ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM) {
+      errors.add(new AeriusException(ImaerExceptionReason.HEAT_CAPACITY_OUT_OF_RANGE, sourceId,
+          String.valueOf(characteristics.getSpecificHeatCapacity()), String.valueOf(ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM),
+          String.valueOf(ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM)));
+      valid = false;
+    }
+    return valid;
+  }
+
+}

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/CharacteristicsValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/CharacteristicsValidator.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.validation;
+
+import java.util.List;
+
+import nl.overheid.aerius.shared.domain.ops.OPSLimits;
+import nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.adms.ADMSLimits;
+import nl.overheid.aerius.shared.domain.v2.characteristics.adms.SourceType;
+import nl.overheid.aerius.shared.exception.AeriusException;
+import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
+
+/**
+ * Class to validate source characteristics
+ */
+class CharacteristicsValidator {
+
+  private final List<AeriusException> errors;
+  private final List<AeriusException> warnings;
+  private final String sourceId;
+
+  CharacteristicsValidator(final List<AeriusException> errors, final List<AeriusException> warnings, final String sourceId) {
+    this.errors = errors;
+    this.warnings = warnings;
+    this.sourceId = sourceId;
+  }
+
+  final boolean validate(final SourceCharacteristics characteristics) {
+    if (characteristics instanceof OPSSourceCharacteristics) {
+      return validateOPSCharacteristics((OPSSourceCharacteristics) characteristics);
+    } else if (characteristics instanceof ADMSSourceCharacteristics) {
+      return validateADMSCharacteristics((ADMSSourceCharacteristics) characteristics);
+    } else {
+      return true;
+    }
+  }
+
+  private boolean validateOPSCharacteristics(final OPSSourceCharacteristics characteristics) {
+    boolean valid = true;
+    if (characteristics.getHeatContentType() == HeatContentType.FORCED) {
+      valid = validateOPSForcedHeatContent(characteristics);
+    } else if (characteristics.getHeatContentType() == HeatContentType.NOT_FORCED) {
+
+    } else {
+      errors.add(new AeriusException(ImaerExceptionReason.MISSING_HEAT_CONTENT, sourceId));
+      valid = false;
+    }
+    return valid;
+  }
+
+  private boolean validateOPSForcedHeatContent(final OPSSourceCharacteristics characteristics) {
+    boolean valid = true;
+    final Double heatContent = characteristics.getHeatContent();
+    if (heatContent == null) {
+      errors.add(new AeriusException(ImaerExceptionReason.MISSING_HEAT_CONTENT, sourceId));
+      valid = false;
+    } else if (heatContent < OPSLimits.SOURCE_HEAT_CONTENT_SENSIBLE_MINIMUM || heatContent > OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM) {
+      errors.add(new AeriusException(ImaerExceptionReason.HEAT_CONTENT_OUT_OF_RANGE, sourceId,
+          String.valueOf(characteristics.getHeatContent()), String.valueOf(OPSLimits.SOURCE_HEAT_CONTENT_SENSIBLE_MINIMUM),
+          String.valueOf(OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM)));
+      valid = false;
+    }
+    return valid;
+  }
+
+  private boolean validateADMSCharacteristics(final ADMSSourceCharacteristics characteristics) {
+    boolean valid = true;
+    if (characteristics.getSourceType() != SourceType.VOLUME && characteristics.getSourceType() != SourceType.ROAD) {
+      valid = validateADMSHeatContent(characteristics);
+    }
+    return valid;
+  }
+
+  private boolean validateADMSHeatContent(final ADMSSourceCharacteristics characteristics) {
+    boolean valid = true;
+    if (characteristics.getSpecificHeatCapacity() < ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM
+        || characteristics.getSpecificHeatCapacity() > ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM) {
+      errors.add(new AeriusException(ImaerExceptionReason.HEAT_CAPACITY_OUT_OF_RANGE, sourceId,
+          String.valueOf(characteristics.getSpecificHeatCapacity()), String.valueOf(ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM),
+          String.valueOf(ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM)));
+      valid = false;
+    }
+    return valid;
+  }
+
+}

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/CharacteristicsValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/CharacteristicsValidator.java
@@ -18,24 +18,17 @@ package nl.overheid.aerius.validation;
 
 import java.util.List;
 
-import nl.overheid.aerius.shared.domain.ops.OPSLimits;
-import nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics;
-import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
-import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
-import nl.overheid.aerius.shared.domain.v2.characteristics.adms.ADMSLimits;
-import nl.overheid.aerius.shared.domain.v2.characteristics.adms.SourceType;
 import nl.overheid.aerius.shared.exception.AeriusException;
-import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 
 /**
- * Class to validate source characteristics
+ * Base class to validate source characteristics
  */
-class CharacteristicsValidator {
+abstract class CharacteristicsValidator<T extends SourceCharacteristics> {
 
-  private final List<AeriusException> errors;
-  private final List<AeriusException> warnings;
-  private final String sourceId;
+  protected final List<AeriusException> errors;
+  protected final List<AeriusException> warnings;
+  protected final String sourceId;
 
   CharacteristicsValidator(final List<AeriusException> errors, final List<AeriusException> warnings, final String sourceId) {
     this.errors = errors;
@@ -43,62 +36,6 @@ class CharacteristicsValidator {
     this.sourceId = sourceId;
   }
 
-  final boolean validate(final SourceCharacteristics characteristics) {
-    if (characteristics instanceof OPSSourceCharacteristics) {
-      return validateOPSCharacteristics((OPSSourceCharacteristics) characteristics);
-    } else if (characteristics instanceof ADMSSourceCharacteristics) {
-      return validateADMSCharacteristics((ADMSSourceCharacteristics) characteristics);
-    } else {
-      return true;
-    }
-  }
-
-  private boolean validateOPSCharacteristics(final OPSSourceCharacteristics characteristics) {
-    boolean valid = true;
-    if (characteristics.getHeatContentType() == HeatContentType.FORCED) {
-      valid = validateOPSForcedHeatContent(characteristics);
-    } else if (characteristics.getHeatContentType() == HeatContentType.NOT_FORCED) {
-
-    } else {
-      errors.add(new AeriusException(ImaerExceptionReason.MISSING_HEAT_CONTENT, sourceId));
-      valid = false;
-    }
-    return valid;
-  }
-
-  private boolean validateOPSForcedHeatContent(final OPSSourceCharacteristics characteristics) {
-    boolean valid = true;
-    final Double heatContent = characteristics.getHeatContent();
-    if (heatContent == null) {
-      errors.add(new AeriusException(ImaerExceptionReason.MISSING_HEAT_CONTENT, sourceId));
-      valid = false;
-    } else if (heatContent < OPSLimits.SOURCE_HEAT_CONTENT_SENSIBLE_MINIMUM || heatContent > OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM) {
-      errors.add(new AeriusException(ImaerExceptionReason.HEAT_CONTENT_OUT_OF_RANGE, sourceId,
-          String.valueOf(characteristics.getHeatContent()), String.valueOf(OPSLimits.SOURCE_HEAT_CONTENT_SENSIBLE_MINIMUM),
-          String.valueOf(OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM)));
-      valid = false;
-    }
-    return valid;
-  }
-
-  private boolean validateADMSCharacteristics(final ADMSSourceCharacteristics characteristics) {
-    boolean valid = true;
-    if (characteristics.getSourceType() != SourceType.VOLUME && characteristics.getSourceType() != SourceType.ROAD) {
-      valid = validateADMSHeatContent(characteristics);
-    }
-    return valid;
-  }
-
-  private boolean validateADMSHeatContent(final ADMSSourceCharacteristics characteristics) {
-    boolean valid = true;
-    if (characteristics.getSpecificHeatCapacity() < ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM
-        || characteristics.getSpecificHeatCapacity() > ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM) {
-      errors.add(new AeriusException(ImaerExceptionReason.HEAT_CAPACITY_OUT_OF_RANGE, sourceId,
-          String.valueOf(characteristics.getSpecificHeatCapacity()), String.valueOf(ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM),
-          String.valueOf(ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM)));
-      valid = false;
-    }
-    return valid;
-  }
+  abstract boolean validate(final T characteristics);
 
 }

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/GenericSourceValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/GenericSourceValidator.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.validation;
+
+import java.util.List;
+
+import nl.overheid.aerius.shared.domain.v2.source.GenericEmissionSource;
+import nl.overheid.aerius.shared.exception.AeriusException;
+
+/**
+ *
+ */
+public class GenericSourceValidator extends SourceValidator<GenericEmissionSource> {
+
+  GenericSourceValidator(final List<AeriusException> errors, final List<AeriusException> warnings) {
+    super(errors, warnings);
+  }
+
+  @Override
+  boolean validate(final GenericEmissionSource source) {
+    return true;
+  }
+
+}

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/OPSCharacteristicsValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/OPSCharacteristicsValidator.java
@@ -36,10 +36,10 @@ class OPSCharacteristicsValidator extends CharacteristicsValidator<OPSSourceChar
   @Override
   boolean validate(final OPSSourceCharacteristics characteristics) {
     boolean valid = true;
-    if (characteristics.getHeatContentType() == HeatContentType.FORCED) {
+    if (characteristics.getHeatContentType() == HeatContentType.NOT_FORCED) {
       valid = validateOPSForcedHeatContent(characteristics);
-    } else if (characteristics.getHeatContentType() == HeatContentType.NOT_FORCED) {
-
+    } else if (characteristics.getHeatContentType() == HeatContentType.FORCED) {
+      // No validations on forced properties (yet), consider it valid.
     } else {
       errors.add(new AeriusException(ImaerExceptionReason.MISSING_HEAT_CONTENT, sourceId));
       valid = false;

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/OPSCharacteristicsValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/OPSCharacteristicsValidator.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.validation;
+
+import java.util.List;
+
+import nl.overheid.aerius.shared.domain.ops.OPSLimits;
+import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+import nl.overheid.aerius.shared.exception.AeriusException;
+import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
+
+/**
+ * Class to validate OPS source characteristics
+ */
+class OPSCharacteristicsValidator extends CharacteristicsValidator<OPSSourceCharacteristics> {
+
+  OPSCharacteristicsValidator(final List<AeriusException> errors, final List<AeriusException> warnings, final String sourceId) {
+    super(errors, warnings, sourceId);
+  }
+
+  @Override
+  boolean validate(final OPSSourceCharacteristics characteristics) {
+    boolean valid = true;
+    if (characteristics.getHeatContentType() == HeatContentType.FORCED) {
+      valid = validateOPSForcedHeatContent(characteristics);
+    } else if (characteristics.getHeatContentType() == HeatContentType.NOT_FORCED) {
+
+    } else {
+      errors.add(new AeriusException(ImaerExceptionReason.MISSING_HEAT_CONTENT, sourceId));
+      valid = false;
+    }
+    return valid;
+  }
+
+  private boolean validateOPSForcedHeatContent(final OPSSourceCharacteristics characteristics) {
+    boolean valid = true;
+    final Double heatContent = characteristics.getHeatContent();
+    if (heatContent == null) {
+      errors.add(new AeriusException(ImaerExceptionReason.MISSING_HEAT_CONTENT, sourceId));
+      valid = false;
+    } else if (heatContent < OPSLimits.SOURCE_HEAT_CONTENT_SENSIBLE_MINIMUM || heatContent > OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM) {
+      errors.add(new AeriusException(ImaerExceptionReason.HEAT_CONTENT_OUT_OF_RANGE, sourceId,
+          String.valueOf(characteristics.getHeatContent()), String.valueOf(OPSLimits.SOURCE_HEAT_CONTENT_SENSIBLE_MINIMUM),
+          String.valueOf(OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM)));
+      valid = false;
+    }
+    return valid;
+  }
+
+}

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/SourceValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/SourceValidator.java
@@ -18,6 +18,8 @@ package nl.overheid.aerius.validation;
 
 import java.util.List;
 
+import nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.domain.v2.geojson.IsFeature;
@@ -60,7 +62,13 @@ abstract class SourceValidator<T extends EmissionSource> {
   }
 
   protected boolean validateCharacteristics(final SourceCharacteristics characteristics, final String sourceId) {
-    return new CharacteristicsValidator(errors, warnings, sourceId).validate(characteristics);
+    if (characteristics instanceof OPSSourceCharacteristics) {
+      return new OPSCharacteristicsValidator(errors, warnings, sourceId).validate((OPSSourceCharacteristics) characteristics);
+    } else if (characteristics instanceof ADMSSourceCharacteristics) {
+      return new ADMSCharacteristicsValidator(errors, warnings, sourceId).validate((ADMSSourceCharacteristics) characteristics);
+    } else {
+      return true;
+    }
   }
 
 }

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/SourceValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/SourceValidator.java
@@ -18,6 +18,7 @@ package nl.overheid.aerius.validation;
 
 import java.util.List;
 
+import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.domain.v2.geojson.IsFeature;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSource;
@@ -36,8 +37,9 @@ abstract class SourceValidator<T extends EmissionSource> {
     this.warnings = warnings;
   }
 
-  boolean validate(final T source, final IsFeature feature) {
+  final boolean validate(final T source, final IsFeature feature) {
     boolean valid = validateGeometry(feature.getGeometry());
+    valid = validateCharacteristics(source.getCharacteristics(), source.getGmlId()) && valid;
     valid = validate(source) && valid;
     return valid;
   }
@@ -55,6 +57,10 @@ abstract class SourceValidator<T extends EmissionSource> {
   protected boolean validateGeometry(final Geometry geometry) {
     // By default any geometry type is valid.
     return true;
+  }
+
+  protected boolean validateCharacteristics(final SourceCharacteristics characteristics, final String sourceId) {
+    return new CharacteristicsValidator(errors, warnings, sourceId).validate(characteristics);
   }
 
 }

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ValidationVisitor.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ValidationVisitor.java
@@ -88,8 +88,7 @@ public class ValidationVisitor implements EmissionSourceVisitor<Boolean> {
 
   @Override
   public Boolean visit(final GenericEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
-    //NO-OP
-    return true;
+    return new GenericSourceValidator(errors, warnings).validate(emissionSource, feature);
   }
 
   @Override

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/ADMSCharacteristicsValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/ADMSCharacteristicsValidatorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.validation;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.adms.ADMSLimits;
+import nl.overheid.aerius.shared.domain.v2.characteristics.adms.SourceType;
+import nl.overheid.aerius.shared.exception.AeriusException;
+import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
+
+/**
+ *
+ */
+class ADMSCharacteristicsValidatorTest {
+
+  private static final String SOURCE_ID = "SomeSourceId";
+
+  @Test
+  void testOPSHeatContentNotForced() {
+    final OPSSourceCharacteristics characteristics = new OPSSourceCharacteristics();
+    characteristics.setHeatContentType(HeatContentType.NOT_FORCED);
+    characteristics.setHeatContent(-0.001);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+    final OPSCharacteristicsValidator validator = new OPSCharacteristicsValidator(errors, warnings, SOURCE_ID);
+
+    final boolean valid = validator.validate(characteristics);
+
+    // Shouldn't be validating heat content when it's not used.
+    assertTrue(valid, "Valid test case");
+    assertTrue(errors.isEmpty(), "No errors");
+    assertTrue(warnings.isEmpty(), "No warnings");
+  }
+
+  @Test
+  void testValidADMSCharacteristics() {
+    final ADMSSourceCharacteristics characteristics = new ADMSSourceCharacteristics();
+    characteristics.setSourceType(SourceType.POINT);
+    characteristics.setSpecificHeatCapacity(30.0);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+    final ADMSCharacteristicsValidator validator = new ADMSCharacteristicsValidator(errors, warnings, SOURCE_ID);
+
+    final boolean valid = validator.validate(characteristics);
+
+    assertTrue(valid, "Valid test case");
+    assertTrue(errors.isEmpty(), "No errors");
+    assertTrue(warnings.isEmpty(), "No warnings");
+  }
+
+  @ParameterizedTest
+  @MethodSource("casesForADMSHeatCapacity")
+  void testADMSHeatCapacityLimits(final SourceType sourceType, final double heatCapacity, final boolean expectedValid) {
+    final ADMSSourceCharacteristics characteristics = new ADMSSourceCharacteristics();
+    characteristics.setSourceType(sourceType);
+    characteristics.setSpecificHeatCapacity(heatCapacity);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+    final ADMSCharacteristicsValidator validator = new ADMSCharacteristicsValidator(errors, warnings, SOURCE_ID);
+
+    final boolean valid = validator.validate(characteristics);
+
+    if (expectedValid) {
+      assertTrue(valid, "Valid test case");
+      assertTrue(errors.isEmpty(), "No errors");
+      assertTrue(warnings.isEmpty(), "No warnings");
+    } else {
+      assertFalse(valid, "Invalid test case");
+      assertEquals(1, errors.size(), "Number of errors");
+      assertEquals(ImaerExceptionReason.HEAT_CAPACITY_OUT_OF_RANGE, errors.get(0).getReason(), "Error reason");
+      assertArrayEquals(new Object[] {
+          SOURCE_ID, String.valueOf(heatCapacity), "1", "100000"
+      }, errors.get(0).getArgs(), "Arguments");
+    }
+  }
+
+  private static Stream<Arguments> casesForADMSHeatCapacity() {
+    return Stream.of(
+        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, false),
+        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM, true),
+        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_DEFAULT, true),
+        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM, true),
+        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM + 0.001, false),
+        // volume and road don't use heat capacity, rest does
+        Arguments.of(SourceType.LINE, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, false),
+        Arguments.of(SourceType.AREA, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, false),
+        Arguments.of(SourceType.JET, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, false),
+        Arguments.of(SourceType.VOLUME, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, true),
+        Arguments.of(SourceType.ROAD, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, true));
+  }
+
+}

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/ADMSCharacteristicsValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/ADMSCharacteristicsValidatorTest.java
@@ -56,8 +56,8 @@ class ADMSCharacteristicsValidatorTest {
     final boolean valid = validator.validate(characteristics);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @ParameterizedTest
@@ -75,8 +75,8 @@ class ADMSCharacteristicsValidatorTest {
 
     if (expectedValid) {
       assertTrue(valid, "Valid test case");
-      assertTrue(errors.isEmpty(), "No errors");
-      assertTrue(warnings.isEmpty(), "No warnings");
+      assertEquals(List.of(), errors, "No errors");
+      assertEquals(List.of(), warnings, "No warnings");
     } else {
       assertFalse(valid, "Invalid test case");
       assertEquals(1, errors.size(), "Number of errors");

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/ADMSCharacteristicsValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/ADMSCharacteristicsValidatorTest.java
@@ -31,8 +31,6 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics;
-import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
-import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.characteristics.adms.ADMSLimits;
 import nl.overheid.aerius.shared.domain.v2.characteristics.adms.SourceType;
 import nl.overheid.aerius.shared.exception.AeriusException;
@@ -44,24 +42,6 @@ import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 class ADMSCharacteristicsValidatorTest {
 
   private static final String SOURCE_ID = "SomeSourceId";
-
-  @Test
-  void testOPSHeatContentNotForced() {
-    final OPSSourceCharacteristics characteristics = new OPSSourceCharacteristics();
-    characteristics.setHeatContentType(HeatContentType.NOT_FORCED);
-    characteristics.setHeatContent(-0.001);
-
-    final List<AeriusException> errors = new ArrayList<>();
-    final List<AeriusException> warnings = new ArrayList<>();
-    final OPSCharacteristicsValidator validator = new OPSCharacteristicsValidator(errors, warnings, SOURCE_ID);
-
-    final boolean valid = validator.validate(characteristics);
-
-    // Shouldn't be validating heat content when it's not used.
-    assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
-  }
 
   @Test
   void testValidADMSCharacteristics() {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/BuildingValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/BuildingValidatorTest.java
@@ -18,7 +18,6 @@ package nl.overheid.aerius.validation;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -47,8 +46,8 @@ class BuildingValidatorTest {
 
     BuildingValidator.validateBuildings(List.of(building), errors, warnings);
 
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -64,7 +63,7 @@ class BuildingValidatorTest {
     assertEquals(1, errors.size(), "Number of errors");
     assertEquals(ImaerExceptionReason.GML_GEOMETRY_NOT_PERMITTED, errors.get(0).getReason(), "Error reason");
     assertArrayEquals(new Object[] {BUILDING_LABEL}, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -76,7 +75,7 @@ class BuildingValidatorTest {
 
     BuildingValidator.validateBuildings(List.of(building), errors, warnings);
 
-    assertTrue(errors.isEmpty(), "No errors");
+    assertEquals(List.of(), errors, "No errors");
     assertEquals(1, warnings.size(), "Number of warnings");
     assertEquals(ImaerExceptionReason.BUILDING_HEIGHT_ZERO, warnings.get(0).getReason(), "Error reason");
     assertArrayEquals(new Object[] {BUILDING_LABEL}, warnings.get(0).getArgs(), "Arguments");
@@ -94,7 +93,7 @@ class BuildingValidatorTest {
     assertEquals(1, errors.size(), "Number of errors");
     assertEquals(ImaerExceptionReason.BUILDING_HEIGHT_TOO_LOW, errors.get(0).getReason(), "Error reason");
     assertArrayEquals(new Object[] {BUILDING_LABEL}, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -108,8 +107,8 @@ class BuildingValidatorTest {
 
     BuildingValidator.validateBuildings(List.of(building), errors, warnings);
 
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -126,7 +125,7 @@ class BuildingValidatorTest {
     assertEquals(1, errors.size(), "Number of errors");
     assertEquals(ImaerExceptionReason.CIRCULAR_BUILDING_INCORRECT_DIAMETER, errors.get(0).getReason(), "Error reason");
     assertArrayEquals(new Object[] {BUILDING_LABEL}, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   private static BuildingFeature createBuilding(final double height) {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/CIMLKMeasureValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/CIMLKMeasureValidatorTest.java
@@ -18,7 +18,6 @@ package nl.overheid.aerius.validation;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -65,8 +64,8 @@ class CIMLKMeasureValidatorTest {
 
     CIMLKMeasureValidator.validateMeasures(List.of(measureFeature), errors, warnings);
 
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -94,7 +93,7 @@ class CIMLKMeasureValidatorTest {
     CIMLKMeasureValidator.validateMeasures(List.of(measureFeature), errors, warnings);
 
     assertEquals(1, errors.size(), "Number of errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
     assertEquals(ImaerExceptionReason.UNEXPECTED_NEGATIVE_VALUE, errors.get(0).getReason(), "Error reason");
     assertArrayEquals(new Object[] {MEASURE_LABEL, String.valueOf(-0.4)}, errors.get(0).getArgs(), "Arguments");
   }

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/CharacteristicsValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/CharacteristicsValidatorTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.validation;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import nl.overheid.aerius.shared.domain.ops.OPSLimits;
+import nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
+import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.adms.ADMSLimits;
+import nl.overheid.aerius.shared.domain.v2.characteristics.adms.SourceType;
+import nl.overheid.aerius.shared.exception.AeriusException;
+import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
+
+/**
+ *
+ */
+class CharacteristicsValidatorTest {
+
+  private static final String SOURCE_ID = "SomeSourceId";
+
+  @Test
+  void testValidOPSCharacteristics() {
+    final OPSSourceCharacteristics characteristics = new OPSSourceCharacteristics();
+    characteristics.setHeatContentType(HeatContentType.FORCED);
+    characteristics.setHeatContent(30.0);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
+
+    final boolean valid = validator.validate(characteristics);
+
+    assertTrue(valid, "Valid test case");
+    assertTrue(errors.isEmpty(), "No errors");
+    assertTrue(warnings.isEmpty(), "No warnings");
+  }
+
+  @Test
+  void testOPSMissingHeatContentType() {
+    final OPSSourceCharacteristics characteristics = new OPSSourceCharacteristics();
+    characteristics.setHeatContentType(null);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
+
+    final boolean valid = validator.validate(characteristics);
+
+    assertFalse(valid, "Invalid test case");
+    assertEquals(1, errors.size(), "Number of errors");
+    assertEquals(ImaerExceptionReason.MISSING_HEAT_CONTENT, errors.get(0).getReason(), "Error reason");
+    assertArrayEquals(new Object[] {
+        SOURCE_ID
+    }, errors.get(0).getArgs(), "Arguments");
+  }
+
+  @Test
+  void testOPSMissingHeatContent() {
+    final OPSSourceCharacteristics characteristics = new OPSSourceCharacteristics();
+    characteristics.setHeatContentType(HeatContentType.FORCED);
+    characteristics.setHeatContent(null);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
+
+    final boolean valid = validator.validate(characteristics);
+
+    assertFalse(valid, "Invalid test case");
+    assertEquals(1, errors.size(), "Number of errors");
+    assertEquals(ImaerExceptionReason.MISSING_HEAT_CONTENT, errors.get(0).getReason(), "Error reason");
+    assertArrayEquals(new Object[] {
+        SOURCE_ID
+    }, errors.get(0).getArgs(), "Arguments");
+  }
+
+  @ParameterizedTest
+  @MethodSource("casesForOPSHeatContent")
+  void testOPSHeatContentLimits(final double heatContent, final boolean expectedValid) {
+    final OPSSourceCharacteristics characteristics = new OPSSourceCharacteristics();
+    characteristics.setHeatContentType(HeatContentType.FORCED);
+    characteristics.setHeatContent(heatContent);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
+
+    final boolean valid = validator.validate(characteristics);
+
+    if (expectedValid) {
+      assertTrue(valid, "Valid test case");
+      assertTrue(errors.isEmpty(), "No errors");
+      assertTrue(warnings.isEmpty(), "No warnings");
+    } else {
+      assertFalse(valid, "Invalid test case");
+      assertEquals(1, errors.size(), "Number of errors");
+      assertEquals(ImaerExceptionReason.HEAT_CONTENT_OUT_OF_RANGE, errors.get(0).getReason(), "Error reason");
+      assertArrayEquals(new Object[] {
+          SOURCE_ID, String.valueOf(heatContent), "0", "999"
+      }, errors.get(0).getArgs(), "Arguments");
+    }
+  }
+
+  private static Stream<Arguments> casesForOPSHeatContent() {
+    return Stream.of(
+        Arguments.of(OPSLimits.SOURCE_HEAT_CONTENT_SENSIBLE_MINIMUM - 0.001, false),
+        Arguments.of(OPSLimits.SOURCE_HEAT_CONTENT_SENSIBLE_MINIMUM, true),
+        Arguments.of(OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM, true),
+        Arguments.of(OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM + 0.001, false),
+        // Even though in OPS -999 is a valid value, that should only be used when another means of heat content is used (i.e. NOT_FORCED properties)
+        Arguments.of(OPSLimits.SOURCE_HEAT_CONTENT_MINIMUM, false));
+  }
+
+  @Test
+  void testOPSHeatContentNotForced() {
+    final OPSSourceCharacteristics characteristics = new OPSSourceCharacteristics();
+    characteristics.setHeatContentType(HeatContentType.NOT_FORCED);
+    characteristics.setHeatContent(-0.001);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
+
+    final boolean valid = validator.validate(characteristics);
+
+    // Shouldn't be validating heat content when it's not used.
+    assertTrue(valid, "Valid test case");
+    assertTrue(errors.isEmpty(), "No errors");
+    assertTrue(warnings.isEmpty(), "No warnings");
+  }
+
+  @Test
+  void testValidADMSCharacteristics() {
+    final ADMSSourceCharacteristics characteristics = new ADMSSourceCharacteristics();
+    characteristics.setSourceType(SourceType.POINT);
+    characteristics.setSpecificHeatCapacity(30.0);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
+
+    final boolean valid = validator.validate(characteristics);
+
+    assertTrue(valid, "Valid test case");
+    assertTrue(errors.isEmpty(), "No errors");
+    assertTrue(warnings.isEmpty(), "No warnings");
+  }
+
+  @ParameterizedTest
+  @MethodSource("casesForADMSHeatCapacity")
+  void testADMSHeatCapacityLimits(final SourceType sourceType, final double heatCapacity, final boolean expectedValid) {
+    final ADMSSourceCharacteristics characteristics = new ADMSSourceCharacteristics();
+    characteristics.setSourceType(sourceType);
+    characteristics.setSpecificHeatCapacity(heatCapacity);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
+
+    final boolean valid = validator.validate(characteristics);
+
+    if (expectedValid) {
+      assertTrue(valid, "Valid test case");
+      assertTrue(errors.isEmpty(), "No errors");
+      assertTrue(warnings.isEmpty(), "No warnings");
+    } else {
+      assertFalse(valid, "Invalid test case");
+      assertEquals(1, errors.size(), "Number of errors");
+      assertEquals(ImaerExceptionReason.HEAT_CAPACITY_OUT_OF_RANGE, errors.get(0).getReason(), "Error reason");
+      assertArrayEquals(new Object[] {
+          SOURCE_ID, String.valueOf(heatCapacity), "1", "100000"
+      }, errors.get(0).getArgs(), "Arguments");
+    }
+  }
+
+  private static Stream<Arguments> casesForADMSHeatCapacity() {
+    return Stream.of(
+        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, false),
+        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM, true),
+        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_DEFAULT, true),
+        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM, true),
+        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM + 0.001, false),
+        // volume and road don't use heat capacity, rest dos
+        Arguments.of(SourceType.LINE, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, false),
+        Arguments.of(SourceType.AREA, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, false),
+        Arguments.of(SourceType.JET, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, false),
+        Arguments.of(SourceType.VOLUME, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, true),
+        Arguments.of(SourceType.ROAD, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, true));
+  }
+
+}

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/DefinitionsValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/DefinitionsValidatorTest.java
@@ -18,7 +18,6 @@ package nl.overheid.aerius.validation;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -50,8 +49,8 @@ class DefinitionsValidatorTest {
 
     DefinitionsValidator.validateDefinitions(definitions, errors, warnings);
 
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -69,8 +68,8 @@ class DefinitionsValidatorTest {
 
     DefinitionsValidator.validateDefinitions(definitions, errors, warnings);
 
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -91,7 +90,7 @@ class DefinitionsValidatorTest {
     assertEquals(1, errors.size(), "Number of errors");
     assertEquals(ImaerExceptionReason.CUSTOM_DIURNAL_VARIATION_TYPE_UNKNOWN, errors.get(0).getReason(), "Error reason");
     assertArrayEquals(new Object[] {"null"}, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -112,7 +111,7 @@ class DefinitionsValidatorTest {
     assertEquals(1, errors.size(), "Number of errors");
     assertEquals(ImaerExceptionReason.CUSTOM_DIURNAL_VARIATION_INVALID_COUNT, errors.get(0).getReason(), "Error reason");
     assertArrayEquals(new Object[] {"24", "23"}, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -133,7 +132,7 @@ class DefinitionsValidatorTest {
     assertEquals(1, errors.size(), "Number of errors");
     assertEquals(ImaerExceptionReason.CUSTOM_DIURNAL_VARIATION_INVALID_SUM, errors.get(0).getReason(), "Error reason");
     assertArrayEquals(new Object[] {"24", "26.4"}, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   private static CustomDiurnalVariation createDiurnalVariation(final CustomDiurnalVariationType type, final List<Double> values) {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/FarmLodgingValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/FarmLodgingValidatorTest.java
@@ -62,8 +62,8 @@ class FarmLodgingValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -84,7 +84,7 @@ class FarmLodgingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, "null"
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -106,7 +106,7 @@ class FarmLodgingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -125,8 +125,8 @@ class FarmLodgingValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -149,7 +149,7 @@ class FarmLodgingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, lodgingCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -173,8 +173,8 @@ class FarmLodgingValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -202,7 +202,7 @@ class FarmLodgingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, additionalSystemCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -226,8 +226,8 @@ class FarmLodgingValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -255,7 +255,7 @@ class FarmLodgingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, reductiveSystemCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -280,8 +280,8 @@ class FarmLodgingValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -309,7 +309,7 @@ class FarmLodgingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, fodderMeasureCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -338,7 +338,7 @@ class FarmLodgingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, fodderMeasureCode, lodgingCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -360,8 +360,8 @@ class FarmLodgingValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -387,7 +387,7 @@ class FarmLodgingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   private FarmLodgingEmissionSource constructSource() {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/FarmlandValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/FarmlandValidatorTest.java
@@ -61,8 +61,8 @@ class FarmlandValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -85,7 +85,7 @@ class FarmlandValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, activityCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -110,8 +110,8 @@ class FarmlandValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -140,7 +140,7 @@ class FarmlandValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, standardActivityCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -169,7 +169,7 @@ class FarmlandValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -198,7 +198,7 @@ class FarmlandValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   private FarmlandEmissionSource constructSource() {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/ManureStorageValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/ManureStorageValidatorTest.java
@@ -185,8 +185,8 @@ class ManureStorageValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   private void assertInvalidCase(final ManureStorageEmissionSource source, final ImaerExceptionReason errorReason, final Object[] errorArguments) {
@@ -200,7 +200,7 @@ class ManureStorageValidatorTest {
     assertEquals(1, errors.size(), "Number of errors");
     assertEquals(errorReason, errors.get(0).getReason(), "Error reason");
     assertArrayEquals(errorArguments, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   private ManureStorageEmissionSource constructSource() {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/MooringInlandShippingValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/MooringInlandShippingValidatorTest.java
@@ -59,8 +59,8 @@ class MooringInlandShippingValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -86,7 +86,7 @@ class MooringInlandShippingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, shipCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   private MooringInlandShippingEmissionSource constructSource() {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/MooringMaritimeShippingValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/MooringMaritimeShippingValidatorTest.java
@@ -58,8 +58,8 @@ class MooringMaritimeShippingValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -82,7 +82,7 @@ class MooringMaritimeShippingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, shipCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   private MooringMaritimeShippingEmissionSource constructSource() {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/OPSCharacteristicsValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/OPSCharacteristicsValidatorTest.java
@@ -31,18 +31,15 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import nl.overheid.aerius.shared.domain.ops.OPSLimits;
-import nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
-import nl.overheid.aerius.shared.domain.v2.characteristics.adms.ADMSLimits;
-import nl.overheid.aerius.shared.domain.v2.characteristics.adms.SourceType;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 
 /**
  *
  */
-class CharacteristicsValidatorTest {
+class OPSCharacteristicsValidatorTest {
 
   private static final String SOURCE_ID = "SomeSourceId";
 
@@ -54,7 +51,7 @@ class CharacteristicsValidatorTest {
 
     final List<AeriusException> errors = new ArrayList<>();
     final List<AeriusException> warnings = new ArrayList<>();
-    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
+    final OPSCharacteristicsValidator validator = new OPSCharacteristicsValidator(errors, warnings, SOURCE_ID);
 
     final boolean valid = validator.validate(characteristics);
 
@@ -70,7 +67,7 @@ class CharacteristicsValidatorTest {
 
     final List<AeriusException> errors = new ArrayList<>();
     final List<AeriusException> warnings = new ArrayList<>();
-    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
+    final OPSCharacteristicsValidator validator = new OPSCharacteristicsValidator(errors, warnings, SOURCE_ID);
 
     final boolean valid = validator.validate(characteristics);
 
@@ -90,7 +87,7 @@ class CharacteristicsValidatorTest {
 
     final List<AeriusException> errors = new ArrayList<>();
     final List<AeriusException> warnings = new ArrayList<>();
-    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
+    final OPSCharacteristicsValidator validator = new OPSCharacteristicsValidator(errors, warnings, SOURCE_ID);
 
     final boolean valid = validator.validate(characteristics);
 
@@ -111,7 +108,7 @@ class CharacteristicsValidatorTest {
 
     final List<AeriusException> errors = new ArrayList<>();
     final List<AeriusException> warnings = new ArrayList<>();
-    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
+    final OPSCharacteristicsValidator validator = new OPSCharacteristicsValidator(errors, warnings, SOURCE_ID);
 
     final boolean valid = validator.validate(characteristics);
 
@@ -147,7 +144,7 @@ class CharacteristicsValidatorTest {
 
     final List<AeriusException> errors = new ArrayList<>();
     final List<AeriusException> warnings = new ArrayList<>();
-    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
+    final OPSCharacteristicsValidator validator = new OPSCharacteristicsValidator(errors, warnings, SOURCE_ID);
 
     final boolean valid = validator.validate(characteristics);
 
@@ -155,65 +152,6 @@ class CharacteristicsValidatorTest {
     assertTrue(valid, "Valid test case");
     assertTrue(errors.isEmpty(), "No errors");
     assertTrue(warnings.isEmpty(), "No warnings");
-  }
-
-  @Test
-  void testValidADMSCharacteristics() {
-    final ADMSSourceCharacteristics characteristics = new ADMSSourceCharacteristics();
-    characteristics.setSourceType(SourceType.POINT);
-    characteristics.setSpecificHeatCapacity(30.0);
-
-    final List<AeriusException> errors = new ArrayList<>();
-    final List<AeriusException> warnings = new ArrayList<>();
-    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
-
-    final boolean valid = validator.validate(characteristics);
-
-    assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
-  }
-
-  @ParameterizedTest
-  @MethodSource("casesForADMSHeatCapacity")
-  void testADMSHeatCapacityLimits(final SourceType sourceType, final double heatCapacity, final boolean expectedValid) {
-    final ADMSSourceCharacteristics characteristics = new ADMSSourceCharacteristics();
-    characteristics.setSourceType(sourceType);
-    characteristics.setSpecificHeatCapacity(heatCapacity);
-
-    final List<AeriusException> errors = new ArrayList<>();
-    final List<AeriusException> warnings = new ArrayList<>();
-    final CharacteristicsValidator validator = new CharacteristicsValidator(errors, warnings, SOURCE_ID);
-
-    final boolean valid = validator.validate(characteristics);
-
-    if (expectedValid) {
-      assertTrue(valid, "Valid test case");
-      assertTrue(errors.isEmpty(), "No errors");
-      assertTrue(warnings.isEmpty(), "No warnings");
-    } else {
-      assertFalse(valid, "Invalid test case");
-      assertEquals(1, errors.size(), "Number of errors");
-      assertEquals(ImaerExceptionReason.HEAT_CAPACITY_OUT_OF_RANGE, errors.get(0).getReason(), "Error reason");
-      assertArrayEquals(new Object[] {
-          SOURCE_ID, String.valueOf(heatCapacity), "1", "100000"
-      }, errors.get(0).getArgs(), "Arguments");
-    }
-  }
-
-  private static Stream<Arguments> casesForADMSHeatCapacity() {
-    return Stream.of(
-        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, false),
-        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM, true),
-        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_DEFAULT, true),
-        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM, true),
-        Arguments.of(SourceType.POINT, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM + 0.001, false),
-        // volume and road don't use heat capacity, rest dos
-        Arguments.of(SourceType.LINE, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, false),
-        Arguments.of(SourceType.AREA, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, false),
-        Arguments.of(SourceType.JET, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, false),
-        Arguments.of(SourceType.VOLUME, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, true),
-        Arguments.of(SourceType.ROAD, ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM - 0.001, true));
   }
 
 }

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/OPSCharacteristicsValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/OPSCharacteristicsValidatorTest.java
@@ -46,7 +46,7 @@ class OPSCharacteristicsValidatorTest {
   @Test
   void testValidOPSCharacteristics() {
     final OPSSourceCharacteristics characteristics = new OPSSourceCharacteristics();
-    characteristics.setHeatContentType(HeatContentType.FORCED);
+    characteristics.setHeatContentType(HeatContentType.NOT_FORCED);
     characteristics.setHeatContent(30.0);
 
     final List<AeriusException> errors = new ArrayList<>();
@@ -82,7 +82,7 @@ class OPSCharacteristicsValidatorTest {
   @Test
   void testOPSMissingHeatContent() {
     final OPSSourceCharacteristics characteristics = new OPSSourceCharacteristics();
-    characteristics.setHeatContentType(HeatContentType.FORCED);
+    characteristics.setHeatContentType(HeatContentType.NOT_FORCED);
     characteristics.setHeatContent(null);
 
     final List<AeriusException> errors = new ArrayList<>();
@@ -103,7 +103,7 @@ class OPSCharacteristicsValidatorTest {
   @MethodSource("casesForOPSHeatContent")
   void testOPSHeatContentLimits(final double heatContent, final boolean expectedValid) {
     final OPSSourceCharacteristics characteristics = new OPSSourceCharacteristics();
-    characteristics.setHeatContentType(HeatContentType.FORCED);
+    characteristics.setHeatContentType(HeatContentType.NOT_FORCED);
     characteristics.setHeatContent(heatContent);
 
     final List<AeriusException> errors = new ArrayList<>();
@@ -132,14 +132,14 @@ class OPSCharacteristicsValidatorTest {
         Arguments.of(OPSLimits.SOURCE_HEAT_CONTENT_SENSIBLE_MINIMUM, true),
         Arguments.of(OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM, true),
         Arguments.of(OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM + 0.001, false),
-        // Even though in OPS -999 is a valid value, that should only be used when another means of heat content is used (i.e. NOT_FORCED properties)
+        // Even though in OPS -999 is a valid value, that should only be used when another means of heat content is used (i.e. FORCED properties)
         Arguments.of(OPSLimits.SOURCE_HEAT_CONTENT_MINIMUM, false));
   }
 
   @Test
-  void testOPSHeatContentNotForced() {
+  void testOPSHeatContentForced() {
     final OPSSourceCharacteristics characteristics = new OPSSourceCharacteristics();
-    characteristics.setHeatContentType(HeatContentType.NOT_FORCED);
+    characteristics.setHeatContentType(HeatContentType.FORCED);
     characteristics.setHeatContent(-0.001);
 
     final List<AeriusException> errors = new ArrayList<>();

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/OPSCharacteristicsValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/OPSCharacteristicsValidatorTest.java
@@ -56,8 +56,8 @@ class OPSCharacteristicsValidatorTest {
     final boolean valid = validator.validate(characteristics);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -114,8 +114,8 @@ class OPSCharacteristicsValidatorTest {
 
     if (expectedValid) {
       assertTrue(valid, "Valid test case");
-      assertTrue(errors.isEmpty(), "No errors");
-      assertTrue(warnings.isEmpty(), "No warnings");
+      assertEquals(List.of(), errors, "No errors");
+      assertEquals(List.of(), warnings, "No warnings");
     } else {
       assertFalse(valid, "Invalid test case");
       assertEquals(1, errors.size(), "Number of errors");
@@ -150,8 +150,8 @@ class OPSCharacteristicsValidatorTest {
 
     // Shouldn't be validating heat content when it's not used.
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
 }

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/OffRoadValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/OffRoadValidatorTest.java
@@ -62,8 +62,8 @@ class OffRoadValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -84,8 +84,8 @@ class OffRoadValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -106,8 +106,8 @@ class OffRoadValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -128,8 +128,8 @@ class OffRoadValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -152,8 +152,8 @@ class OffRoadValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -180,7 +180,7 @@ class OffRoadValidatorTest {
     assertArrayEquals(new Object[] {
         SUB_SOURCE_DESCRIPTION
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -207,7 +207,7 @@ class OffRoadValidatorTest {
     assertArrayEquals(new Object[] {
         SUB_SOURCE_DESCRIPTION
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -234,7 +234,7 @@ class OffRoadValidatorTest {
     assertArrayEquals(new Object[] {
         SUB_SOURCE_DESCRIPTION
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -255,7 +255,7 @@ class OffRoadValidatorTest {
 
     assertFalse(valid, "Invalid test case");
     assertEquals(3, errors.size(), "Nr of errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -284,7 +284,7 @@ class OffRoadValidatorTest {
     assertArrayEquals(new Object[] {
         SUB_SOURCE_DESCRIPTION, "700.00", "1000"
     }, warnings.get(0).getArgs(), "Arguments");
-    assertTrue(errors.isEmpty(), "No errors");
+    assertEquals(List.of(), errors, "No errors");
   }
 
   private OffRoadMobileEmissionSource constructSource() {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/PlanValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/PlanValidatorTest.java
@@ -58,8 +58,8 @@ class PlanValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -82,7 +82,7 @@ class PlanValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, planCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   private PlanEmissionSource constructSource() {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/RoadValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/RoadValidatorTest.java
@@ -76,8 +76,8 @@ class RoadValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -128,8 +128,8 @@ class RoadValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -164,7 +164,7 @@ class RoadValidatorTest {
         String.valueOf(strictEnforcement),
         String.valueOf(vehicleType)
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -195,7 +195,7 @@ class RoadValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_LABEL
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -218,7 +218,7 @@ class RoadValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_LABEL
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -236,7 +236,7 @@ class RoadValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
+    assertEquals(List.of(), errors, "No errors");
     assertEquals(1, warnings.size(), "No warnings");
     assertEquals(ImaerExceptionReason.SRM2_SOURCE_NO_VEHICLES, warnings.get(0).getReason(), "Error reason");
     assertArrayEquals(new Object[] {
@@ -273,7 +273,7 @@ class RoadValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_LABEL
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -305,7 +305,7 @@ class RoadValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_LABEL
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -335,8 +335,8 @@ class RoadValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -371,7 +371,7 @@ class RoadValidatorTest {
     assertArrayEquals(new Object[] {
         String.valueOf(-0.5)
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -406,7 +406,7 @@ class RoadValidatorTest {
     assertArrayEquals(new Object[] {
         String.valueOf(1.1)
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -436,8 +436,8 @@ class RoadValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -476,7 +476,7 @@ class RoadValidatorTest {
     assertArrayEquals(new Object[] {
         String.valueOf(1.7)
     }, errors.get(1).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -499,8 +499,8 @@ class RoadValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -528,7 +528,7 @@ class RoadValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_LABEL, String.valueOf(-0.3)
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -556,7 +556,7 @@ class RoadValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_LABEL, String.valueOf(-0.5)
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -579,8 +579,8 @@ class RoadValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -608,7 +608,7 @@ class RoadValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_LABEL, String.valueOf(-0.3)
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -636,7 +636,7 @@ class RoadValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_LABEL, String.valueOf(-0.5)
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -651,8 +651,8 @@ class RoadValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -672,7 +672,7 @@ class RoadValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_LABEL, String.valueOf(-0.22)
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   private SRM1RoadEmissionSource constructSrm1Source() {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/RouteInlandShippingValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/RouteInlandShippingValidatorTest.java
@@ -65,8 +65,8 @@ class RouteInlandShippingValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -93,7 +93,7 @@ class RouteInlandShippingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, shipCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -121,7 +121,7 @@ class RouteInlandShippingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, waterwayCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -150,7 +150,7 @@ class RouteInlandShippingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, shipCode, waterwayCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -169,7 +169,7 @@ class RouteInlandShippingValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
+    assertEquals(List.of(), errors, "No errors");
     assertEquals(1, warnings.size(), "Number of warnings");
     assertEquals(ImaerExceptionReason.GML_INLAND_WATERWAY_NOT_SET, warnings.get(0).getReason(), "Warning reason");
     assertArrayEquals(new Object[] {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/RouteMaritimeShippingValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/RouteMaritimeShippingValidatorTest.java
@@ -59,8 +59,8 @@ class RouteMaritimeShippingValidatorTest {
     final boolean valid = validator.validate(source);
 
     assertTrue(valid, "Valid test case");
-    assertTrue(errors.isEmpty(), "No errors");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), errors, "No errors");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   @Test
@@ -83,7 +83,7 @@ class RouteMaritimeShippingValidatorTest {
     assertArrayEquals(new Object[] {
         SOURCE_ID, shipCode
     }, errors.get(0).getArgs(), "Arguments");
-    assertTrue(warnings.isEmpty(), "No warnings");
+    assertEquals(List.of(), warnings, "No warnings");
   }
 
   private MaritimeShippingEmissionSource constructSource() {


### PR DESCRIPTION
We didn't validate characteristics in this generic part yet (only on model objects, which is a bit limited and late in the process), so had to add some new validators.

Tbh the heat capacity isn't directly part of the issue, so that can be considered a bonus (felt wrong to just do something for OPS and leave ADMS hanging).