### PR TITLE
AER-2477 Validate by schema when writing GML

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLWriter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLWriter.java
@@ -324,7 +324,7 @@ public class GMLWriter {
     createInternalWriter().write(outputStream, scenario, metaDataInput);
   }
 
-  private InternalGMLWriter createInternalWriter() {
+  private InternalGMLWriter createInternalWriter() throws AeriusException {
     return new InternalGMLWriter(receptorGridSettings, referenceGenerator, formattedOutput, version);
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/AeriusGMLVersion.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/AeriusGMLVersion.java
@@ -26,51 +26,57 @@ public enum AeriusGMLVersion {
   /**
    * AERIUS GML version 5.1 (IMAER).
    */
-  V5_1,
+  V5_1(nl.overheid.aerius.gml.v5_1.base.CalculatorSchema.SCHEMA_LOCATION),
   /**
    * AERIUS GML version 5.0 (IMAER).
    */
-  V5_0,
+  V5_0(nl.overheid.aerius.gml.v5_0.base.CalculatorSchema.SCHEMA_LOCATION),
   /**
    * AERIUS GML version 4.0 (IMAER).
    */
-  V4_0,
+  V4_0(nl.overheid.aerius.gml.v4_0.base.CalculatorSchema.SCHEMA_LOCATION),
   /**
    * AERIUS GML version 3.1 (IMAER).
    */
-  V3_1,
+  V3_1(nl.overheid.aerius.gml.v3_1.base.CalculatorSchema.SCHEMA_LOCATION),
   /**
    * AERIUS GML version 3.0 (IMAER).
    */
-  V3_0,
+  V3_0(nl.overheid.aerius.gml.v3_0.base.CalculatorSchema.SCHEMA_LOCATION),
   /**
    * AERIUS GML version 2.2 (IMAER).
    */
-  V2_2,
+  V2_2(nl.overheid.aerius.gml.v2_2.base.CalculatorSchema.SCHEMA_LOCATION),
   /**
    * AERIUS GML version 2.1 (IMAER).
    */
-  V2_1,
+  V2_1(nl.overheid.aerius.gml.v2_1.base.CalculatorSchema.SCHEMA_LOCATION),
   /**
    * AERIUS GML version 2.0 (IMAER).
    */
-  V2_0,
+  V2_0(nl.overheid.aerius.gml.v2_0.base.CalculatorSchema.SCHEMA_LOCATION),
   /**
    * AERIUS GML version 1.1 (IMAER).
    */
-  V1_1,
+  V1_1(nl.overheid.aerius.gml.v1_1.base.CalculatorSchema.SCHEMA_LOCATION),
   /**
    * AERIUS GML version 1.0 (IMAER).
    * @deprecated Old version.
    */
   @Deprecated
-  V1_0,
+  V1_0(nl.overheid.aerius.gml.v1_0.base.CalculatorSchema.SCHEMA_LOCATION),
   /**
    * AERIUS GML version 0.5 (IMAER).
    * @deprecated Old version.
    */
   @Deprecated
-  V0_5;
+  V0_5(nl.overheid.aerius.gml.v0_5.base.CalculatorSchema.SCHEMA_LOCATION);
+
+  private final String schemaLocation;
+
+  private AeriusGMLVersion(final String schemaLocation) {
+    this.schemaLocation = schemaLocation;
+  }
 
   /**
    * Safely returns an AeriusGMLVersion. It is case independent and returns null in
@@ -85,6 +91,10 @@ public enum AeriusGMLVersion {
     } catch (final IllegalArgumentException e) {
       return null;
     }
+  }
+
+  String getSchemaLocation() {
+    return schemaLocation;
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/AeriusGMLVersion.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/AeriusGMLVersion.java
@@ -26,56 +26,58 @@ public enum AeriusGMLVersion {
   /**
    * AERIUS GML version 5.1 (IMAER).
    */
-  V5_1(nl.overheid.aerius.gml.v5_1.base.CalculatorSchema.SCHEMA_LOCATION),
+  V5_1("5.1"),
   /**
    * AERIUS GML version 5.0 (IMAER).
    */
-  V5_0(nl.overheid.aerius.gml.v5_0.base.CalculatorSchema.SCHEMA_LOCATION),
+  V5_0("5.0"),
   /**
    * AERIUS GML version 4.0 (IMAER).
    */
-  V4_0(nl.overheid.aerius.gml.v4_0.base.CalculatorSchema.SCHEMA_LOCATION),
+  V4_0("4.0"),
   /**
    * AERIUS GML version 3.1 (IMAER).
    */
-  V3_1(nl.overheid.aerius.gml.v3_1.base.CalculatorSchema.SCHEMA_LOCATION),
+  V3_1("3.1"),
   /**
    * AERIUS GML version 3.0 (IMAER).
    */
-  V3_0(nl.overheid.aerius.gml.v3_0.base.CalculatorSchema.SCHEMA_LOCATION),
+  V3_0("3.0"),
   /**
    * AERIUS GML version 2.2 (IMAER).
    */
-  V2_2(nl.overheid.aerius.gml.v2_2.base.CalculatorSchema.SCHEMA_LOCATION),
+  V2_2("2.2"),
   /**
    * AERIUS GML version 2.1 (IMAER).
    */
-  V2_1(nl.overheid.aerius.gml.v2_1.base.CalculatorSchema.SCHEMA_LOCATION),
+  V2_1("2.1"),
   /**
    * AERIUS GML version 2.0 (IMAER).
    */
-  V2_0(nl.overheid.aerius.gml.v2_0.base.CalculatorSchema.SCHEMA_LOCATION),
+  V2_0("2.0"),
   /**
    * AERIUS GML version 1.1 (IMAER).
    */
-  V1_1(nl.overheid.aerius.gml.v1_1.base.CalculatorSchema.SCHEMA_LOCATION),
+  V1_1("1.1"),
   /**
    * AERIUS GML version 1.0 (IMAER).
    * @deprecated Old version.
    */
   @Deprecated
-  V1_0(nl.overheid.aerius.gml.v1_0.base.CalculatorSchema.SCHEMA_LOCATION),
+  V1_0("1.0"),
   /**
    * AERIUS GML version 0.5 (IMAER).
    * @deprecated Old version.
    */
   @Deprecated
-  V0_5(nl.overheid.aerius.gml.v0_5.base.CalculatorSchema.SCHEMA_LOCATION);
+  V0_5("0.5");
+
+  private static final String SCHEMA_LOCATION_PATTERN = "/imaer/%s/IMAER.xsd";
 
   private final String schemaLocation;
 
-  private AeriusGMLVersion(final String schemaLocation) {
-    this.schemaLocation = schemaLocation;
+  private AeriusGMLVersion(final String versionString) {
+    this.schemaLocation = String.format(SCHEMA_LOCATION_PATTERN, versionString);
   }
 
   /**

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLSchemaFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLSchemaFactory.java
@@ -17,8 +17,6 @@
 package nl.overheid.aerius.gml.base;
 
 import java.net.URL;
-import java.util.EnumMap;
-import java.util.Map;
 
 import javax.xml.XMLConstants;
 import javax.xml.validation.Schema;
@@ -39,28 +37,13 @@ public final class GMLSchemaFactory {
   private static final Logger LOG = LoggerFactory.getLogger(GMLSchemaFactory.class);
 
   private static final String CATALOG_LOCATION = "/gml-catalog.xml";
-  private static final Map<AeriusGMLVersion, String> SCHEMA_LOCATIONS = new EnumMap<>(AeriusGMLVersion.class);
-
-  static {
-    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V0_5, nl.overheid.aerius.gml.v0_5.base.CalculatorSchema.SCHEMA_LOCATION);
-    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V1_0, nl.overheid.aerius.gml.v1_0.base.CalculatorSchema.SCHEMA_LOCATION);
-    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V1_1, nl.overheid.aerius.gml.v1_1.base.CalculatorSchema.SCHEMA_LOCATION);
-    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V2_0, nl.overheid.aerius.gml.v2_0.base.CalculatorSchema.SCHEMA_LOCATION);
-    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V2_1, nl.overheid.aerius.gml.v2_1.base.CalculatorSchema.SCHEMA_LOCATION);
-    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V2_2, nl.overheid.aerius.gml.v2_2.base.CalculatorSchema.SCHEMA_LOCATION);
-    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V3_0, nl.overheid.aerius.gml.v3_0.base.CalculatorSchema.SCHEMA_LOCATION);
-    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V3_1, nl.overheid.aerius.gml.v3_1.base.CalculatorSchema.SCHEMA_LOCATION);
-    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V4_0, nl.overheid.aerius.gml.v4_0.base.CalculatorSchema.SCHEMA_LOCATION);
-    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V5_0, nl.overheid.aerius.gml.v5_0.base.CalculatorSchema.SCHEMA_LOCATION);
-    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V5_1, nl.overheid.aerius.gml.v5_1.base.CalculatorSchema.SCHEMA_LOCATION);
-  }
 
   private GMLSchemaFactory() {
     // Util-like
   }
 
   public static Schema createSchema(final AeriusGMLVersion version) throws AeriusException {
-    return createSchema(SCHEMA_LOCATIONS.get(version));
+    return createSchema(version.getSchemaLocation());
   }
 
   public static Schema createSchema(final String schemaLocation) throws AeriusException {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLSchemaFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLSchemaFactory.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.gml.base;
+
+import java.net.URL;
+import java.util.EnumMap;
+import java.util.Map;
+
+import javax.xml.XMLConstants;
+import javax.xml.validation.Schema;
+import javax.xml.validation.SchemaFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.xml.sax.SAXException;
+
+import nl.overheid.aerius.shared.exception.AeriusException;
+import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
+
+/**
+ *
+ */
+public final class GMLSchemaFactory {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GMLSchemaFactory.class);
+
+  private static final String CATALOG_LOCATION = "/gml-catalog.xml";
+  private static final Map<AeriusGMLVersion, String> SCHEMA_LOCATIONS = new EnumMap<>(AeriusGMLVersion.class);
+
+  static {
+    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V0_5, nl.overheid.aerius.gml.v0_5.base.CalculatorSchema.SCHEMA_LOCATION);
+    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V1_0, nl.overheid.aerius.gml.v1_0.base.CalculatorSchema.SCHEMA_LOCATION);
+    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V1_1, nl.overheid.aerius.gml.v1_1.base.CalculatorSchema.SCHEMA_LOCATION);
+    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V2_0, nl.overheid.aerius.gml.v2_0.base.CalculatorSchema.SCHEMA_LOCATION);
+    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V2_1, nl.overheid.aerius.gml.v2_1.base.CalculatorSchema.SCHEMA_LOCATION);
+    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V2_2, nl.overheid.aerius.gml.v2_2.base.CalculatorSchema.SCHEMA_LOCATION);
+    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V3_0, nl.overheid.aerius.gml.v3_0.base.CalculatorSchema.SCHEMA_LOCATION);
+    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V3_1, nl.overheid.aerius.gml.v3_1.base.CalculatorSchema.SCHEMA_LOCATION);
+    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V4_0, nl.overheid.aerius.gml.v4_0.base.CalculatorSchema.SCHEMA_LOCATION);
+    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V5_0, nl.overheid.aerius.gml.v5_0.base.CalculatorSchema.SCHEMA_LOCATION);
+    SCHEMA_LOCATIONS.put(AeriusGMLVersion.V5_1, nl.overheid.aerius.gml.v5_1.base.CalculatorSchema.SCHEMA_LOCATION);
+  }
+
+  private GMLSchemaFactory() {
+    // Util-like
+  }
+
+  public static Schema createSchema(final AeriusGMLVersion version) throws AeriusException {
+    return createSchema(SCHEMA_LOCATIONS.get(version));
+  }
+
+  public static Schema createSchema(final String schemaLocation) throws AeriusException {
+    final CatalogResolver catalogResolver = new CatalogResolver(GMLSchemaFactory.class.getResource(CATALOG_LOCATION).toString());
+    final URL xsdURL = GMLSchemaFactory.class.getResource(schemaLocation);
+    try {
+      final SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
+      // disable DOCTYPE declarations, fixes XXE vulnerability
+      sf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+      sf.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+      // Explicitly allow file, as we're referencing some other local files.
+      sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "file");
+      // use a catalogresolver to avoid calling non-local xsd's
+      sf.setResourceResolver(catalogResolver);
+      return sf.newSchema(xsdURL);
+    } catch (final SAXException e) {
+      LOG.error("Parsing the AERIUS GML schema {} failed.", schemaLocation, e);
+      throw new AeriusException(ImaerExceptionReason.INTERNAL_ERROR, e.getMessage());
+    }
+  }
+
+}

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionReaderFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionReaderFactory.java
@@ -36,15 +36,14 @@ public abstract class GMLVersionReaderFactory {
    * Constructor.
    * @param legacyCodeSupplier The legacy code supplier
    * @param version AERIUS version
-   * @param schemaLocation schema location of the specific AERIUS GML version
    * @param nameSpace name space of the specific AERIUS GML version
    * @param featureCollectionClass class of the GML specific feature collection
    * @throws AeriusException in case of an error.
    */
-  protected GMLVersionReaderFactory(final GMLLegacyCodesSupplier legacyCodeSupplier, final AeriusGMLVersion version, final String schemaLocation,
-      final String namespace, final Class<?> featureCollectionClass) throws AeriusException {
+  protected GMLVersionReaderFactory(final GMLLegacyCodesSupplier legacyCodeSupplier, final AeriusGMLVersion version, final String namespace,
+      final Class<?> featureCollectionClass) throws AeriusException {
     this.version = version;
-    this.schemaLocation = schemaLocation;
+    this.schemaLocation = version.getSchemaLocation();
     this.namespace = namespace;
     this.featureCollectionClass = featureCollectionClass;
     schema = GMLSchemaFactory.createSchema(schemaLocation);

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionReaderFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionReaderFactory.java
@@ -16,26 +16,14 @@
  */
 package nl.overheid.aerius.gml.base;
 
-import java.net.URL;
-
-import javax.xml.XMLConstants;
 import javax.xml.validation.Schema;
-import javax.xml.validation.SchemaFactory;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.xml.sax.SAXException;
 
 import nl.overheid.aerius.shared.exception.AeriusException;
-import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 
 /**
  * Base class for readers of a Specific version of AERIUS GML.
  */
 public abstract class GMLVersionReaderFactory {
-
-  private static final Logger LOG = LoggerFactory.getLogger(GMLVersionReaderFactory.class);
-  private static final String CATALOG_LOCATION = "/gml-catalog.xml";
 
   private final AeriusGMLVersion version;
   private final String schemaLocation;
@@ -59,25 +47,9 @@ public abstract class GMLVersionReaderFactory {
     this.schemaLocation = schemaLocation;
     this.namespace = namespace;
     this.featureCollectionClass = featureCollectionClass;
-    schema = createSchema(schemaLocation);
+    schema = GMLSchemaFactory.createSchema(schemaLocation);
     legacyCodeConverter = new GMLLegacyCodeConverter(legacyCodeSupplier.getLegacyCodes(version),
         legacyCodeSupplier.getLegacyMobileSourceOffRoadConversions(), legacyCodeSupplier.getLegacyPlanConversions());
-  }
-
-  private static Schema createSchema(final String schemaLocation) throws AeriusException {
-    final CatalogResolver catalogResolver = new CatalogResolver(GMLVersionReaderFactory.class.getResource(CATALOG_LOCATION).toString());
-    final URL xsdURL = GMLVersionReaderFactory.class.getResource(schemaLocation);
-    try {
-      final SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-      // disable DOCTYPE declarations, fixes XXE vulnerability
-      sf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
-      // use a catalogresolver to avoid calling non-local xsd's
-      sf.setResourceResolver(catalogResolver);
-      return sf.newSchema(xsdURL);
-    } catch (final SAXException e) {
-      LOG.error("Parsing the AERIUS GML schema {} failed.", schemaLocation, e);
-      throw new AeriusException(ImaerExceptionReason.INTERNAL_ERROR, e.getMessage());
-    }
   }
 
   /**

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionWriterFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionWriterFactory.java
@@ -16,9 +16,12 @@
  */
 package nl.overheid.aerius.gml.base;
 
+import javax.xml.validation.Schema;
+
 import nl.overheid.aerius.gml.v5_0.togml.GMLVersionWriterV50;
 import nl.overheid.aerius.gml.v5_1.togml.GMLVersionWriterV51;
 import nl.overheid.aerius.shared.domain.geo.HexagonZoomLevel;
+import nl.overheid.aerius.shared.exception.AeriusException;
 
 public class GMLVersionWriterFactory {
 
@@ -32,5 +35,9 @@ public class GMLVersionWriterFactory {
     default:
       throw new IllegalArgumentException("Aerius GML version is not supported");
     }
+  }
+
+  public static Schema getSchema(final AeriusGMLVersion aeriusGMLVersion) throws AeriusException {
+    return GMLSchemaFactory.createSchema(aeriusGMLVersion);
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/GMLReaderFactoryV05.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/GMLReaderFactoryV05.java
@@ -36,7 +36,7 @@ public class GMLReaderFactoryV05 extends GMLVersionReaderFactory {
    * @throws AeriusException error
    */
   public GMLReaderFactoryV05(final GMLLegacyCodesSupplier legacyCodesSupplier) throws AeriusException {
-    super(legacyCodesSupplier, AeriusGMLVersion.V0_5, CalculatorSchema.SCHEMA_LOCATION, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
+    super(legacyCodesSupplier, AeriusGMLVersion.V0_5, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
   }
 
   @Override

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/base/CalculatorSchema.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/base/CalculatorSchema.java
@@ -37,16 +37,6 @@ public final class CalculatorSchema {
   public static final String PREFIX = "imaer";
 
   /**
-   * Name of the XSD file.
-   */
-  public static final String XSD_FILENAME = "IMAER.xsd";
-
-  /**
-   * Schema location.
-   */
-  public static final String SCHEMA_LOCATION = "/imaer/" + IMAER_VERSION + "/" + XSD_FILENAME;
-
-  /**
    * prefix used for id's in GML.
    */
   public static final String GML_ID_NAMESPACE = "NL.IMAER";

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_0/GMLReaderFactoryV10.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_0/GMLReaderFactoryV10.java
@@ -36,7 +36,7 @@ public class GMLReaderFactoryV10 extends GMLVersionReaderFactory {
    * @throws AeriusException error
    */
   public GMLReaderFactoryV10(final GMLLegacyCodesSupplier legacyCodesSupplier) throws AeriusException {
-    super(legacyCodesSupplier, AeriusGMLVersion.V1_0, CalculatorSchema.SCHEMA_LOCATION, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
+    super(legacyCodesSupplier, AeriusGMLVersion.V1_0, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
   }
 
   @Override

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_0/base/CalculatorSchema.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_0/base/CalculatorSchema.java
@@ -37,16 +37,6 @@ public final class CalculatorSchema {
   public static final String PREFIX = "imaer";
 
   /**
-   * Name of the XSD file.
-   */
-  public static final String XSD_FILENAME = "IMAER.xsd";
-
-  /**
-   * Schema location.
-   */
-  public static final String SCHEMA_LOCATION = "/imaer/" + IMAER_VERSION + "/" + XSD_FILENAME;
-
-  /**
    * prefix used for id's in GML.
    */
   public static final String GML_ID_NAMESPACE = "NL.IMAER";

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/GMLReaderFactoryV11.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/GMLReaderFactoryV11.java
@@ -37,7 +37,7 @@ public class GMLReaderFactoryV11 extends GMLVersionReaderFactory {
    * @throws AeriusException error
    */
   public GMLReaderFactoryV11(final GMLLegacyCodesSupplier legacyCodesSupplier) throws AeriusException {
-    super(legacyCodesSupplier, AeriusGMLVersion.V1_1, CalculatorSchema.SCHEMA_LOCATION, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
+    super(legacyCodesSupplier, AeriusGMLVersion.V1_1, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
   }
 
   @Override

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/base/CalculatorSchema.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v1_1/base/CalculatorSchema.java
@@ -47,11 +47,6 @@ public final class CalculatorSchema {
   public static final String PUBLIC_SCHEMA_LOCATION = NAMESPACE + "/" + XSD_FILENAME;
 
   /**
-   * Schema location.
-   */
-  public static final String SCHEMA_LOCATION = "/imaer/" + IMAER_VERSION + "/" + XSD_FILENAME;
-
-  /**
    * prefix used for id's in GML.
    */
   public static final String GML_ID_NAMESPACE = "NL.IMAER";

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/GMLReaderFactoryV20.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/GMLReaderFactoryV20.java
@@ -37,7 +37,7 @@ public class GMLReaderFactoryV20 extends GMLVersionReaderFactory {
    * @throws AeriusException error
    */
   public GMLReaderFactoryV20(final GMLLegacyCodesSupplier legacyCodesSupplier) throws AeriusException {
-    super(legacyCodesSupplier, AeriusGMLVersion.V2_0, CalculatorSchema.SCHEMA_LOCATION, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
+    super(legacyCodesSupplier, AeriusGMLVersion.V2_0, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
   }
 
   @Override

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/GMLReaderFactoryV21.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/GMLReaderFactoryV21.java
@@ -37,7 +37,7 @@ public class GMLReaderFactoryV21 extends GMLVersionReaderFactory {
    * @throws AeriusException error
    */
   public GMLReaderFactoryV21(final GMLLegacyCodesSupplier legacyCodesSupplier) throws AeriusException {
-    super(legacyCodesSupplier, AeriusGMLVersion.V2_1, CalculatorSchema.SCHEMA_LOCATION, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
+    super(legacyCodesSupplier, AeriusGMLVersion.V2_1, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
   }
 
   @Override

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/base/CalculatorSchema.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/base/CalculatorSchema.java
@@ -47,11 +47,6 @@ public final class CalculatorSchema {
   public static final String PUBLIC_SCHEMA_LOCATION = NAMESPACE + "/" + XSD_FILENAME;
 
   /**
-   * Schema location.
-   */
-  public static final String SCHEMA_LOCATION = "/imaer/" + IMAER_VERSION + "/" + XSD_FILENAME;
-
-  /**
    * prefix used for id's in GML.
    */
   public static final String GML_ID_NAMESPACE = "NL.IMAER";

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/GMLReaderFactoryV22.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/GMLReaderFactoryV22.java
@@ -37,7 +37,7 @@ public class GMLReaderFactoryV22 extends GMLVersionReaderFactory {
    * @throws AeriusException error
    */
   public GMLReaderFactoryV22(final GMLLegacyCodesSupplier legacyCodesSupplier) throws AeriusException {
-    super(legacyCodesSupplier, AeriusGMLVersion.V2_2, CalculatorSchema.SCHEMA_LOCATION, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
+    super(legacyCodesSupplier, AeriusGMLVersion.V2_2, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
   }
 
   @Override

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/base/CalculatorSchema.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/base/CalculatorSchema.java
@@ -47,11 +47,6 @@ public final class CalculatorSchema {
   public static final String PUBLIC_SCHEMA_LOCATION = NAMESPACE + "/" + XSD_FILENAME;
 
   /**
-   * Schema location.
-   */
-  public static final String SCHEMA_LOCATION = "/imaer/" + IMAER_VERSION + "/" + XSD_FILENAME;
-
-  /**
    * prefix used for id's in GML.
    */
   public static final String GML_ID_NAMESPACE = "NL.IMAER";

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/GMLReaderFactoryV30.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/GMLReaderFactoryV30.java
@@ -37,7 +37,7 @@ public class GMLReaderFactoryV30 extends GMLVersionReaderFactory {
    * @throws AeriusException error
    */
   public GMLReaderFactoryV30(final GMLLegacyCodesSupplier legacyCodesSupplier) throws AeriusException {
-    super(legacyCodesSupplier, AeriusGMLVersion.V3_0, CalculatorSchema.SCHEMA_LOCATION, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
+    super(legacyCodesSupplier, AeriusGMLVersion.V3_0, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
   }
 
   @Override

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/base/CalculatorSchema.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/base/CalculatorSchema.java
@@ -47,11 +47,6 @@ public final class CalculatorSchema {
   public static final String PUBLIC_SCHEMA_LOCATION = NAMESPACE + "/" + XSD_FILENAME;
 
   /**
-   * Schema location.
-   */
-  public static final String SCHEMA_LOCATION = "/imaer/" + IMAER_VERSION + "/" + XSD_FILENAME;
-
-  /**
    * prefix used for id's in GML.
    */
   public static final String GML_ID_NAMESPACE = "NL.IMAER";

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/GMLReaderFactoryV31.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/GMLReaderFactoryV31.java
@@ -36,7 +36,7 @@ public class GMLReaderFactoryV31 extends GMLVersionReaderFactory {
    * @throws AeriusException error
    */
   public GMLReaderFactoryV31(final GMLLegacyCodesSupplier legacyCodesSupplier) throws AeriusException {
-    super(legacyCodesSupplier, AeriusGMLVersion.V3_1, CalculatorSchema.SCHEMA_LOCATION, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
+    super(legacyCodesSupplier, AeriusGMLVersion.V3_1, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
   }
 
   @Override

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/base/CalculatorSchema.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/base/CalculatorSchema.java
@@ -47,11 +47,6 @@ public final class CalculatorSchema {
   public static final String PUBLIC_SCHEMA_LOCATION = NAMESPACE + "/" + XSD_FILENAME;
 
   /**
-   * Schema location.
-   */
-  public static final String SCHEMA_LOCATION = "/imaer/" + IMAER_VERSION + "/" + XSD_FILENAME;
-
-  /**
    * prefix used for id's in GML.
    */
   public static final String GML_ID_NAMESPACE = "NL.IMAER";

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GMLReaderFactoryV40.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GMLReaderFactoryV40.java
@@ -40,7 +40,7 @@ public class GMLReaderFactoryV40 extends GMLVersionReaderFactory {
    * @throws AeriusException error
    */
   public GMLReaderFactoryV40(final GMLLegacyCodesSupplier legacyCodesSupplier) throws AeriusException {
-    super(legacyCodesSupplier, AeriusGMLVersion.V4_0, CalculatorSchema.SCHEMA_LOCATION, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
+    super(legacyCodesSupplier, AeriusGMLVersion.V4_0, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
   }
 
   @Override

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/base/CalculatorSchema.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/base/CalculatorSchema.java
@@ -52,11 +52,6 @@ public final class CalculatorSchema {
   public static final String PUBLIC_SCHEMA_LOCATION = PUBLIC_VERSION_LOCATION + "/" + XSD_FILENAME;
 
   /**
-   * Schema location.
-   */
-  public static final String SCHEMA_LOCATION = "/imaer/" + IMAER_VERSION + "/" + XSD_FILENAME;
-
-  /**
    * prefix used for id's in GML.
    */
   public static final String GML_ID_NAMESPACE = "NL.IMAER";

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/GMLReaderFactoryV50.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/GMLReaderFactoryV50.java
@@ -41,7 +41,7 @@ public class GMLReaderFactoryV50 extends GMLVersionReaderFactory {
    * @throws AeriusException error
    */
   public GMLReaderFactoryV50(final GMLLegacyCodesSupplier legacyCodesSupplier) throws AeriusException {
-    super(legacyCodesSupplier, AeriusGMLVersion.V5_0, CalculatorSchema.SCHEMA_LOCATION, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
+    super(legacyCodesSupplier, AeriusGMLVersion.V5_0, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
   }
 
   @Override

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/base/CalculatorSchema.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/base/CalculatorSchema.java
@@ -52,11 +52,6 @@ public final class CalculatorSchema {
   public static final String PUBLIC_SCHEMA_LOCATION = PUBLIC_VERSION_LOCATION + "/" + XSD_FILENAME;
 
   /**
-   * Schema location.
-   */
-  public static final String SCHEMA_LOCATION = "/imaer/" + IMAER_VERSION + "/" + XSD_FILENAME;
-
-  /**
    * prefix used for id's in GML.
    */
   public static final String GML_ID_NAMESPACE = "NL.IMAER";

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/GMLReaderFactoryV51.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/GMLReaderFactoryV51.java
@@ -41,7 +41,7 @@ public class GMLReaderFactoryV51 extends GMLVersionReaderFactory {
    * @throws AeriusException error
    */
   public GMLReaderFactoryV51(final GMLLegacyCodesSupplier legacyCodesSupplier) throws AeriusException {
-    super(legacyCodesSupplier, AeriusGMLVersion.V5_1, CalculatorSchema.SCHEMA_LOCATION, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
+    super(legacyCodesSupplier, AeriusGMLVersion.V5_1, CalculatorSchema.NAMESPACE, FeatureCollectionImpl.class);
   }
 
   @Override

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/base/CalculatorSchema.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/base/CalculatorSchema.java
@@ -52,11 +52,6 @@ public final class CalculatorSchema {
   public static final String PUBLIC_SCHEMA_LOCATION = PUBLIC_VERSION_LOCATION + "/" + XSD_FILENAME;
 
   /**
-   * Schema location.
-   */
-  public static final String SCHEMA_LOCATION = "/imaer/" + IMAER_VERSION + "/" + XSD_FILENAME;
-
-  /**
    * prefix used for id's in GML.
    */
   public static final String GML_ID_NAMESPACE = "NL.IMAER";


### PR DESCRIPTION
By setting the schema on the marshaller, any XSD violations should be caught before invalid GMLs end up at the user.

This will cause some unittests to fail upstream, but that's for later concern.