### PR TITLE
Updated gwt-maven-plugin, removed gwt version numbers

### DIFF
--- a/source/pom.xml
+++ b/source/pom.xml
@@ -61,10 +61,8 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-    <com.google.gwt.version>2.9.0</com.google.gwt.version>
     <validation-api.version>2.0.1.Final</validation-api.version>
     <jackson.version>2.14.0</jackson.version>
-    <org.codehaus.mojo.gwtmavenplugin.version>${com.google.gwt.version}</org.codehaus.mojo.gwtmavenplugin.version>
 
     <maven.surefire.plugin.version>2.22.2</maven.surefire.plugin.version>
     <aerius-tools.version>1.2.0</aerius-tools.version>
@@ -238,7 +236,7 @@
         <plugin>
           <groupId>net.ltgt.gwt.maven</groupId>
           <artifactId>gwt-maven-plugin</artifactId>
-          <version>1.0.1</version>
+          <version>1.1.0</version>
         </plugin>
 
         <plugin>


### PR DESCRIPTION
These gwt version numbers are not used in the pom.xml files and therefor can be removed.