### PR TITLE
Changed PR github action to fail when test fails

### DIFF
--- a/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
+++ b/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
@@ -14,11 +14,9 @@ jobs:
         with:
           repository: aerius/github-actions
           path: aerius-github-actions
-          ref: v1.0.2
+          ref: v1.1
 
-      - uses: aerius/github-actions/events/pull_request-event-action@v1.0.2
+      - uses: aerius/github-actions/events/pull_request-event-action@v1.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ROOT_POM_DIRECTORY: repo/source
-          JDK_VERSION: 17
-          IGNORE_TEST_FAILURES: false

--- a/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
+++ b/.github/workflows/on-pull_request-opened-synchronize-reopened.yml
@@ -21,3 +21,4 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ROOT_POM_DIRECTORY: repo/source
           JDK_VERSION: 17
+          IGNORE_TEST_FAILURES: false

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -13,13 +13,12 @@ jobs:
         with:
           repository: aerius/github-actions
           path: aerius-github-actions
-          ref: v1.0.2
+          ref: v1.1
 
-      - uses: aerius/github-actions/events/push-event-action@v1.0.2
+      - uses: aerius/github-actions/events/push-event-action@v1.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           ROOT_POM_DIRECTORY: repo/source
-          JDK_VERSION: 17

--- a/.github/workflows/on-release-published.yml
+++ b/.github/workflows/on-release-published.yml
@@ -14,13 +14,12 @@ jobs:
         with:
           repository: aerius/github-actions
           path: aerius-github-actions
-          ref: v1.0.2
+          ref: v1.1
 
-      - uses: aerius/github-actions/events/release-event-action@v1.0.2
+      - uses: aerius/github-actions/events/release-event-action@v1.1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
           NEXUS_USERNAME: ${{ secrets.NEXUS_USERNAME }}
           NEXUS_PASSWORD: ${{ secrets.NEXUS_PASSWORD }}
           ROOT_POM_DIRECTORY: repo/source
-          JDK_VERSION: 17

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/ExternalEntitiesDisabledTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/ExternalEntitiesDisabledTest.java
@@ -19,6 +19,7 @@ package nl.overheid.aerius.gml;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -87,6 +88,7 @@ class ExternalEntitiesDisabledTest {
 
     assertNotNull(content, "No content read from xml.");
     assertEquals(referencedText, content, "Invalid content.");
+    fail("Just testing");
   }
 
   /**

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/ExternalEntitiesDisabledTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/ExternalEntitiesDisabledTest.java
@@ -19,7 +19,6 @@ package nl.overheid.aerius.gml;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -88,7 +87,6 @@ class ExternalEntitiesDisabledTest {
 
     assertNotNull(content, "No content read from xml.");
     assertEquals(referencedText, content, "Invalid content.");
-    fail("Just testing");
   }
 
   /**


### PR DESCRIPTION
Release already fails if this is the case, so makes more sense to fail when a PR introduces new failing tests. (noticed some tests failing, thought it already worked this way)