### PR TITLE
AER-2918 Met site changes

### DIFF
--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLCalculationSetOptionsReaderTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLCalculationSetOptionsReaderTest.java
@@ -195,7 +195,7 @@ class GMLCalculationSetOptionsReaderTest {
     suppliedOptions.add(mockCalculationOption("adms_surface_albedo", "4.5"));
     suppliedOptions.add(mockCalculationOption("adms_priestley_taylor_parameter", "5.6"));
     suppliedOptions.add(mockCalculationOption("adms_met_site_id", "939"));
-    suppliedOptions.add(mockCalculationOption("adms_met_dataset_type", "OBS_RAW_GT_75PCT"));
+    suppliedOptions.add(mockCalculationOption("adms_met_dataset_type", "OBS_RAW_GT_90PCT"));
     suppliedOptions.add(mockCalculationOption("adms_met_years", "2022,2023"));
     suppliedOptions.add(mockCalculationOption("adms_met_site_roughness", "3.1"));
     suppliedOptions.add(mockCalculationOption("adms_met_site_min_monin_obukhov_length", "4.2"));
@@ -223,7 +223,7 @@ class GMLCalculationSetOptionsReaderTest {
     assertEquals(4.5, admsOptions.getSurfaceAlbedo(), "SurfaceAlbedo");
     assertEquals(5.6, admsOptions.getPriestleyTaylorParameter(), "PriestleyTaylorParameter");
     assertEquals(939, admsOptions.getMetSiteId(), "MetSiteId");
-    assertEquals(MetDatasetType.OBS_RAW_GT_75PCT, admsOptions.getMetDatasetType(), "MetDatasetType");
+    assertEquals(MetDatasetType.OBS_RAW_GT_90PCT, admsOptions.getMetDatasetType(), "MetDatasetType");
     assertEquals(List.of("2022", "2023"), admsOptions.getMetYears(), "MetYears");
     assertEquals(3.1, admsOptions.getMsRoughness(), "MsRoughness");
     assertEquals(4.2, admsOptions.getMsMinMoninObukhovLength(), "MsMinMoninObukhovLength");

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLCalculationSetOptionsReaderTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLCalculationSetOptionsReaderTest.java
@@ -43,6 +43,7 @@ import nl.overheid.aerius.shared.domain.calculation.ADMSOptions;
 import nl.overheid.aerius.shared.domain.calculation.CalculationJobType;
 import nl.overheid.aerius.shared.domain.calculation.CalculationMethod;
 import nl.overheid.aerius.shared.domain.calculation.CalculationSetOptions;
+import nl.overheid.aerius.shared.domain.calculation.MetDatasetType;
 import nl.overheid.aerius.shared.domain.calculation.NCACalculationOptions;
 import nl.overheid.aerius.shared.domain.v2.characteristics.adms.ADMSLimits;
 
@@ -194,6 +195,8 @@ class GMLCalculationSetOptionsReaderTest {
     suppliedOptions.add(mockCalculationOption("adms_surface_albedo", "4.5"));
     suppliedOptions.add(mockCalculationOption("adms_priestley_taylor_parameter", "5.6"));
     suppliedOptions.add(mockCalculationOption("adms_met_site_id", "939"));
+    suppliedOptions.add(mockCalculationOption("adms_met_dataset_type", "OBS_RAW_GT_75PCT"));
+    suppliedOptions.add(mockCalculationOption("adms_met_years", "2022,2023"));
     suppliedOptions.add(mockCalculationOption("adms_met_site_roughness", "3.1"));
     suppliedOptions.add(mockCalculationOption("adms_met_site_min_monin_obukhov_length", "4.2"));
     suppliedOptions.add(mockCalculationOption("adms_met_site_surface_albedo", "5.3"));
@@ -215,13 +218,13 @@ class GMLCalculationSetOptionsReaderTest {
     assertEquals(CalculationJobType.MAX_TEMPORARY_EFFECT, options.getCalculationJobType(), "Calculation job type should match");
     final NCACalculationOptions ncaOptions = options.getNcaCalculationOptions();
     assertEquals("somewhere", ncaOptions.getPermitArea(), "PermitArea");
-    assertEquals("some meteo loc", ncaOptions.getMeteoSiteLocation(), "MeteoSiteLocation");
-    assertEquals(List.of("2040", "2042"), ncaOptions.getMeteoYears(), "MeteoYears");
     final ADMSOptions admsOptions = ncaOptions.getAdmsOptions();
     assertEquals(3.4, admsOptions.getMinMoninObukhovLength(), "MinMoninObukhovLength");
     assertEquals(4.5, admsOptions.getSurfaceAlbedo(), "SurfaceAlbedo");
     assertEquals(5.6, admsOptions.getPriestleyTaylorParameter(), "PriestleyTaylorParameter");
     assertEquals(939, admsOptions.getMetSiteId(), "MetSiteId");
+    assertEquals(MetDatasetType.OBS_RAW_GT_75PCT, admsOptions.getMetDatasetType(), "MetDatasetType");
+    assertEquals(List.of("2022", "2023"), admsOptions.getMetYears(), "MetYears");
     assertEquals(3.1, admsOptions.getMsRoughness(), "MsRoughness");
     assertEquals(4.2, admsOptions.getMsMinMoninObukhovLength(), "MsMinMoninObukhovLength");
     assertEquals(5.3, admsOptions.getMsSurfaceAlbedo(), "MsSurfaceAlbedo");
@@ -353,7 +356,6 @@ class GMLCalculationSetOptionsReaderTest {
     final CalculationSetOptions options = reader.readCalculationSetOptions(Theme.NCA);
     assertNotNull(options, "returned options shouldn't be null");
     final NCACalculationOptions ncaOptions = options.getNcaCalculationOptions();
-    assertEquals(List.of("MySpecialYear"), ncaOptions.getMeteoYears(), "MeteoYears");
     final ADMSOptions admsOptions = ncaOptions.getAdmsOptions();
     assertEquals(false, admsOptions.isPlumeDepletionNH3(), "PlumeDepletionNH3");
     assertEquals(false, admsOptions.isPlumeDepletionNOX(), "PlumeDepletionNOX");

--- a/source/imaer-gml/src/test/resources/gml/v5_1/roundtrip/nca_calculation_options.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_1/roundtrip/nca_calculation_options.gml
@@ -26,12 +26,6 @@
                     <imaer:resultType>DEPOSITION</imaer:resultType>
                     <imaer:option>
                         <imaer:CalculationOption>
-                            <imaer:key>adms_meteo_years</imaer:key>
-                            <imaer:value></imaer:value>
-                        </imaer:CalculationOption>
-                    </imaer:option>
-                    <imaer:option>
-                        <imaer:CalculationOption>
                             <imaer:key>road_local_fraction_no2_receptors_option</imaer:key>
                             <imaer:value>ONE_CUSTOM_VALUE</imaer:value>
                         </imaer:CalculationOption>

--- a/source/imaer-gml/src/test/resources/gml/v5_1/roundtrip/nca_calculation_options_quick_run.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_1/roundtrip/nca_calculation_options_quick_run.gml
@@ -27,12 +27,6 @@
                     <imaer:maximumRange>10.0</imaer:maximumRange>
                     <imaer:option>
                         <imaer:CalculationOption>
-                            <imaer:key>adms_meteo_years</imaer:key>
-                            <imaer:value></imaer:value>
-                        </imaer:CalculationOption>
-                    </imaer:option>
-                    <imaer:option>
-                        <imaer:CalculationOption>
                             <imaer:key>road_local_fraction_no2_receptors_option</imaer:key>
                             <imaer:value>ONE_CUSTOM_VALUE</imaer:value>
                         </imaer:CalculationOption>

--- a/source/imaer-gml/src/test/resources/gml/v6_0/roundtrip/nca_calculation_options.gml
+++ b/source/imaer-gml/src/test/resources/gml/v6_0/roundtrip/nca_calculation_options.gml
@@ -26,12 +26,6 @@
                     <imaer:resultType>DEPOSITION</imaer:resultType>
                     <imaer:option>
                         <imaer:CalculationOption>
-                            <imaer:key>adms_meteo_years</imaer:key>
-                            <imaer:value></imaer:value>
-                        </imaer:CalculationOption>
-                    </imaer:option>
-                    <imaer:option>
-                        <imaer:CalculationOption>
                             <imaer:key>road_local_fraction_no2_receptors_option</imaer:key>
                             <imaer:value>ONE_CUSTOM_VALUE</imaer:value>
                         </imaer:CalculationOption>

--- a/source/imaer-gml/src/test/resources/gml/v6_0/roundtrip/nca_calculation_options_quick_run.gml
+++ b/source/imaer-gml/src/test/resources/gml/v6_0/roundtrip/nca_calculation_options_quick_run.gml
@@ -27,12 +27,6 @@
                     <imaer:maximumRange>10.0</imaer:maximumRange>
                     <imaer:option>
                         <imaer:CalculationOption>
-                            <imaer:key>adms_meteo_years</imaer:key>
-                            <imaer:value></imaer:value>
-                        </imaer:CalculationOption>
-                    </imaer:option>
-                    <imaer:option>
-                        <imaer:CalculationOption>
                             <imaer:key>road_local_fraction_no2_receptors_option</imaer:key>
                             <imaer:value>ONE_CUSTOM_VALUE</imaer:value>
                         </imaer:CalculationOption>

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/ADMSOptions.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/ADMSOptions.java
@@ -17,18 +17,22 @@
 package nl.overheid.aerius.shared.domain.calculation;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Contains ADMS specific options for a calculation.
  */
 public class ADMSOptions implements Serializable {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   private double minMoninObukhovLength;
   private double surfaceAlbedo;
   private double priestleyTaylorParameter;
   private int metSiteId;
+  private MetDatasetType metDatasetType;
+  private List<String> metYears = new ArrayList<>();
   private double msRoughness;
   private double msMinMoninObukhovLength;
   private double msSurfaceAlbedo;
@@ -68,6 +72,22 @@ public class ADMSOptions implements Serializable {
 
   public void setMetSiteId(final int metSiteId) {
     this.metSiteId = metSiteId;
+  }
+
+  public MetDatasetType getMetDatasetType() {
+    return metDatasetType;
+  }
+
+  public void setMetDatasetType(final MetDatasetType metDatasetType) {
+    this.metDatasetType = metDatasetType;
+  }
+
+  public List<String> getMetYears() {
+    return metYears;
+  }
+
+  public void setMetYears(final List<String> metYears) {
+    this.metYears = metYears;
   }
 
   public double getMsRoughness() {

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/MetDatasetType.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/MetDatasetType.java
@@ -1,0 +1,83 @@
+/*
+ * Crown copyright
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.shared.domain.calculation;
+
+import java.util.Locale;
+
+/**
+ * Types of Met(eorological) datasets used.
+ */
+public enum MetDatasetType {
+
+  OBS_RAW_GT_90PCT(false, "raw_gt_90pct_OBS"),
+  OBS_RAW_GT_75PCT(false, "raw_gt_75pct_OBS"),
+  NWP_3_KM2(true, "3km2_NWP");
+
+  private final boolean nwp;
+  private final String alternativeName;
+
+  MetDatasetType(final boolean nwp, final String alternativeName) {
+    this.nwp = nwp;
+    this.alternativeName = alternativeName;
+  }
+
+  public boolean isObserved() {
+    return !nwp;
+  }
+
+  public boolean isNwp() {
+    return nwp;
+  }
+
+  public String getAlternativeName() {
+    return alternativeName;
+  }
+
+  /**
+   * Safely returns a MetDatasetType. It is case independent and returns null in
+   * case the input was null or the dataset type could not be found.
+   *
+   * @param value value to convert
+   * @return MetDatasetType or null if no valid input
+   */
+  public static MetDatasetType safeValueOf(final String value) {
+    try {
+      return value == null ? null : valueOf(value.toUpperCase(Locale.ROOT));
+    } catch (final IllegalArgumentException e) {
+      return byAlternativeName(value);
+    }
+  }
+
+  /**
+   * Determine MetDatasetType by alternative name. It is case independent and returns null in
+   * case the dataset type could not be found.
+   *
+   * @param value value to convert
+   * @return MetDatasetType or null if no valid input
+   */
+  public static MetDatasetType byAlternativeName(final String value) {
+    MetDatasetType correct = null;
+    for (final MetDatasetType type : values()) {
+      if (type.alternativeName.equalsIgnoreCase(value)) {
+        correct = type;
+        break;
+      }
+    }
+    return correct;
+  }
+
+}

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/MetDatasetType.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/MetDatasetType.java
@@ -23,16 +23,15 @@ import java.util.Locale;
  */
 public enum MetDatasetType {
 
-  OBS_RAW_GT_90PCT(false, "raw_gt_90pct_OBS"),
-  OBS_RAW_GT_75PCT(false, "raw_gt_75pct_OBS"),
-  NWP_3_KM2(true, "3km2_NWP");
+  OBS_RAW_GT_90PCT(false),
+  // Expect another observed set, but what the term will be exactly is unsure so uncommented for now.
+//  OBS_RAW_GT_75PCT(false),
+  NWP_3KM2(true);
 
   private final boolean nwp;
-  private final String alternativeName;
 
-  MetDatasetType(final boolean nwp, final String alternativeName) {
+  MetDatasetType(final boolean nwp) {
     this.nwp = nwp;
-    this.alternativeName = alternativeName;
   }
 
   public boolean isObserved() {
@@ -43,9 +42,6 @@ public enum MetDatasetType {
     return nwp;
   }
 
-  public String getAlternativeName() {
-    return alternativeName;
-  }
 
   /**
    * Safely returns a MetDatasetType. It is case independent and returns null in
@@ -58,26 +54,8 @@ public enum MetDatasetType {
     try {
       return value == null ? null : valueOf(value.toUpperCase(Locale.ROOT));
     } catch (final IllegalArgumentException e) {
-      return byAlternativeName(value);
+      return null;
     }
-  }
-
-  /**
-   * Determine MetDatasetType by alternative name. It is case independent and returns null in
-   * case the dataset type could not be found.
-   *
-   * @param value value to convert
-   * @return MetDatasetType or null if no valid input
-   */
-  public static MetDatasetType byAlternativeName(final String value) {
-    MetDatasetType correct = null;
-    for (final MetDatasetType type : values()) {
-      if (type.alternativeName.equalsIgnoreCase(value)) {
-        correct = type;
-        break;
-      }
-    }
-    return correct;
   }
 
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/NCACalculationOptions.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/NCACalculationOptions.java
@@ -40,7 +40,7 @@ public class NCACalculationOptions implements Serializable {
   /**
    * List of meteo years to calculate.
    */
-  private List<String> meteoYears = new ArrayList<String>();
+  private List<String> meteoYears = new ArrayList<>();
 
   /**
    * ADMS version to use.
@@ -75,18 +75,34 @@ public class NCACalculationOptions implements Serializable {
     this.permitArea = permitArea;
   }
 
+  /**
+   * @Deprecated Use Met information on ADMSOptions instead.
+   */
+  @Deprecated
   public String getMeteoSiteLocation() {
     return meteoSiteLocation;
   }
 
+  /**
+   * @Deprecated Use Met information on ADMSOptions instead.
+   */
+  @Deprecated
   public void setMeteoSiteLocation(final String meteoSiteLocation) {
     this.meteoSiteLocation = meteoSiteLocation;
   }
 
+  /**
+   * @Deprecated Use Met information on ADMSOptions instead.
+   */
+  @Deprecated
   public List<String> getMeteoYears() {
     return meteoYears;
   }
 
+  /**
+   * @Deprecated Use Met information on ADMSOptions instead.
+   */
+  @Deprecated
   public void setMeteoYears(final List<String> meteoYears) {
     this.meteoYears = meteoYears;
   }

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/util/OptionsMetadataUtil.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/util/OptionsMetadataUtil.java
@@ -28,6 +28,7 @@ import nl.overheid.aerius.shared.domain.calculation.CalculationJobType;
 import nl.overheid.aerius.shared.domain.calculation.CalculationRoadOPS;
 import nl.overheid.aerius.shared.domain.calculation.CalculationSetOptions;
 import nl.overheid.aerius.shared.domain.calculation.ConnectSuppliedOptions;
+import nl.overheid.aerius.shared.domain.calculation.MetDatasetType;
 import nl.overheid.aerius.shared.domain.calculation.NCACalculationOptions;
 import nl.overheid.aerius.shared.domain.calculation.OPSOptions;
 import nl.overheid.aerius.shared.domain.calculation.OwN2000CalculationOptions;
@@ -77,8 +78,6 @@ public final class OptionsMetadataUtil {
     /* ADMS options related */
     ADMS_VERSION,
     ADMS_PERMIT_AREA,
-    ADMS_METEO_SITE_LOCATION,
-    ADMS_METEO_YEARS,
     ADMS_MIN_MONIN_OBUKHOV_LENGTH,
     ADMS_SURFACE_ALBEDO,
     ADMS_PRIESTLEY_TAYLOR_PARAMETER,
@@ -87,6 +86,8 @@ public final class OptionsMetadataUtil {
     ADMS_SPATIALLY_VARYING_ROUGHNESS,
     ADMS_COMPLEX_TERRAIN,
     ADMS_MET_SITE_ID,
+    ADMS_MET_DATASET_TYPE,
+    ADMS_MET_YEARS,
     ADMS_MET_SITE_ROUGHNESS,
     ADMS_MET_SITE_MIN_MONIN_OBUKHOV_LENGTH,
     ADMS_MET_SITE_SURFACE_ALBEDO,
@@ -188,7 +189,6 @@ public final class OptionsMetadataUtil {
 
   private static void ncaOptionsFromMap(final NCACalculationOptions options, final Map<Option, String> map) {
     options.setPermitArea(map.get(Option.ADMS_PERMIT_AREA));
-    options.setMeteoSiteLocation(map.get(Option.ADMS_METEO_SITE_LOCATION));
     options.setRoadLocalFractionNO2ReceptorsOption(RoadLocalFractionNO2Option.safeValueOf(map.get(Option.ROAD_LOCAL_FRACTION_NO2_RECEPTORS_OPTION)));
     options.setRoadLocalFractionNO2PointsOption(RoadLocalFractionNO2Option.safeValueOf(map.get(Option.ROAD_LOCAL_FRACTION_NO2_POINTS_OPTION)));
     if (options.getRoadLocalFractionNO2ReceptorsOption() == RoadLocalFractionNO2Option.ONE_CUSTOM_VALUE
@@ -196,29 +196,29 @@ public final class OptionsMetadataUtil {
       options.setRoadLocalFractionNO2(
           Optional.ofNullable(map.get(Option.ROAD_LOCAL_FRACTION_NO2_CUSTOM_VALUE)).map(Double::parseDouble).orElse(null));
     }
-    parseMeteoYears(options, map);
 
-    options.getAdmsOptions()
-        .setMinMoninObukhovLength(getOrDefault(map, Option.ADMS_MIN_MONIN_OBUKHOV_LENGTH, ADMSLimits.MIN_MONIN_OBUKHOV_LENGTH_DEFAULT));
-    options.getAdmsOptions().setSurfaceAlbedo(getOrDefault(map, Option.ADMS_SURFACE_ALBEDO, ADMSLimits.SURFACE_ALBEDO_DEFAULT));
-    options.getAdmsOptions()
-        .setPriestleyTaylorParameter(getOrDefault(map, Option.ADMS_PRIESTLEY_TAYLOR_PARAMETER, ADMSLimits.PRIESTLEY_TAYLOR_PARAMETER_DEFAULT));
+    final ADMSOptions admsOptions = options.getAdmsOptions();
+    admsOptions.setMinMoninObukhovLength(getOrDefault(map, Option.ADMS_MIN_MONIN_OBUKHOV_LENGTH, ADMSLimits.MIN_MONIN_OBUKHOV_LENGTH_DEFAULT));
+    admsOptions.setSurfaceAlbedo(getOrDefault(map, Option.ADMS_SURFACE_ALBEDO, ADMSLimits.SURFACE_ALBEDO_DEFAULT));
+    admsOptions.setPriestleyTaylorParameter(getOrDefault(map, Option.ADMS_PRIESTLEY_TAYLOR_PARAMETER, ADMSLimits.PRIESTLEY_TAYLOR_PARAMETER_DEFAULT));
 
     if (map.get(Option.ADMS_MET_SITE_ID) != null) {
-      options.getAdmsOptions().setMetSiteId(Integer.parseInt(map.get(Option.ADMS_MET_SITE_ID)));
-      options.getAdmsOptions().setMsRoughness(getOrDefault(map, Option.ADMS_MET_SITE_ROUGHNESS, ADMSLimits.ROUGHNESS_DEFAULT));
-      options.getAdmsOptions()
+      admsOptions.setMetSiteId(Integer.parseInt(map.get(Option.ADMS_MET_SITE_ID)));
+      admsOptions.setMetDatasetType(MetDatasetType.safeValueOf(map.get(Option.ADMS_MET_DATASET_TYPE)));
+      parseMetYears(admsOptions, map);
+      admsOptions.setMsRoughness(getOrDefault(map, Option.ADMS_MET_SITE_ROUGHNESS, ADMSLimits.ROUGHNESS_DEFAULT));
+      admsOptions
           .setMsMinMoninObukhovLength(getOrDefault(map, Option.ADMS_MET_SITE_MIN_MONIN_OBUKHOV_LENGTH, ADMSLimits.MIN_MONIN_OBUKHOV_LENGTH_DEFAULT));
-      options.getAdmsOptions().setMsSurfaceAlbedo(getOrDefault(map, Option.ADMS_MET_SITE_SURFACE_ALBEDO, ADMSLimits.SURFACE_ALBEDO_DEFAULT));
-      options.getAdmsOptions().setMsPriestleyTaylorParameter(
+      admsOptions.setMsSurfaceAlbedo(getOrDefault(map, Option.ADMS_MET_SITE_SURFACE_ALBEDO, ADMSLimits.SURFACE_ALBEDO_DEFAULT));
+      admsOptions.setMsPriestleyTaylorParameter(
           getOrDefault(map, Option.ADMS_MET_SITE_PRIESTLEY_TAYLOR_PARAMETER, ADMSLimits.PRIESTLEY_TAYLOR_PARAMETER_DEFAULT));
     }
 
-    options.getAdmsOptions().setPlumeDepletionNH3(getOrDefault(map, Option.ADMS_PLUME_DEPLETION_NH3, ADMSLimits.ADMS_PLUME_DEPLETION_NH3_DEFAULT));
-    options.getAdmsOptions().setPlumeDepletionNOX(getOrDefault(map, Option.ADMS_PLUME_DEPLETION_NOX, ADMSLimits.ADMS_PLUME_DEPLETION_NOX_DEFAULT));
-    options.getAdmsOptions()
+    admsOptions.setPlumeDepletionNH3(getOrDefault(map, Option.ADMS_PLUME_DEPLETION_NH3, ADMSLimits.ADMS_PLUME_DEPLETION_NH3_DEFAULT));
+    admsOptions.setPlumeDepletionNOX(getOrDefault(map, Option.ADMS_PLUME_DEPLETION_NOX, ADMSLimits.ADMS_PLUME_DEPLETION_NOX_DEFAULT));
+    admsOptions
         .setSpatiallyVaryingRoughness(getOrDefault(map, Option.ADMS_SPATIALLY_VARYING_ROUGHNESS, ADMSLimits.SPATIALLY_VARYING_ROUGHNESS_DEFAULT));
-    options.getAdmsOptions().setComplexTerrain(getOrDefault(map, Option.ADMS_COMPLEX_TERRAIN, ADMSLimits.ADMS_COMPLEX_TERRAIN_DEFAULT));
+    admsOptions.setComplexTerrain(getOrDefault(map, Option.ADMS_COMPLEX_TERRAIN, ADMSLimits.ADMS_COMPLEX_TERRAIN_DEFAULT));
   }
 
   private static double getOrDefault(final Map<Option, String> map, final Option option, final double defaultValue) {
@@ -229,12 +229,12 @@ public final class OptionsMetadataUtil {
     return Optional.ofNullable(map.get(option)).map(Boolean::parseBoolean).orElse(defaultValue);
   }
 
-  private static void parseMeteoYears(final NCACalculationOptions options, final Map<Option, String> map) {
-    final String meteoYearString = map.get(Option.ADMS_METEO_YEARS);
-    if (meteoYearString != null && !meteoYearString.isBlank()) {
-      final String[] meteoYears = meteoYearString.split(METEO_YEARS_SEPARATOR);
+  private static void parseMetYears(final ADMSOptions admsOptions, final Map<Option, String> map) {
+    final String metYearString = map.get(Option.ADMS_MET_YEARS);
+    if (metYearString != null && !metYearString.isBlank()) {
+      final String[] meteoYears = metYearString.split(METEO_YEARS_SEPARATOR);
       if (meteoYears.length > 0) {
-        options.setMeteoYears(Arrays.asList(meteoYears));
+        admsOptions.setMetYears(Arrays.asList(meteoYears));
       }
     }
   }
@@ -243,8 +243,6 @@ public final class OptionsMetadataUtil {
     if (options != null) {
       addValue(mapToAddTo, Option.ADMS_VERSION, options.getAdmsVersion(), addDefaults);
       addValue(mapToAddTo, Option.ADMS_PERMIT_AREA, options.getPermitArea(), addDefaults);
-      addValue(mapToAddTo, Option.ADMS_METEO_SITE_LOCATION, options.getMeteoSiteLocation(), addDefaults);
-      addValue(mapToAddTo, Option.ADMS_METEO_YEARS, String.join(METEO_YEARS_SEPARATOR, options.getMeteoYears()), addDefaults);
       addValue(mapToAddTo, Option.ROAD_LOCAL_FRACTION_NO2_RECEPTORS_OPTION, options.getRoadLocalFractionNO2ReceptorsOption(), addDefaults);
       addValue(mapToAddTo, Option.ROAD_LOCAL_FRACTION_NO2_POINTS_OPTION, options.getRoadLocalFractionNO2PointsOption(), addDefaults);
       if (options.getRoadLocalFractionNO2ReceptorsOption() == RoadLocalFractionNO2Option.ONE_CUSTOM_VALUE
@@ -258,6 +256,9 @@ public final class OptionsMetadataUtil {
         addValue(mapToAddTo, Option.ADMS_SURFACE_ALBEDO, adms.getSurfaceAlbedo(), addDefaults);
         addValue(mapToAddTo, Option.ADMS_PRIESTLEY_TAYLOR_PARAMETER, adms.getPriestleyTaylorParameter(), addDefaults);
         addIntValue(mapToAddTo, Option.ADMS_MET_SITE_ID, adms.getMetSiteId(), addDefaults);
+        addValue(mapToAddTo, Option.ADMS_MET_DATASET_TYPE, adms.getMetDatasetType(), addDefaults);
+        addValue(mapToAddTo, Option.ADMS_MET_YEARS, adms.getMetYears().isEmpty() ? null : String.join(METEO_YEARS_SEPARATOR, adms.getMetYears()),
+            addDefaults);
         addValue(mapToAddTo, Option.ADMS_MET_SITE_ROUGHNESS, adms.getMsRoughness(), addDefaults);
         addValue(mapToAddTo, Option.ADMS_MET_SITE_MIN_MONIN_OBUKHOV_LENGTH, adms.getMsMinMoninObukhovLength(), addDefaults);
         addValue(mapToAddTo, Option.ADMS_MET_SITE_SURFACE_ALBEDO, adms.getMsSurfaceAlbedo(), addDefaults);

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/util/OptionsMetadataUtilTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/util/OptionsMetadataUtilTest.java
@@ -33,11 +33,12 @@ import nl.overheid.aerius.shared.domain.calculation.CalculationMethod;
 import nl.overheid.aerius.shared.domain.calculation.CalculationRoadOPS;
 import nl.overheid.aerius.shared.domain.calculation.CalculationSetOptions;
 import nl.overheid.aerius.shared.domain.calculation.ConnectSuppliedOptions;
+import nl.overheid.aerius.shared.domain.calculation.MetDatasetType;
 import nl.overheid.aerius.shared.domain.calculation.NCACalculationOptions;
 import nl.overheid.aerius.shared.domain.calculation.OPSOptions;
+import nl.overheid.aerius.shared.domain.calculation.OwN2000CalculationOptions;
 import nl.overheid.aerius.shared.domain.calculation.RoadLocalFractionNO2Option;
 import nl.overheid.aerius.shared.domain.calculation.SubReceptorsMode;
-import nl.overheid.aerius.shared.domain.calculation.OwN2000CalculationOptions;
 import nl.overheid.aerius.shared.domain.meteo.Meteo;
 
 /**
@@ -198,8 +199,6 @@ class OptionsMetadataUtilTest {
 
     ncaOptions.setAdmsVersion("5.0.0.1");
     ncaOptions.setPermitArea("London");
-    ncaOptions.setMeteoSiteLocation("Near London");
-    ncaOptions.setMeteoYears(List.of("2022", "2023"));
     ncaOptions.setRoadLocalFractionNO2ReceptorsOption(RoadLocalFractionNO2Option.ONE_CUSTOM_VALUE);
     ncaOptions.setRoadLocalFractionNO2PointsOption(RoadLocalFractionNO2Option.ONE_CUSTOM_VALUE);
     ncaOptions.setRoadLocalFractionNO2(0.4);
@@ -213,6 +212,8 @@ class OptionsMetadataUtilTest {
     adms.setSpatiallyVaryingRoughness(true);
     adms.setComplexTerrain(true);
     adms.setMetSiteId(100);
+    adms.setMetDatasetType(MetDatasetType.OBS_RAW_GT_90PCT);
+    adms.setMetYears(List.of("2022", "2023"));
     adms.setMsRoughness(0.8);
     adms.setMsMinMoninObukhovLength(1.1);
     adms.setMsSurfaceAlbedo(1.2);
@@ -221,8 +222,6 @@ class OptionsMetadataUtilTest {
 
     assertEquals("5.0.0.1", result.get("adms_version"), "adms_version should be set");
     assertEquals("London", result.get("adms_permit_area"), "adms_permit_area should be set");
-    assertEquals("Near London", result.get("adms_meteo_site_location"), "adms_meteo_site_location should be set");
-    assertEquals("2022,2023", result.get("adms_meteo_years"), "adms_meteo_years should be set");
     assertEquals("12.3", result.get("adms_min_monin_obukhov_length"), "adms_min_monin_obukhov_length should be set");
     assertEquals("23.4", result.get("adms_surface_albedo"), "adms_surface_albedo should be set");
     assertEquals("34.5", result.get("adms_priestley_taylor_parameter"), "adms_priestley_taylor_parameter should be set");
@@ -231,6 +230,8 @@ class OptionsMetadataUtilTest {
     assertEquals("true", result.get("adms_spatially_varying_roughness"), "adms_spatially_varying_roughness should be set");
     assertEquals("true", result.get("adms_complex_terrain"), "adms_complex_terrain should be set");
     assertEquals("100", result.get("adms_met_site_id"), "adms_met_site_id should be set");
+    assertEquals("OBS_RAW_GT_90PCT", result.get("adms_met_dataset_type"), "adms_met_dataset_type should be set");
+    assertEquals("2022,2023", result.get("adms_met_years"), "adms_years should be set");
     assertEquals("0.8", result.get("adms_met_site_roughness"), "adms_met_site_roughness should be set");
     assertEquals("1.1", result.get("adms_met_site_min_monin_obukhov_length"), "adms_met_site_min_monin_obukhov_length should be set");
     assertEquals("1.2", result.get("adms_met_site_surface_albedo"), "adms_met_site_surface_albedo should be set");
@@ -276,8 +277,6 @@ class OptionsMetadataUtilTest {
     final NCACalculationOptions ncaOptions = options.getNcaCalculationOptions();
 
     ncaOptions.setPermitArea("London");
-    ncaOptions.setMeteoSiteLocation("Near London");
-    ncaOptions.setMeteoYears(List.of("2022", "2023"));
     ncaOptions.setRoadLocalFractionNO2ReceptorsOption(RoadLocalFractionNO2Option.ONE_CUSTOM_VALUE);
     ncaOptions.setRoadLocalFractionNO2PointsOption(RoadLocalFractionNO2Option.ONE_CUSTOM_VALUE);
     ncaOptions.setRoadLocalFractionNO2(0.4);
@@ -291,6 +290,8 @@ class OptionsMetadataUtilTest {
     adms.setSpatiallyVaryingRoughness(true);
     adms.setComplexTerrain(true);
     adms.setMetSiteId(100);
+    adms.setMetDatasetType(MetDatasetType.OBS_RAW_GT_90PCT);
+    adms.setMetYears(List.of("2022", "2023"));
     adms.setMsRoughness(0.8);
     adms.setMsMinMoninObukhovLength(1.1);
     adms.setMsSurfaceAlbedo(1.2);


### PR DESCRIPTION
Added MetDatasetType enum, and properties in ADMSOptions to support the new met site selection (dataset type and years). Deprecated met site properties on NCACalculationOptions: we never really used these.