### PR TITLE
Added method to GMLWriter to pass full filename

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLWriter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLWriter.java
@@ -201,29 +201,6 @@ public class GMLWriter {
   }
 
   /**
-   * Build GML and write it directly to file.
-   * The GML file will be generated in the supplied file.
-   *
-   * @param file The file path to write the file to.
-   * @param scenario Scenario containing all scenario related data
-   * @param metaData The metadata to write for this file.
-   * @return The file generated.
-   * @throws AeriusException When exception occurred generating the GML.
-   */
-  public File writeToFile(final Path file, final IsScenario scenario, final MetaDataInput metaData) throws AeriusException {
-    try (final OutputStream outputStream = Files.newOutputStream(file)) {
-      write(outputStream, scenario, metaData);
-    } catch (final IOException e) {
-      // catch any exception and put them in a GML exception.
-      LOG.error("Internal error occurred.", e);
-      throw new AeriusException(ImaerExceptionReason.INTERNAL_ERROR);
-    }
-
-    LOG.info("File generated for {} to {}.", scenario.getName(), file);
-    return file.toFile();
-  }
-
-  /**
    * Build archive GML and write it directly to file.
    * The file will be generated in the supplied directory.
    *
@@ -249,9 +226,33 @@ public class GMLWriter {
     return file.toFile();
   }
 
+
   /**
    * Build GML and write it directly to file.
-   * The file will be generated in the supplied directory.
+   * The GML file will be generated in the supplied file.
+   *
+   * @param file The file path to write the file to.
+   * @param scenario Scenario containing all scenario related data
+   * @param metaData The metadata to write for this file.
+   * @return The file generated.
+   * @throws AeriusException When exception occurred generating the GML.
+   */
+  public File writeToFile(final Path file, final IsScenario scenario, final MetaDataInput metaData) throws AeriusException {
+    try (final OutputStream outputStream = Files.newOutputStream(file)) {
+      write(outputStream, scenario, metaData);
+    } catch (final IOException e) {
+      // catch any exception and put them in a GML exception.
+      LOG.error("Internal error occurred.", e);
+      throw new AeriusException(ImaerExceptionReason.INTERNAL_ERROR);
+    }
+
+    LOG.info("File generated for {} to {}.", scenario.getName(), file);
+    return file.toFile();
+  }
+
+  /**
+   * Build GML and write it directly to file.
+   * The GML file will be generated in the supplied directory.
    *
    * @param dir The directory to write the file to.
    * @param scenario Scenario containing all scenario related data

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLWriter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLWriter.java
@@ -202,19 +202,15 @@ public class GMLWriter {
 
   /**
    * Build GML and write it directly to file.
-   * The file will be generated in the supplied directory.
+   * The GML file will be generated in the supplied file.
    *
-   * @param dir The directory to write the file to.
+   * @param file The file path to write the file to.
    * @param scenario Scenario containing all scenario related data
    * @param metaData The metadata to write for this file.
-   * @param fileId The ID that should be reflected in the filename.
-   * @param fileNamePart The optional filename that will be incorporated in the resulting file's name.
    * @return The file generated.
    * @throws AeriusException When exception occurred generating the GML.
    */
-  public File writeToFile(final File dir, final IsScenario scenario, final MetaDataInput metaData, final int fileId,
-      final Optional<String> fileNamePart, final Optional<Date> fileNameDatePart) throws AeriusException {
-    final Path file = new File(dir, getFileName(scenario, fileId, fileNamePart, fileNameDatePart)).toPath();
+  public File writeToFile(final Path file, final IsScenario scenario, final MetaDataInput metaData) throws AeriusException {
     try (final OutputStream outputStream = Files.newOutputStream(file)) {
       write(outputStream, scenario, metaData);
     } catch (final IOException e) {
@@ -253,6 +249,27 @@ public class GMLWriter {
     return file.toFile();
   }
 
+  /**
+   * Build GML and write it directly to file.
+   * The file will be generated in the supplied directory.
+   *
+   * @param dir The directory to write the file to.
+   * @param scenario Scenario containing all scenario related data
+   * @param metaData The metadata to write for this file.
+   * @param fileId The ID that should be reflected in the filename.
+   * @param fileNamePart The optional filename that will be incorporated in the resulting file's name.
+   * @return The file generated.
+   * @throws AeriusException When exception occurred generating the GML.
+   * @deprecated Use {@link #writeToFile(Path, IsScenario, MetaDataInput)}
+   */
+  @Deprecated
+  public File writeToFile(final File dir, final IsScenario scenario, final MetaDataInput metaData, final int fileId,
+      final Optional<String> fileNamePart, final Optional<Date> fileNameDatePart) throws AeriusException {
+    final Path file = new File(dir, getFileName(scenario, fileId, fileNamePart, fileNameDatePart)).toPath();
+    return writeToFile(file, scenario, metaData);
+  }
+
+  @Deprecated
   protected String getFileName(final IsScenario scenario, final int fileId, final Optional<String> fileNamePart,
       final Optional<Date> fileNameDatePart) {
     return getFileName(Optional.of(scenario), fileId, fileNamePart, fileNameDatePart);

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/UnsupportedFeaturesTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/UnsupportedFeaturesTest.java
@@ -48,12 +48,7 @@ import nl.overheid.aerius.util.ImaerFileUtil;
 class UnsupportedFeaturesTest {
   private static final String RESOURCE_PATH = "latest/validate/unsupportedFeatures/";
 
-  private static final FilenameFilter GML_FILENAME_FILTER = new FilenameFilter() {
-    @Override
-    public boolean accept(final File dir, final String name) {
-      return name != null && name.endsWith(".gml");
-    }
-  };
+  private static final FilenameFilter GML_FILENAME_FILTER = (dir, name) -> name != null && name.endsWith(".gml");
 
   private static List<File> getGMLFiles() throws FileNotFoundException {
     final File basePath = new File(UnsupportedFeaturesTest.class.getResource("/gml/").getPath(), RESOURCE_PATH);

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/EmissionValueKey.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/EmissionValueKey.java
@@ -25,9 +25,7 @@ import java.util.List;
 /**
  * EmissionSource objects keep track of multiple emission values,
  * because for certain information the emission values are different.
- * @deprecated year and substance will be split because year applies to all substances in one set and isn't different.
  */
-@Deprecated
 public class EmissionValueKey implements Comparable<EmissionValueKey>, Serializable {
 
   private static final long serialVersionUID = -7656975594074285482L;

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationJobType.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationJobType.java
@@ -27,7 +27,17 @@ import jsinterop.annotations.JsProperty;
 import nl.overheid.aerius.shared.domain.scenario.SituationType;
 
 /**
- * type of Calculation Job
+ * Type of Calculation Job.
+ *
+ * This enum specifies constraints on allowed situation types.
+ * <dl>
+ * <dt>Required Situations</dt>
+ * <dd>Specifies which situations are required. If left empty no situation is required.</dd>
+ * <dt>Optional Situations</dt>
+ * <dd>Specifies which situations are optional. If left empty no situation is optional.</dd>
+ * <dt>Plural Situations</dt>
+ * <dd>Specifies which situations can occur multiple times. If left empty no situation can occur multiple times.</dd>
+ * </dl>
  */
 public enum CalculationJobType {
 

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ValidationHelper.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ValidationHelper.java
@@ -25,11 +25,7 @@ public interface ValidationHelper {
 
   FarmlandValidationHelper farmlandValidation();
 
-  default ManureStorageValidationHelper manureStorageValidation() {
-    // Temporary default while projects implement this method.
-    // TODO: remove after a week or so.
-    return null;
-  }
+  ManureStorageValidationHelper manureStorageValidation();
 
   OffRoadValidationHelper offRoadMobileValidation();
 

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/util/ImaerFileUtilTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/util/ImaerFileUtilTest.java
@@ -23,6 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FilenameFilter;
 import java.util.Calendar;
 
 import org.junit.jupiter.api.Test;
@@ -37,6 +40,24 @@ public class ImaerFileUtilTest {
   private static final String TEST_FILE_PREFIX = "naam";
   private static final String TEST_FILE_NAME_EXTENSION = "test";
   private static final String TEST_LONG_FILE_NAME = "abcdefghijklmnopqrstuvwxyz_are_the_letters_in_the_alphabet";
+
+  @Test
+  void testGetFilesWithExtension() throws FileNotFoundException {
+    final String file = ImaerFileUtilTest.class.getResource("").getFile();
+    assertFalse(ImaerFileUtil.getFilesWithExtension(new File(file), null).isEmpty(), "Check if find files in directory with no filter");
+    assertFalse(ImaerFileUtil.getFilesWithExtension(new File(file), new FilenameFilter() {
+      @Override
+      public boolean accept(final File dir, final String name) {
+        return name.endsWith("class");
+      }
+    }).isEmpty(), "Check if find files in directory with");
+    assertFalse(ImaerFileUtil.getFilesWithExtension(new File(file, ImaerFileUtilTest.class.getSimpleName() + ".class"), new FilenameFilter() {
+      @Override
+      public boolean accept(final File dir, final String name) {
+        return name.endsWith("class");
+      }
+    }).isEmpty(), "Check if find this file");
+  }
 
   @Test
   public void testGetSafeFilename() {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/util/ImaerFileUtilTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/util/ImaerFileUtilTest.java
@@ -44,19 +44,20 @@ public class ImaerFileUtilTest {
   @Test
   void testGetFilesWithExtension() throws FileNotFoundException {
     final String file = ImaerFileUtilTest.class.getResource("").getFile();
-    assertFalse(ImaerFileUtil.getFilesWithExtension(new File(file), null).isEmpty(), "Check if find files in directory with no filter");
+    assertFalse(ImaerFileUtil.getFilesWithExtension(new File(file), null).isEmpty(),
+        "Check whether you can find files in directory with no extension filter");
     assertFalse(ImaerFileUtil.getFilesWithExtension(new File(file), new FilenameFilter() {
       @Override
       public boolean accept(final File dir, final String name) {
         return name.endsWith("class");
       }
-    }).isEmpty(), "Check if find files in directory with");
+    }).isEmpty(), "Check whether files with a specific extension can be found in the directory");
     assertFalse(ImaerFileUtil.getFilesWithExtension(new File(file, ImaerFileUtilTest.class.getSimpleName() + ".class"), new FilenameFilter() {
       @Override
       public boolean accept(final File dir, final String name) {
         return name.endsWith("class");
       }
-    }).isEmpty(), "Check if find this file");
+    }).isEmpty(), "Check whether a specific file can be found");
   }
 
   @Test


### PR DESCRIPTION
Deprecate methods that construct filename. That logic should not be part of GMLWriter. Also some small codestyle improvements. Removed deprecated from EmissionValueKey as it was intended to be deprecated, but that is not the case at the moment.