### PR TITLE
Removed forRemoval from deprecated annotation

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/EmissionSourceType.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/EmissionSourceType.java
@@ -24,7 +24,7 @@ public enum EmissionSourceType {
    * Farm Lodge emission values.
    * @Deprecated Replaced by Animal Housing approach
    */
-  @Deprecated(forRemoval = true)
+  @Deprecated
   FARM_LODGE(Names.FARM_LODGE),
   /**
    * Farm animal housing emission values.


### PR DESCRIPTION
GWT compile does not like it apparantly, at least not on build server.

Not sure if it has to be removed from all places in imaer-shared. Error during compile only hinted at this one, if this doesn't fix it i'll remove it from all.