### PR TITLE
Adjusted farmland to not export same property twice

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/farmland/AbstractFarmlandActivity.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/farmland/AbstractFarmlandActivity.java
@@ -29,18 +29,9 @@ import nl.overheid.aerius.shared.exception.AeriusException;
 })
 public abstract class AbstractFarmlandActivity extends AbstractSubSource {
 
-  private static final long serialVersionUID = 2L;
+  private static final long serialVersionUID = 3L;
 
-  private String activityType;
   private String activityCode;
-
-  public String getActivityType() {
-    return activityType;
-  }
-
-  public void setActivityType(final String activityType) {
-    this.activityType = activityType;
-  }
 
   public String getActivityCode() {
     return activityCode;


### PR DESCRIPTION
As it was, if jackson's objectmapper was not explicitly set to exclude null properties, it would export activityType twice. While this is not really a problem when using the correct settings, it's cleaner to not have a property that we shouldn't have anyway.