### PR TITLE
Changed ZonedDateTime to OffsetDateTime for archive retrieval date

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLScenarioHelper.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLScenarioHelper.java
@@ -26,6 +26,7 @@ import nl.overheid.aerius.shared.domain.scenario.IsScenario;
 import nl.overheid.aerius.shared.domain.v2.archive.ArchiveMetaData;
 import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
 import nl.overheid.aerius.shared.domain.v2.scenario.Scenario;
+import nl.overheid.aerius.shared.domain.v2.scenario.ScenarioMetaData;
 import nl.overheid.aerius.shared.domain.v2.scenario.ScenarioSituation;
 
 /**
@@ -65,11 +66,13 @@ public final class GMLScenarioHelper {
       final String aeriusVersion, final String databaseVersion) {
     final MetaDataInput metaData = new MetaDataInput();
     metaData.setTheme(scenario.getTheme());
+    metaData.setScenarioMetaData(new ScenarioMetaData());
     metaData.setArchiveMetaData(archiveMetaData);
     metaData.setYear(year);
     metaData.setVersion(aeriusVersion);
     metaData.setDatabaseVersion(databaseVersion);
     metaData.setOptions(scenario.getOptions());
+    metaData.setResultsIncluded(true);
     scenario.getSituations().stream()
         .map(GMLScenarioHelper::otherSituation)
         .forEach(metaData::addOtherSituation);

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/IsArchiveMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/IsArchiveMetadata.java
@@ -16,7 +16,7 @@
  */
 package nl.overheid.aerius.gml.base;
 
-import java.time.ZonedDateTime;
+import java.time.OffsetDateTime;
 import java.util.List;
 
 /**
@@ -24,7 +24,7 @@ import java.util.List;
  */
 public interface IsArchiveMetadata {
 
-  ZonedDateTime getRetrievalDateTime();
+  OffsetDateTime getRetrievalDateTime();
 
   List<IsArchiveProject> getArchiveProjects();
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/OffsetDateTimeAdapter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/OffsetDateTimeAdapter.java
@@ -16,7 +16,7 @@
  */
 package nl.overheid.aerius.gml.base;
 
-import java.time.ZonedDateTime;
+import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 
 import javax.xml.bind.annotation.adapters.XmlAdapter;
@@ -24,18 +24,18 @@ import javax.xml.bind.annotation.adapters.XmlAdapter;
 /**
  *
  */
-public class ZonedDateTimeAdapter extends XmlAdapter<String, ZonedDateTime> {
+public class OffsetDateTimeAdapter extends XmlAdapter<String, OffsetDateTime> {
 
-  private final DateTimeFormatter formatter = DateTimeFormatter.ISO_ZONED_DATE_TIME;
+  private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_OFFSET_DATE_TIME;
 
   @Override
-  public ZonedDateTime unmarshal(final String v) throws Exception {
-    return ZonedDateTime.parse(v, formatter);
+  public OffsetDateTime unmarshal(final String v) throws Exception {
+    return OffsetDateTime.parse(v, FORMATTER);
   }
 
   @Override
-  public String marshal(final ZonedDateTime v) throws Exception {
-    return formatter.format(v);
+  public String marshal(final OffsetDateTime v) throws Exception {
+    return FORMATTER.format(v);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/metadata/ArchiveMetadata.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/metadata/ArchiveMetadata.java
@@ -16,7 +16,7 @@
  */
 package nl.overheid.aerius.gml.v5_1.metadata;
 
-import java.time.ZonedDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -28,7 +28,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 import nl.overheid.aerius.gml.base.IsArchiveMetadata;
 import nl.overheid.aerius.gml.base.IsArchiveProject;
-import nl.overheid.aerius.gml.base.ZonedDateTimeAdapter;
+import nl.overheid.aerius.gml.base.OffsetDateTimeAdapter;
 import nl.overheid.aerius.gml.v5_1.base.CalculatorSchema;
 
 /**
@@ -37,17 +37,17 @@ import nl.overheid.aerius.gml.v5_1.base.CalculatorSchema;
 @XmlType(name = "ArchiveMetadataType", namespace = CalculatorSchema.NAMESPACE, propOrder = {"retrievalDateTime", "archiveProjectProperties"})
 public class ArchiveMetadata implements IsArchiveMetadata {
 
-  private ZonedDateTime retrievalDateTime;
+  private OffsetDateTime retrievalDateTime;
   private List<ArchiveProjectProperty> archiveProjects = new ArrayList<>();
 
   @Override
-  @XmlJavaTypeAdapter(ZonedDateTimeAdapter.class)
+  @XmlJavaTypeAdapter(OffsetDateTimeAdapter.class)
   @XmlElement(namespace = CalculatorSchema.NAMESPACE)
-  public ZonedDateTime getRetrievalDateTime() {
+  public OffsetDateTime getRetrievalDateTime() {
     return retrievalDateTime;
   }
 
-  public void setRetrievalDateTime(final ZonedDateTime retrievalDateTime) {
+  public void setRetrievalDateTime(final OffsetDateTime retrievalDateTime) {
     this.retrievalDateTime = retrievalDateTime;
   }
 

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/archive/ArchiveMetaData.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/archive/ArchiveMetaData.java
@@ -17,7 +17,7 @@
 package nl.overheid.aerius.shared.domain.v2.archive;
 
 import java.io.Serializable;
-import java.time.ZonedDateTime;
+import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,14 +28,14 @@ public class ArchiveMetaData implements Serializable {
 
   private static final long serialVersionUID = 1L;
 
-  private ZonedDateTime retrievalDateTime;
+  private OffsetDateTime retrievalDateTime;
   private List<ArchiveProject> archiveProjects = new ArrayList<>();
 
-  public ZonedDateTime getRetrievalDateTime() {
+  public OffsetDateTime getRetrievalDateTime() {
     return retrievalDateTime;
   }
 
-  public void setRetrievalDateTime(final ZonedDateTime retrievalDateTime) {
+  public void setRetrievalDateTime(final OffsetDateTime retrievalDateTime) {
     this.retrievalDateTime = retrievalDateTime;
   }
 


### PR DESCRIPTION
ZonedDateTime can include a identifier for the zone, but that isn't actually allowed. Turns out, if you don't have a zone ID specified in the string when parsing it, you'll end up with a zoned date time that does not contain one and when you format that again, you end up with something that's valid for offset date time as well (which is why the test case was succesful...)