### PR TITLE
AER-1815 Added separate minimum height for source volumes, and changed defaults

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/adms/ADMSLimits.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/adms/ADMSLimits.java
@@ -25,7 +25,8 @@ public final class ADMSLimits implements BuildingLimits {
 
   private static final long serialVersionUID = 1L;
 
-  public static final double SOURCE_HEIGHT_MINIMUM = 0.001;
+  public static final double SOURCE_HEIGHT_MINIMUM = 0.0;
+  public static final double SOURCE_HEIGHT_VOLUME_MINIMUM = 0.0005;
   public static final int SOURCE_HEIGHT_MAXIMUM = 15_000;
   public static final double SOURCE_HEIGHT_DEFAULT = 0.5;
   public static final double SOURCE_WIDTH_MINIMUM = 0.001;


### PR DESCRIPTION
Volume source default should be 0.0005 and other sources default should be 0.0.