### PR TITLE
AER-1006 Allow netting in 5.1 

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/metadata/MetaDataImpl.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/metadata/MetaDataImpl.java
@@ -139,7 +139,7 @@ public class MetaDataImpl implements MetaData {
 
   @Override
   public SituationType getSituationType() {
-    return situation == null ? null : situation.getSituationType();
+    return situation == null || situation.getSituationType() == null ? null : situation.getSituationType().toSituationType();
   }
 
   @Override

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/metadata/SituationMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/metadata/SituationMetadata.java
@@ -19,8 +19,8 @@ package nl.overheid.aerius.gml.v5_1.metadata;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlType;
 
+import nl.overheid.aerius.gml.base.metadata.LegacySituationType;
 import nl.overheid.aerius.gml.v5_1.base.CalculatorSchema;
-import nl.overheid.aerius.shared.domain.scenario.SituationType;
 
 /**
  *
@@ -30,7 +30,7 @@ public class SituationMetadata {
 
   private String name;
   private String reference;
-  private SituationType situationType;
+  private LegacySituationType situationType;
   private Double nettingFactor;
 
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
@@ -52,11 +52,11 @@ public class SituationMetadata {
   }
 
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
-  public SituationType getSituationType() {
+  public LegacySituationType getSituationType() {
     return situationType;
   }
 
-  public void setSituationType(final SituationType situationType) {
+  public void setSituationType(final LegacySituationType situationType) {
     this.situationType = situationType;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/GMLVersionWriterV51.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/GMLVersionWriterV51.java
@@ -31,6 +31,7 @@ import nl.overheid.aerius.gml.base.MetaDataInput;
 import nl.overheid.aerius.gml.base.OtherSituationMetaData;
 import nl.overheid.aerius.gml.base.StringUtils;
 import nl.overheid.aerius.gml.base.geo.Geometry2GML;
+import nl.overheid.aerius.gml.base.metadata.LegacySituationType;
 import nl.overheid.aerius.gml.v5_1.base.CalculatorSchema;
 import nl.overheid.aerius.gml.v5_1.collection.FeatureCollectionImpl;
 import nl.overheid.aerius.gml.v5_1.definitions.CustomDiurnalVariation;
@@ -122,7 +123,7 @@ public class GMLVersionWriterV51 implements GMLVersionWriter {
       situation = new SituationMetadata();
       situation.setName(input.getName());
       situation.setReference(input.getReference());
-      situation.setSituationType(input.getSituationType());
+      situation.setSituationType(LegacySituationType.safeValueOf(input.getSituationType() != null ? input.getSituationType().name() : null));
       situation.setNettingFactor(input.getNettingFactor());
     }
     return situation;


### PR DESCRIPTION
the situationtype `NETTING` is valid in version 5.1 according to its xsd (and can now be exported from production). But it could not be read, and would be defaulted back to PROPOSED.