### PR TITLE
Excluding some packages from GWT

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/archive/ArchiveMetaData.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/archive/ArchiveMetaData.java
@@ -16,6 +16,7 @@
  */
 package nl.overheid.aerius.shared.domain.v2.archive;
 
+import java.io.Serializable;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,7 +24,9 @@ import java.util.List;
 /**
  * Metadata information related to Archive.
  */
-public class ArchiveMetaData {
+public class ArchiveMetaData implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   private ZonedDateTime retrievalDateTime;
   private List<ArchiveProject> archiveProjects = new ArrayList<>();

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/archive/ArchiveProject.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/archive/ArchiveProject.java
@@ -16,10 +16,14 @@
  */
 package nl.overheid.aerius.shared.domain.v2.archive;
 
+import java.io.Serializable;
+
 /**
  * A project in archive.
  */
-public class ArchiveProject {
+public class ArchiveProject implements Serializable {
+
+  private static final long serialVersionUID = 1L;
 
   private String id;
   private String name;

--- a/source/imaer-shared/src/main/resources/nl/overheid/aerius/ImaerShared.gwt.xml
+++ b/source/imaer-shared/src/main/resources/nl/overheid/aerius/ImaerShared.gwt.xml
@@ -18,6 +18,9 @@
 -->
 <module>
   <super-source path="super" />
-  <source path="geo"/>
-  <source path="shared"/>
+  <source path="geo" />
+  <source path="shared">
+    <exclude name="**/v2/importer/**" />
+    <exclude name="**/v2/archive/**" />
+  </source>
 </module>

--- a/source/imaer-shared/src/main/resources/nl/overheid/aerius/ImaerShared.gwt.xml
+++ b/source/imaer-shared/src/main/resources/nl/overheid/aerius/ImaerShared.gwt.xml
@@ -19,8 +19,5 @@
 <module>
   <super-source path="super" />
   <source path="geo" />
-  <source path="shared">
-    <exclude name="**/v2/importer/**" />
-    <exclude name="**/v2/archive/**" />
-  </source>
+  <source path="shared" />
 </module>

--- a/source/imaer-shared/src/main/resources/nl/overheid/aerius/ImaerShared.gwt.xml
+++ b/source/imaer-shared/src/main/resources/nl/overheid/aerius/ImaerShared.gwt.xml
@@ -18,6 +18,6 @@
 -->
 <module>
   <super-source path="super" />
-  <source path="geo" />
-  <source path="shared" />
+  <source path="geo"/>
+  <source path="shared"/>
 </module>

--- a/source/imaer-shared/src/main/resources/nl/overheid/aerius/super/java/time/ZonedDateTime.java
+++ b/source/imaer-shared/src/main/resources/nl/overheid/aerius/super/java/time/ZonedDateTime.java
@@ -1,0 +1,7 @@
+// GWT wrapper object for java.time.ZonedDateTime.
+// Needed to use imaer-shared in GWT context as ZonedDateTime is used, although the object using it is not used on the client, but is on the classpath.
+package java.time;
+
+public class ZonedDateTime {
+
+}


### PR DESCRIPTION
ArchiveMetaData contains ZonedDateTime, and that is not emulated by GWT apparantly. To avoid having to resort to some other way (string perhaps?), we might as well exclude some packages, as these shouldn't be serialized to GWT code anyway.