### PR TITLE
Ensuring ID for subpoints includes both subpoint ID and receptor ID

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/Result2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/togml/Result2GML.java
@@ -28,10 +28,10 @@ import nl.overheid.aerius.gml.base.geo.Geometry2GML;
 import nl.overheid.aerius.gml.v5_0.base.CalculatorSchema;
 import nl.overheid.aerius.gml.v5_0.geo.Polygon;
 import nl.overheid.aerius.gml.v5_0.result.AbstractCalculationPoint;
+import nl.overheid.aerius.gml.v5_0.result.CIMLKCalculationPoint;
 import nl.overheid.aerius.gml.v5_0.result.CalculationPointCorrection;
 import nl.overheid.aerius.gml.v5_0.result.CalculationPointCorrectionProperty;
 import nl.overheid.aerius.gml.v5_0.result.CustomCalculationPoint;
-import nl.overheid.aerius.gml.v5_0.result.CIMLKCalculationPoint;
 import nl.overheid.aerius.gml.v5_0.result.ReceptorPoint;
 import nl.overheid.aerius.gml.v5_0.result.Result;
 import nl.overheid.aerius.gml.v5_0.result.ResultProperty;
@@ -41,9 +41,9 @@ import nl.overheid.aerius.shared.domain.geo.HexagonUtil;
 import nl.overheid.aerius.shared.domain.geo.HexagonZoomLevel;
 import nl.overheid.aerius.shared.domain.result.EmissionResultKey;
 import nl.overheid.aerius.shared.domain.result.EmissionResultType;
+import nl.overheid.aerius.shared.domain.v2.cimlk.CIMLKCorrection;
 import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.domain.v2.geojson.Point;
-import nl.overheid.aerius.shared.domain.v2.cimlk.CIMLKCorrection;
 import nl.overheid.aerius.shared.domain.v2.point.CalculationPoint;
 import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
 import nl.overheid.aerius.shared.exception.AeriusException;
@@ -76,8 +76,7 @@ final class Result2GML {
     final AbstractCalculationPoint returnPoint = determineSpecificType(point, feature.getGeometry());
     //set the generic properties.
     returnPoint.setGeometry(geometry2gml, feature.getGeometry());
-    //avoid conflicting IDs by using a prefix.
-    returnPoint.setId(GMLIdUtil.toValidGmlId(point.getGmlId(), GMLIdUtil.POINT_PREFIX, String.valueOf(point.getId())));
+    returnPoint.setId(determineId(point));
     returnPoint.setLabel(point.getLabel());
     returnPoint.setDescription(point.getDescription());
     returnPoint.setJurisdictionId(point.getJurisdictionId());
@@ -89,6 +88,16 @@ final class Result2GML {
     returnPoint.setResults(getResults(point, substances));
     returnPoint.setCorrections(getCorrections(point, corrections));
     return returnPoint;
+  }
+
+  private String determineId(final CalculationPoint point) {
+    //avoid conflicting IDs by using a prefix.
+    if (point instanceof nl.overheid.aerius.shared.domain.v2.point.SubPoint) {
+      final nl.overheid.aerius.shared.domain.v2.point.SubPoint subPoint = (nl.overheid.aerius.shared.domain.v2.point.SubPoint) point;
+      return GMLIdUtil.toValidGmlId(point.getGmlId(), GMLIdUtil.SUB_POINT_PREFIX, subPoint.getReceptorId() + "_" + subPoint.getSubPointId());
+    } else {
+      return GMLIdUtil.toValidGmlId(point.getGmlId(), GMLIdUtil.POINT_PREFIX, String.valueOf(point.getId()));
+    }
   }
 
   private AbstractCalculationPoint determineSpecificType(final CalculationPoint aeriusPoint, final Point point) throws AeriusException {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/Result2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/Result2GML.java
@@ -78,8 +78,7 @@ final class Result2GML {
     final AbstractCalculationPoint returnPoint = determineSpecificType(point, feature.getGeometry());
     //set the generic properties.
     returnPoint.setGeometry(geometry2gml, feature.getGeometry());
-    //avoid conflicting IDs by using a prefix.
-    returnPoint.setId(GMLIdUtil.toValidGmlId(point.getGmlId(), GMLIdUtil.POINT_PREFIX, String.valueOf(point.getId())));
+    returnPoint.setId(determineId(point));
     returnPoint.setLabel(point.getLabel());
     returnPoint.setDescription(point.getDescription());
     returnPoint.setJurisdictionId(point.getJurisdictionId());
@@ -91,6 +90,16 @@ final class Result2GML {
     returnPoint.setResults(getResults(point, substances));
     returnPoint.setCorrections(getCorrections(point, corrections));
     return returnPoint;
+  }
+
+  private String determineId(final CalculationPoint point) {
+    //avoid conflicting IDs by using a prefix.
+    if (point instanceof nl.overheid.aerius.shared.domain.v2.point.SubPoint) {
+      final nl.overheid.aerius.shared.domain.v2.point.SubPoint subPoint = (nl.overheid.aerius.shared.domain.v2.point.SubPoint) point;
+      return GMLIdUtil.toValidGmlId(point.getGmlId(), GMLIdUtil.SUB_POINT_PREFIX, subPoint.getReceptorId() + "_" + subPoint.getSubPointId());
+    } else {
+      return GMLIdUtil.toValidGmlId(point.getGmlId(), GMLIdUtil.POINT_PREFIX, String.valueOf(point.getId()));
+    }
   }
 
   private AbstractCalculationPoint determineSpecificType(final CalculationPoint aeriusPoint, final Point point) throws AeriusException {

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLReaderTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLReaderTest.java
@@ -113,7 +113,7 @@ class GMLReaderTest {
     final File file = getFile(AssertGML.PATH_LATEST_VERSION, RECEPTORS_FILE);
     final List<CalculationPointFeature> points = getAeriusPointsFromFile(file, true);
     assertNotNull(points, "Receptor points");
-    assertEquals(4, points.size(), "Number of receptor points");
+    assertEquals(5, points.size(), "Number of receptor points");
   }
 
   @Test
@@ -135,7 +135,7 @@ class GMLReaderTest {
     final File file = getFile(AssertGML.PATH_LATEST_VERSION, MIXED_FEATURES_FILE);
     final List<CalculationPointFeature> points = getAeriusPointsFromFile(file, true);
     assertNotNull(points, "Receptor points");
-    assertEquals(4, points.size(), "Number of receptor points");
+    assertEquals(5, points.size(), "Number of receptor points");
 
     final List<EmissionSourceFeature> sources = getEmissionSourcesFromFile(file);
     assertNotNull(sources, "Emission sources");
@@ -254,14 +254,14 @@ class GMLReaderTest {
       final List<CalculationPointFeature> points = getAeriusPointsFromFile(file, true);
       assertNotNull(points, "Receptor points");
       // In older versions there are only a receptor and 2 calculation points
-      // In newer versions (> 5.0) a sub point is added
-      assertTrue(3 == points.size() || 4 == points.size(), "Number of receptor points");
+      // In newer versions (> 5.0) sub points are added
+      assertTrue(3 == points.size() || 5 == points.size(), "Number of receptor points");
     }
     files = getFiles(PATH_ALL, MIXED_FEATURES_FILE);
     for (final File file : files) {
       final List<CalculationPointFeature> points = getAeriusPointsFromFile(file, true);
       assertNotNull(points, "Receptor points");
-      assertTrue(3 == points.size() || 4 == points.size(), "Number of receptor points");
+      assertTrue(3 == points.size() || 5 == points.size(), "Number of receptor points");
       assertFalse(points.get(0).getProperties().getResults().isEmpty(), "Results included");
       final List<EmissionSourceFeature> sources = getEmissionSourcesFromFile(file);
       assertNotNull(sources, "Emission sources for " + file);

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterTest.java
@@ -335,6 +335,26 @@ class GMLWriterTest {
     feature4.setProperties(calculationPoint4);
     receptors.add(feature4);
 
+    final int xCoord5 = xCoord1 - 20;
+    final int yCoord5 = yCoord1 - 20;
+    final CalculationPointFeature feature5 = new CalculationPointFeature();
+    final Point point5 = new Point(xCoord5, yCoord5);
+    feature5.setGeometry(point5);
+    final SubPoint calculationPoint5 = new SubPoint();
+    calculationPoint5.setSubPointId(19);
+    calculationPoint5.setReceptorId(calculationPoint1.getId() + 1);
+    calculationPoint5.setLevel(2);
+    if (includeDeposition) {
+      calculationPoint5.getResults().put(EmissionResultKey.NH3_DEPOSITION, 182.31);
+      calculationPoint5.getResults().put(EmissionResultKey.NOX_DEPOSITION, 22.3);
+    }
+    if (includeConcentration) {
+      calculationPoint5.getResults().put(EmissionResultKey.NH3_CONCENTRATION, 42.42);
+      calculationPoint5.getResults().put(EmissionResultKey.NOX_CONCENTRATION, 5.0);
+    }
+    feature5.setProperties(calculationPoint5);
+    receptors.add(feature5);
+
     return receptors;
   }
 

--- a/source/imaer-gml/src/test/resources/gml/v5_0/test_mixed_features.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_0/test_mixed_features.gml
@@ -236,15 +236,15 @@
         </imaer:CalculationPoint>
     </imaer:featureMember>
     <imaer:featureMember>
-        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="CP.19">
+        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="SP.1_19">
             <imaer:identifier>
                 <imaer:NEN3610ID>
                     <imaer:namespace>NL.IMAER</imaer:namespace>
-                    <imaer:localId>CP.19</imaer:localId>
+                    <imaer:localId>SP.1_19</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
             <imaer:GM_Point>
-                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.19.POINT">
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.1_19.POINT">
                     <gml:pos>137548.0 137548.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
@@ -256,6 +256,32 @@
             <imaer:result>
                 <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
                     <imaer:value>32.1</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:level>2</imaer:level>
+        </imaer:SubPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:SubPoint receptorPointId="2" subPointId="19" gml:id="SP.2_19">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>SP.2_19</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.2_19.POINT">
+                    <gml:pos>137538.0 456231.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NH3">
+                    <imaer:value>182.31</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
+                    <imaer:value>22.3</imaer:value>
                 </imaer:CalculationResult>
             </imaer:result>
             <imaer:level>2</imaer:level>

--- a/source/imaer-gml/src/test/resources/gml/v5_0/test_receptors.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_0/test_receptors.gml
@@ -144,15 +144,15 @@
         </imaer:CalculationPoint>
     </imaer:featureMember>
     <imaer:featureMember>
-        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="CP.19">
+        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="SP.1_19">
             <imaer:identifier>
                 <imaer:NEN3610ID>
                     <imaer:namespace>NL.IMAER</imaer:namespace>
-                    <imaer:localId>CP.19</imaer:localId>
+                    <imaer:localId>SP.1_19</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
             <imaer:GM_Point>
-                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.19.POINT">
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.1_19.POINT">
                     <gml:pos>137548.0 137548.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
@@ -174,6 +174,42 @@
             <imaer:result>
                 <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
                     <imaer:value>32.1</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:level>2</imaer:level>
+        </imaer:SubPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:SubPoint receptorPointId="2" subPointId="19" gml:id="SP.2_19">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>SP.2_19</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.2_19.POINT">
+                    <gml:pos>137538.0 456231.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NH3">
+                    <imaer:value>42.42</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NH3">
+                    <imaer:value>182.31</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NOX">
+                    <imaer:value>5.0</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
+                    <imaer:value>22.3</imaer:value>
                 </imaer:CalculationResult>
             </imaer:result>
             <imaer:level>2</imaer:level>

--- a/source/imaer-gml/src/test/resources/gml/v5_0/test_receptors_concentration_only.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_0/test_receptors_concentration_only.gml
@@ -109,15 +109,15 @@
         </imaer:CalculationPoint>
     </imaer:featureMember>
     <imaer:featureMember>
-        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="CP.19">
+        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="SP.1_19">
             <imaer:identifier>
                 <imaer:NEN3610ID>
                     <imaer:namespace>NL.IMAER</imaer:namespace>
-                    <imaer:localId>CP.19</imaer:localId>
+                    <imaer:localId>SP.1_19</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
             <imaer:GM_Point>
-                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.19.POINT">
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.1_19.POINT">
                     <gml:pos>137548.0 137548.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
@@ -129,6 +129,32 @@
             <imaer:result>
                 <imaer:CalculationResult resultType="CONCENTRATION" substance="NOX">
                     <imaer:value>9.006</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:level>2</imaer:level>
+        </imaer:SubPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:SubPoint receptorPointId="2" subPointId="19" gml:id="SP.2_19">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>SP.2_19</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.2_19.POINT">
+                    <gml:pos>137538.0 456231.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NH3">
+                    <imaer:value>42.42</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NOX">
+                    <imaer:value>5.0</imaer:value>
                 </imaer:CalculationResult>
             </imaer:result>
             <imaer:level>2</imaer:level>

--- a/source/imaer-gml/src/test/resources/gml/v5_0/test_receptors_deposition_only.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_0/test_receptors_deposition_only.gml
@@ -109,15 +109,15 @@
         </imaer:CalculationPoint>
     </imaer:featureMember>
     <imaer:featureMember>
-        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="CP.19">
+        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="SP.1_19">
             <imaer:identifier>
                 <imaer:NEN3610ID>
                     <imaer:namespace>NL.IMAER</imaer:namespace>
-                    <imaer:localId>CP.19</imaer:localId>
+                    <imaer:localId>SP.1_19</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
             <imaer:GM_Point>
-                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.19.POINT">
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.1_19.POINT">
                     <gml:pos>137548.0 137548.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
@@ -129,6 +129,32 @@
             <imaer:result>
                 <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
                     <imaer:value>32.1</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:level>2</imaer:level>
+        </imaer:SubPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:SubPoint receptorPointId="2" subPointId="19" gml:id="SP.2_19">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>SP.2_19</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.2_19.POINT">
+                    <gml:pos>137538.0 456231.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NH3">
+                    <imaer:value>182.31</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
+                    <imaer:value>22.3</imaer:value>
                 </imaer:CalculationResult>
             </imaer:result>
             <imaer:level>2</imaer:level>

--- a/source/imaer-gml/src/test/resources/gml/v5_0/test_receptors_edge_effect.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_0/test_receptors_edge_effect.gml
@@ -154,15 +154,15 @@
         </imaer:CalculationPoint>
     </imaer:featureMember>
     <imaer:featureMember>
-        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="CP.19">
+        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="SP.1_19">
             <imaer:identifier>
                 <imaer:NEN3610ID>
                     <imaer:namespace>NL.IMAER</imaer:namespace>
-                    <imaer:localId>CP.19</imaer:localId>
+                    <imaer:localId>SP.1_19</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
             <imaer:GM_Point>
-                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.19.POINT">
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.1_19.POINT">
                     <gml:pos>137548.0 137548.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
@@ -184,6 +184,42 @@
             <imaer:result>
                 <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
                     <imaer:value>32.1</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:level>2</imaer:level>
+        </imaer:SubPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:SubPoint receptorPointId="2" subPointId="19" gml:id="SP.2_19">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>SP.2_19</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.2_19.POINT">
+                    <gml:pos>137538.0 456231.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NH3">
+                    <imaer:value>42.42</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NH3">
+                    <imaer:value>182.31</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NOX">
+                    <imaer:value>5.0</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
+                    <imaer:value>22.3</imaer:value>
                 </imaer:CalculationResult>
             </imaer:result>
             <imaer:level>2</imaer:level>

--- a/source/imaer-gml/src/test/resources/gml/v5_1/test_mixed_features.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_1/test_mixed_features.gml
@@ -243,15 +243,15 @@
         </imaer:CalculationPoint>
     </imaer:featureMember>
     <imaer:featureMember>
-        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="CP.19">
+        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="SP.1_19">
             <imaer:identifier>
                 <imaer:NEN3610ID>
                     <imaer:namespace>NL.IMAER</imaer:namespace>
-                    <imaer:localId>CP.19</imaer:localId>
+                    <imaer:localId>SP.1_19</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
             <imaer:GM_Point>
-                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.19.POINT">
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.1_19.POINT">
                     <gml:pos>137548.0 137548.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
@@ -263,6 +263,32 @@
             <imaer:result>
                 <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
                     <imaer:value>32.1</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:level>2</imaer:level>
+        </imaer:SubPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:SubPoint receptorPointId="2" subPointId="19" gml:id="SP.2_19">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>SP.2_19</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.2_19.POINT">
+                    <gml:pos>137538.0 456231.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NH3">
+                    <imaer:value>182.31</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
+                    <imaer:value>22.3</imaer:value>
                 </imaer:CalculationResult>
             </imaer:result>
             <imaer:level>2</imaer:level>

--- a/source/imaer-gml/src/test/resources/gml/v5_1/test_receptors.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_1/test_receptors.gml
@@ -151,15 +151,15 @@
         </imaer:CalculationPoint>
     </imaer:featureMember>
     <imaer:featureMember>
-        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="CP.19">
+        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="SP.1_19">
             <imaer:identifier>
                 <imaer:NEN3610ID>
                     <imaer:namespace>NL.IMAER</imaer:namespace>
-                    <imaer:localId>CP.19</imaer:localId>
+                    <imaer:localId>SP.1_19</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
             <imaer:GM_Point>
-                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.19.POINT">
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.1_19.POINT">
                     <gml:pos>137548.0 137548.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
@@ -181,6 +181,42 @@
             <imaer:result>
                 <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
                     <imaer:value>32.1</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:level>2</imaer:level>
+        </imaer:SubPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:SubPoint receptorPointId="2" subPointId="19" gml:id="SP.2_19">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>SP.2_19</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.2_19.POINT">
+                    <gml:pos>137538.0 456231.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NH3">
+                    <imaer:value>42.42</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NH3">
+                    <imaer:value>182.31</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NOX">
+                    <imaer:value>5.0</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
+                    <imaer:value>22.3</imaer:value>
                 </imaer:CalculationResult>
             </imaer:result>
             <imaer:level>2</imaer:level>

--- a/source/imaer-gml/src/test/resources/gml/v5_1/test_receptors_concentration_only.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_1/test_receptors_concentration_only.gml
@@ -116,15 +116,15 @@
         </imaer:CalculationPoint>
     </imaer:featureMember>
     <imaer:featureMember>
-        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="CP.19">
+        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="SP.1_19">
             <imaer:identifier>
                 <imaer:NEN3610ID>
                     <imaer:namespace>NL.IMAER</imaer:namespace>
-                    <imaer:localId>CP.19</imaer:localId>
+                    <imaer:localId>SP.1_19</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
             <imaer:GM_Point>
-                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.19.POINT">
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.1_19.POINT">
                     <gml:pos>137548.0 137548.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
@@ -136,6 +136,32 @@
             <imaer:result>
                 <imaer:CalculationResult resultType="CONCENTRATION" substance="NOX">
                     <imaer:value>9.006</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:level>2</imaer:level>
+        </imaer:SubPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:SubPoint receptorPointId="2" subPointId="19" gml:id="SP.2_19">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>SP.2_19</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.2_19.POINT">
+                    <gml:pos>137538.0 456231.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NH3">
+                    <imaer:value>42.42</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NOX">
+                    <imaer:value>5.0</imaer:value>
                 </imaer:CalculationResult>
             </imaer:result>
             <imaer:level>2</imaer:level>

--- a/source/imaer-gml/src/test/resources/gml/v5_1/test_receptors_deposition_only.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_1/test_receptors_deposition_only.gml
@@ -116,15 +116,15 @@
         </imaer:CalculationPoint>
     </imaer:featureMember>
     <imaer:featureMember>
-        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="CP.19">
+        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="SP.1_19">
             <imaer:identifier>
                 <imaer:NEN3610ID>
                     <imaer:namespace>NL.IMAER</imaer:namespace>
-                    <imaer:localId>CP.19</imaer:localId>
+                    <imaer:localId>SP.1_19</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
             <imaer:GM_Point>
-                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.19.POINT">
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.1_19.POINT">
                     <gml:pos>137548.0 137548.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
@@ -136,6 +136,32 @@
             <imaer:result>
                 <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
                     <imaer:value>32.1</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:level>2</imaer:level>
+        </imaer:SubPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:SubPoint receptorPointId="2" subPointId="19" gml:id="SP.2_19">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>SP.2_19</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.2_19.POINT">
+                    <gml:pos>137538.0 456231.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NH3">
+                    <imaer:value>182.31</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
+                    <imaer:value>22.3</imaer:value>
                 </imaer:CalculationResult>
             </imaer:result>
             <imaer:level>2</imaer:level>

--- a/source/imaer-gml/src/test/resources/gml/v5_1/test_receptors_edge_effect.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_1/test_receptors_edge_effect.gml
@@ -161,15 +161,15 @@
         </imaer:CalculationPoint>
     </imaer:featureMember>
     <imaer:featureMember>
-        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="CP.19">
+        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="SP.1_19">
             <imaer:identifier>
                 <imaer:NEN3610ID>
                     <imaer:namespace>NL.IMAER</imaer:namespace>
-                    <imaer:localId>CP.19</imaer:localId>
+                    <imaer:localId>SP.1_19</imaer:localId>
                 </imaer:NEN3610ID>
             </imaer:identifier>
             <imaer:GM_Point>
-                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.19.POINT">
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.1_19.POINT">
                     <gml:pos>137548.0 137548.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
@@ -191,6 +191,42 @@
             <imaer:result>
                 <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
                     <imaer:value>32.1</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:level>2</imaer:level>
+        </imaer:SubPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:SubPoint receptorPointId="2" subPointId="19" gml:id="SP.2_19">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>SP.2_19</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.2_19.POINT">
+                    <gml:pos>137538.0 456231.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NH3">
+                    <imaer:value>42.42</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NH3">
+                    <imaer:value>182.31</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NOX">
+                    <imaer:value>5.0</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
+                    <imaer:value>22.3</imaer:value>
                 </imaer:CalculationResult>
             </imaer:result>
             <imaer:level>2</imaer:level>

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/util/gml/GMLIdUtil.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/util/gml/GMLIdUtil.java
@@ -26,6 +26,7 @@ public final class GMLIdUtil {
 
   public static final String SOURCE_PREFIX = "ES";
   public static final String POINT_PREFIX = "CP";
+  public static final String SUB_POINT_PREFIX = "SP";
   public static final String MEASURE_PREFIX = "RMA";
   public static final String BUILDING_PREFIX = "Building";
   public static final String DIURNAL_VARIATION_PREFIX = "DV";


### PR DESCRIPTION
As this combination is going to be unique, it makes sense to have these IDs be combined in the default GML ID(s). Added a second point with the same subpoint ID to the existing test cases: these would fail some tests in the old situation.