### PR TITLE
AER-2858 description when farm lodging could not be converted

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/lodging/GML2Farm.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/lodging/GML2Farm.java
@@ -16,6 +16,11 @@
  */
 package nl.overheid.aerius.gml.base.source.lodging;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -126,7 +131,10 @@ public class GML2Farm<T extends IsGmlFarmLodgingEmissionSource> extends Abstract
     customEmissions.setAnimalTypeCode(standardLodging.getCode() == null || standardLodging.getCode().length() <= 1
         ? UNKNOWN_ANIMAL_TYPE_CODE
         : standardLodging.getCode().substring(0, 1));
-    customEmissions.setDescription("");
+    final List<String> descriptionParts = new ArrayList<>();
+    Optional.ofNullable(standardLodging.getCode()).ifPresent(descriptionParts::add);
+    Optional.ofNullable(standardLodging.getLodgingSystemDefinitionCode()).ifPresent(descriptionParts::add);
+    customEmissions.setDescription(descriptionParts.stream().collect(Collectors.joining(", ")));
     customEmissions.setFarmEmissionFactorType(FarmEmissionFactorType.PER_ANIMAL_PER_YEAR);
     customEmissions.getEmissionFactors().put(Substance.NH3, 0.0);
     // Warn the user that this source has been converted to custom animal housing.

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/lodging/GML2Farm.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/lodging/GML2Farm.java
@@ -19,7 +19,6 @@ package nl.overheid.aerius.gml.base.source.lodging;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -134,7 +133,7 @@ public class GML2Farm<T extends IsGmlFarmLodgingEmissionSource> extends Abstract
     final List<String> descriptionParts = new ArrayList<>();
     Optional.ofNullable(standardLodging.getCode()).ifPresent(descriptionParts::add);
     Optional.ofNullable(standardLodging.getLodgingSystemDefinitionCode()).ifPresent(descriptionParts::add);
-    customEmissions.setDescription(descriptionParts.stream().collect(Collectors.joining(", ")));
+    customEmissions.setDescription(String.join(", ", descriptionParts));
     customEmissions.setFarmEmissionFactorType(FarmEmissionFactorType.PER_ANIMAL_PER_YEAR);
     customEmissions.getEmissionFactors().put(Substance.NH3, 0.0);
     // Warn the user that this source has been converted to custom animal housing.

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLRoundtripTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLRoundtripTest.java
@@ -163,6 +163,9 @@ class GMLRoundtripTest {
       {"farm_animal_housing", CharacteristicsType.OPS},
       {"farm_animal_housing_with_systems", CharacteristicsType.OPS},
       {"farm_animal_housing_custom_per_day", CharacteristicsType.OPS},
+      // Case where lodging could not be converted directly to animal housing
+      {"farm_no_conversion", CharacteristicsType.OPS,
+        EnumSet.of(ImaerExceptionReason.GML_SOURCE_NO_EMISSION, ImaerExceptionReason.GML_CONVERTED_LODGING_TO_CUSTOM), true},
   };
 
   private static final String LATEST_VERSION = "latest";
@@ -229,6 +232,9 @@ class GMLRoundtripTest {
     }
     if (warnings.contains(ImaerExceptionReason.GML_CONVERTED_LODGING_WITH_SYSTEMS) && version.ordinal() <= AeriusGMLVersion.V6_0.ordinal()) {
       warnings.remove(ImaerExceptionReason.GML_CONVERTED_LODGING_WITH_SYSTEMS);
+    }
+    if (warnings.contains(ImaerExceptionReason.GML_CONVERTED_LODGING_TO_CUSTOM) && version.ordinal() <= AeriusGMLVersion.V6_0.ordinal()) {
+      warnings.remove(ImaerExceptionReason.GML_CONVERTED_LODGING_TO_CUSTOM);
     }
     return warnings;
   }

--- a/source/imaer-gml/src/test/resources/gml/v5_1/roundtrip/farm_no_conversion.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_1/roundtrip/farm_no_conversion.gml
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imaer:FeatureCollectionCalculator xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:imaer="http://imaer.aerius.nl/5.1" gml:id="NL.IMAER.Collection" xsi:schemaLocation="http://imaer.aerius.nl/5.1 https://imaer.aerius.nl/5.1/IMAER.xsd">
+    <imaer:metadata>
+        <imaer:AeriusCalculatorMetadata>
+            <imaer:project>
+                <imaer:ProjectMetadata>
+                    <imaer:year>2013</imaer:year>
+                    <imaer:name>Situatie 1</imaer:name>
+                </imaer:ProjectMetadata>
+            </imaer:project>
+            <imaer:situation>
+                <imaer:SituationMetadata>
+                    <imaer:name>Situatie 1</imaer:name>
+                    <imaer:reference>RpXpU4DVH2Nw</imaer:reference>
+                    <imaer:situationType>PROPOSED</imaer:situationType>
+                </imaer:SituationMetadata>
+            </imaer:situation>
+            <imaer:version>
+                <imaer:VersionMetadata>
+                    <imaer:aeriusVersion>DEV</imaer:aeriusVersion>
+                    <imaer:databaseVersion>BETA8_20140904_7fbba21b46</imaer:databaseVersion>
+                </imaer:VersionMetadata>
+            </imaer:version>
+        </imaer:AeriusCalculatorMetadata>
+    </imaer:metadata>
+    <imaer:featureMember>
+        <imaer:FarmLodgingEmissionSource sectorId="4110" gml:id="ES.6">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>ES.6</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:label>Boerderij</imaer:label>
+            <imaer:emissionSourceCharacteristics>
+                <imaer:EmissionSourceCharacteristics>
+                    <imaer:heatContent>
+                        <imaer:SpecifiedHeatContent>
+                            <imaer:value>0.0</imaer:value>
+                        </imaer:SpecifiedHeatContent>
+                    </imaer:heatContent>
+                    <imaer:emissionHeight>5.0</imaer:emissionHeight>
+                </imaer:EmissionSourceCharacteristics>
+            </imaer:emissionSourceCharacteristics>
+            <imaer:geometry>
+                <imaer:EmissionSourceGeometry>
+                    <imaer:GM_Point>
+                        <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="ES.6.POINT">
+                            <gml:pos>69462.46 443548.56</gml:pos>
+                        </gml:Point>
+                    </imaer:GM_Point>
+                </imaer:EmissionSourceGeometry>
+            </imaer:geometry>
+            <imaer:emission>
+                <imaer:Emission substance="NH3">
+                    <imaer:value>2149.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NOX">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="PM10">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NO2">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:farmLodging>
+                <imaer:StandardFarmLodging farmLodgingType="X9.8">
+                    <imaer:numberOfAnimals>100</imaer:numberOfAnimals>
+                    <imaer:farmLodgingSystemDefinitionType>LWB1999.0.1</imaer:farmLodgingSystemDefinitionType>
+                </imaer:StandardFarmLodging>
+            </imaer:farmLodging>
+        </imaer:FarmLodgingEmissionSource>
+    </imaer:featureMember>
+</imaer:FeatureCollectionCalculator>

--- a/source/imaer-gml/src/test/resources/gml/v6_0/roundtrip/farm_no_conversion.gml
+++ b/source/imaer-gml/src/test/resources/gml/v6_0/roundtrip/farm_no_conversion.gml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imaer:FeatureCollectionCalculator xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:imaer="http://imaer.aerius.nl/6.0" gml:id="NL.IMAER.Collection" xsi:schemaLocation="http://imaer.aerius.nl/6.0 https://imaer.aerius.nl/6.0/IMAER.xsd">
+    <imaer:metadata>
+        <imaer:AeriusCalculatorMetadata>
+            <imaer:project>
+                <imaer:ProjectMetadata>
+                    <imaer:year>2013</imaer:year>
+                    <imaer:name>Situatie 1</imaer:name>
+                </imaer:ProjectMetadata>
+            </imaer:project>
+            <imaer:situation>
+                <imaer:SituationMetadata>
+                    <imaer:name>Situatie 1</imaer:name>
+                    <imaer:reference>RpXpU4DVH2Nw</imaer:reference>
+                    <imaer:situationType>PROPOSED</imaer:situationType>
+                </imaer:SituationMetadata>
+            </imaer:situation>
+            <imaer:version>
+                <imaer:VersionMetadata>
+                    <imaer:aeriusVersion>DEV</imaer:aeriusVersion>
+                    <imaer:databaseVersion>BETA8_20140904_7fbba21b46</imaer:databaseVersion>
+                </imaer:VersionMetadata>
+            </imaer:version>
+        </imaer:AeriusCalculatorMetadata>
+    </imaer:metadata>
+    <imaer:featureMember>
+        <imaer:FarmAnimalHousingSource sectorId="4110" gml:id="ES.6">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>ES.6</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:label>Boerderij</imaer:label>
+            <imaer:emissionSourceCharacteristics>
+                <imaer:EmissionSourceCharacteristics>
+                    <imaer:heatContent>
+                        <imaer:SpecifiedHeatContent>
+                            <imaer:value>0.0</imaer:value>
+                        </imaer:SpecifiedHeatContent>
+                    </imaer:heatContent>
+                    <imaer:emissionHeight>5.0</imaer:emissionHeight>
+                </imaer:EmissionSourceCharacteristics>
+            </imaer:emissionSourceCharacteristics>
+            <imaer:geometry>
+                <imaer:EmissionSourceGeometry>
+                    <imaer:GM_Point>
+                        <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="ES.6.POINT">
+                            <gml:pos>69462.46 443548.56</gml:pos>
+                        </gml:Point>
+                    </imaer:GM_Point>
+                </imaer:EmissionSourceGeometry>
+            </imaer:geometry>
+            <imaer:emission>
+                <imaer:Emission substance="NH3">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NOX">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="PM10">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:emission>
+                <imaer:Emission substance="NO2">
+                    <imaer:value>0.0</imaer:value>
+                </imaer:Emission>
+            </imaer:emission>
+            <imaer:animalHousing>
+                <imaer:CustomFarmAnimalHousing animalType="X">
+                    <imaer:numberOfAnimals>100</imaer:numberOfAnimals>
+                    <imaer:description>X9.8, LWB1999.0.1</imaer:description>
+                    <imaer:emissionFactor>
+                        <imaer:Emission substance="NH3">
+                            <imaer:value>0.0</imaer:value>
+                        </imaer:Emission>
+                    </imaer:emissionFactor>
+                    <imaer:emissionFactorType>PER_ANIMAL_PER_YEAR</imaer:emissionFactorType>
+                </imaer:CustomFarmAnimalHousing>
+            </imaer:animalHousing>
+        </imaer:FarmAnimalHousingSource>
+    </imaer:featureMember>
+</imaer:FeatureCollectionCalculator>


### PR DESCRIPTION
Instead of an empty description, the description should now contain the main codes used in the old lodging definition. Only the main one, not any of the additional stuff, that would just get messy.