### PR TITLE
AER-2978 Validation on building radius

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/importer/ImaerImporter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/importer/ImaerImporter.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 
 import org.apache.commons.io.input.ReaderInputStream;
 import org.slf4j.Logger;
@@ -284,7 +283,7 @@ public class ImaerImporter {
   private static List<CalculationPointFeature> filterCalculationPoints(final List<CalculationPointFeature> points) {
     return points.stream()
         .filter(p -> p.getProperties() instanceof CustomCalculationPoint)
-        .collect(Collectors.toList());
+        .toList();
   }
 
   /**
@@ -341,12 +340,13 @@ public class ImaerImporter {
     }
   }
 
-  private static void addBuildings(final GMLReader reader, final Set<ImportOption> importOptions, final ImportParcel result,
+  private void addBuildings(final GMLReader reader, final Set<ImportOption> importOptions, final ImportParcel result,
       final ScenarioSituation situation) {
     if (ImportOption.INCLUDE_SOURCES.in(importOptions)) {
       final List<BuildingFeature> buildings = reader.getBuildings();
       if (ImportOption.VALIDATE_SOURCES.in(importOptions)) {
-        BuildingValidator.validateBuildings(buildings, result.getExceptions(), result.getWarnings());
+        BuildingValidator.validateBuildings(buildings, factory.createValidationHelper().buildingLimits(),
+            result.getExceptions(), result.getWarnings());
       }
       situation.getBuildingsList().addAll(buildings);
     }

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
@@ -203,7 +203,8 @@ public final class AssertGML {
     when(gmlHelper.getReceptorGridSettings()).thenReturn(RECEPTOR_GRID_SETTINGS);
     mockEmissionSourceGeometryLimits(gmlHelper);
     when(gmlHelper.getCharacteristicsType()).thenAnswer((i) -> currentCharacteristicsType);
-    final TestValidationAndEmissionHelper valiationAndEmissionHelper = new TestValidationAndEmissionHelper();
+    final TestValidationAndEmissionHelper valiationAndEmissionHelper = new TestValidationAndEmissionHelper(
+        () -> currentCharacteristicsType);
     doAnswer(invocation -> {
       final List<EmissionSourceFeature> arg1 = (List<EmissionSourceFeature>) invocation.getArgument(1);
 

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLRoundtripTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLRoundtripTest.java
@@ -121,7 +121,7 @@ class GMLRoundtripTest {
       {"industry_with_calculated_heat_content", CharacteristicsType.OPS},
       {"industry_with_default_emission_temperature", CharacteristicsType.OPS},
       {"industry_with_building", CharacteristicsType.OPS},
-      {"industry_with_circular_building", CharacteristicsType.OPS},
+      {"industry_with_circular_building", CharacteristicsType.ADMS},
       {"two_networks", CharacteristicsType.OPS},
       {"road_srm1", CharacteristicsType.OPS},
       {"nsl_full_example", CharacteristicsType.OPS},

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/test/TestValidationAndEmissionHelper.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/test/TestValidationAndEmissionHelper.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalDouble;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 
 import nl.overheid.aerius.gml.base.GMLLegacyCodeConverter.Conversion;
@@ -31,8 +32,12 @@ import nl.overheid.aerius.gml.base.conversion.MobileSourceOffRoadConversion;
 import nl.overheid.aerius.gml.base.conversion.PlanConversion;
 import nl.overheid.aerius.shared.domain.Substance;
 import nl.overheid.aerius.shared.domain.ops.DiurnalVariation;
+import nl.overheid.aerius.shared.domain.ops.OPSLimits;
+import nl.overheid.aerius.shared.domain.v2.building.BuildingLimits;
+import nl.overheid.aerius.shared.domain.v2.characteristics.CharacteristicsType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.adms.ADMSLimits;
 import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.domain.v2.source.road.RoadStandardEmissionFactorsKey;
 import nl.overheid.aerius.shared.domain.v2.source.road.RoadStandardsInterpolationValues;
@@ -542,6 +547,17 @@ public class TestValidationAndEmissionHelper implements ValidationHelper, Emissi
         helper -> conversions.put(helper.oldCode,
             new FarmLodgingConversion(helper.newAnimalTypeCode, helper.newAnimalHousingCode, helper.newAdditionalSystemCode)));
     return conversions;
+  }
+
+  private final Supplier<CharacteristicsType> characteristicsType;
+
+  public TestValidationAndEmissionHelper(final Supplier<CharacteristicsType> characteristicsType) {
+    this.characteristicsType = characteristicsType;
+  }
+
+  @Override
+  public BuildingLimits buildingLimits() {
+    return characteristicsType.get() == CharacteristicsType.ADMS ? ADMSLimits.INSTANCE : OPSLimits.INSTANCE;
   }
 
   @Override

--- a/source/imaer-gml/src/test/resources/gml/v5_0/roundtrip/industry_with_circular_building.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_0/roundtrip/industry_with_circular_building.gml
@@ -33,20 +33,22 @@
             </imaer:identifier>
             <imaer:label>Steenfabriek</imaer:label>
             <imaer:emissionSourceCharacteristics>
-                <imaer:EmissionSourceCharacteristics>
+                <imaer:ADMSSourceCharacteristics>
                     <imaer:building xlink:href="#Building.1"/>
-                    <imaer:heatContent>
-                        <imaer:SpecifiedHeatContent>
-                            <imaer:value>0.22</imaer:value>
-                        </imaer:SpecifiedHeatContent>
-                    </imaer:heatContent>
-                    <imaer:emissionHeight>35.0</imaer:emissionHeight>
+                    <imaer:height>35.0</imaer:height>
+                    <imaer:specificHeatCapacity>342.12</imaer:specificHeatCapacity>
+                    <imaer:sourceType>POINT</imaer:sourceType>
+                    <imaer:diameter>4.3</imaer:diameter>
+                    <imaer:buoyancyType>DENSITY</imaer:buoyancyType>
+                    <imaer:density>58.23</imaer:density>
+                    <imaer:effluxType>VELOCITY</imaer:effluxType>
+                    <imaer:verticalVelocity>49.2</imaer:verticalVelocity>
                     <imaer:diurnalVariation>
                         <imaer:StandardDiurnalVariation>
-                            <imaer:standardType>INDUSTRIAL_ACTIVITY</imaer:standardType>
+                            <imaer:standardType>SOME_TYPE</imaer:standardType>
                         </imaer:StandardDiurnalVariation>
                     </imaer:diurnalVariation>
-                </imaer:EmissionSourceCharacteristics>
+                </imaer:ADMSSourceCharacteristics>
             </imaer:emissionSourceCharacteristics>
             <imaer:geometry>
                 <imaer:EmissionSourceGeometry>

--- a/source/imaer-gml/src/test/resources/gml/v5_1/roundtrip/industry_with_circular_building.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_1/roundtrip/industry_with_circular_building.gml
@@ -33,20 +33,22 @@
             </imaer:identifier>
             <imaer:label>Steenfabriek</imaer:label>
             <imaer:emissionSourceCharacteristics>
-                <imaer:EmissionSourceCharacteristics>
+                <imaer:ADMSSourceCharacteristics>
                     <imaer:building xlink:href="#Building.1"/>
-                    <imaer:heatContent>
-                        <imaer:SpecifiedHeatContent>
-                            <imaer:value>0.22</imaer:value>
-                        </imaer:SpecifiedHeatContent>
-                    </imaer:heatContent>
-                    <imaer:emissionHeight>35.0</imaer:emissionHeight>
+                    <imaer:height>35.0</imaer:height>
+                    <imaer:specificHeatCapacity>342.12</imaer:specificHeatCapacity>
+                    <imaer:sourceType>POINT</imaer:sourceType>
+                    <imaer:diameter>4.3</imaer:diameter>
+                    <imaer:buoyancyType>DENSITY</imaer:buoyancyType>
+                    <imaer:density>58.23</imaer:density>
+                    <imaer:effluxType>VELOCITY</imaer:effluxType>
+                    <imaer:verticalVelocity>49.2</imaer:verticalVelocity>
                     <imaer:diurnalVariation>
                         <imaer:StandardDiurnalVariation>
-                            <imaer:standardType>INDUSTRIAL_ACTIVITY</imaer:standardType>
+                            <imaer:standardType>SOME_TYPE</imaer:standardType>
                         </imaer:StandardDiurnalVariation>
                     </imaer:diurnalVariation>
-                </imaer:EmissionSourceCharacteristics>
+                </imaer:ADMSSourceCharacteristics>
             </imaer:emissionSourceCharacteristics>
             <imaer:geometry>
                 <imaer:EmissionSourceGeometry>

--- a/source/imaer-gml/src/test/resources/gml/v6_0/roundtrip/industry_with_circular_building.gml
+++ b/source/imaer-gml/src/test/resources/gml/v6_0/roundtrip/industry_with_circular_building.gml
@@ -33,20 +33,22 @@
             </imaer:identifier>
             <imaer:label>Steenfabriek</imaer:label>
             <imaer:emissionSourceCharacteristics>
-                <imaer:EmissionSourceCharacteristics>
+                <imaer:ADMSSourceCharacteristics>
                     <imaer:building xlink:href="#Building.1"/>
-                    <imaer:heatContent>
-                        <imaer:SpecifiedHeatContent>
-                            <imaer:value>0.22</imaer:value>
-                        </imaer:SpecifiedHeatContent>
-                    </imaer:heatContent>
-                    <imaer:emissionHeight>35.0</imaer:emissionHeight>
-                    <imaer:timeVaryingProfile>
+                    <imaer:height>35.0</imaer:height>
+                    <imaer:specificHeatCapacity>342.12</imaer:specificHeatCapacity>
+                    <imaer:sourceType>POINT</imaer:sourceType>
+                    <imaer:diameter>4.3</imaer:diameter>
+                    <imaer:buoyancyType>DENSITY</imaer:buoyancyType>
+                    <imaer:density>58.23</imaer:density>
+                    <imaer:effluxType>VELOCITY</imaer:effluxType>
+                    <imaer:verticalVelocity>49.2</imaer:verticalVelocity>
+                    <imaer:hourlyVariation>
                         <imaer:StandardTimeVaryingProfile>
-                            <imaer:standardType>INDUSTRIAL_ACTIVITY</imaer:standardType>
+                            <imaer:standardType>SOME_TYPE</imaer:standardType>
                         </imaer:StandardTimeVaryingProfile>
-                    </imaer:timeVaryingProfile>
-                </imaer:EmissionSourceCharacteristics>
+                    </imaer:hourlyVariation>
+                </imaer:ADMSSourceCharacteristics>
             </imaer:emissionSourceCharacteristics>
             <imaer:geometry>
                 <imaer:EmissionSourceGeometry>

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/ops/OPSLimits.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/ops/OPSLimits.java
@@ -484,4 +484,15 @@ public final class OPSLimits implements BuildingLimits {
   public double buildingLengthMaximum() {
     return SCOPE_BUILDING_LENGTH_MAXIMUM;
   }
+
+  @Override
+  public double buildingDiameterMinimum() {
+    return 0;
+  }
+
+  @Override
+  public double buildingDiameterMaximum() {
+    return Double.MAX_VALUE;
+  }
+
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/building/BuildingLimits.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/building/BuildingLimits.java
@@ -43,4 +43,8 @@ public interface BuildingLimits extends Serializable {
   double buildingLengthMinimum();
 
   double buildingLengthMaximum();
+
+  double buildingDiameterMinimum();
+
+  double buildingDiameterMaximum();
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/adms/ADMSLimits.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/adms/ADMSLimits.java
@@ -91,6 +91,9 @@ public final class ADMSLimits implements BuildingLimits {
   public static final double BUILDING_LENGTH_MINIMUM = 0.001;
   public static final double BUILDING_LENGTH_MAXIMUM = 1_000;
 
+  public static final double BUILDING_DIAMETER_MINIMUM = 0.001;
+  public static final double BUILDING_DIAMETER_MAXIMUM = 1_000;
+
   public static final int ROAD_GRADIENT_MIN = -50;
   public static final int ROAD_GRADIENT_MAX = 50;
   public static final int ROAD_ELEVATION_MIN = 0;
@@ -179,5 +182,15 @@ public final class ADMSLimits implements BuildingLimits {
   @Override
   public double buildingLengthMaximum() {
     return BUILDING_LENGTH_MAXIMUM;
+  }
+
+  @Override
+  public double buildingDiameterMinimum() {
+    return BUILDING_DIAMETER_MINIMUM;
+  }
+
+  @Override
+  public double buildingDiameterMaximum() {
+    return BUILDING_DIAMETER_MAXIMUM;
   }
 }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/exception/ImaerExceptionReason.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/exception/ImaerExceptionReason.java
@@ -628,9 +628,9 @@ public enum ImaerExceptionReason implements Reason {
   BUILDING_HEIGHT_ZERO(5241),
 
   /**
-   * Buildingheight is < 0.
+   * Buildingheight is too low.
    *
-   * @param 0 Label of the building that has height < 0.
+   * @param 0 Label of the building that has too low a height (model-dependent).
    */
   BUILDING_HEIGHT_TOO_LOW(5242),
 
@@ -640,6 +640,13 @@ public enum ImaerExceptionReason implements Reason {
    * @param 0 Label of the circular building that has an incorrect diameter.
    */
   CIRCULAR_BUILDING_INCORRECT_DIAMETER(5243),
+
+  /**
+   * Buildingheight is too high.
+   *
+   * @param 0 Label of the building that has too high a height (model-dependent).
+   */
+  BUILDING_HEIGHT_TOO_HIGH(5244),
 
   /**
    * Value is <= 0.

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/BuildingValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/BuildingValidator.java
@@ -82,7 +82,7 @@ public final class BuildingValidator {
     // When the geometry is a point, that indicates that a circular building is defined.
     // A circular building consists of a point and a positive diameter.
     final double diameter = building.getDiameter();
-    if (feature.getGeometry() instanceof Point
+    if (buildingLimits.isCircularBuildingSupported() && feature.getGeometry() instanceof Point
         && (diameter <= buildingLimits.buildingDiameterMinimum() || diameter > buildingLimits.buildingDiameterMaximum())) {
       errors.add(new AeriusException(ImaerExceptionReason.CIRCULAR_BUILDING_INCORRECT_DIAMETER, building.getLabel()));
     }

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ScenarioSituationValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ScenarioSituationValidator.java
@@ -44,7 +44,7 @@ public final class ScenarioSituationValidator {
    */
   public static void validateSituation(final ScenarioSituation situation, final ValidationHelper validationHelper) throws AeriusException {
     validateSources(situation.getEmissionSourcesList(), validationHelper);
-    validateBuildings(situation.getBuildingsList());
+    validateBuildings(situation.getBuildingsList(), validationHelper);
     validateCimlkMeasures(situation.getCimlkMeasuresList());
     validateDefinitions(situation.getDefinitions());
   }
@@ -57,9 +57,9 @@ public final class ScenarioSituationValidator {
     }
   }
 
-  public static void validateBuildings(final List<BuildingFeature> buildings) throws AeriusException {
+  public static void validateBuildings(final List<BuildingFeature> buildings, final ValidationHelper validationHelper) throws AeriusException {
     final List<AeriusException> errors = new ArrayList<>();
-    BuildingValidator.validateBuildings(buildings, errors, new ArrayList<>());
+    BuildingValidator.validateBuildings(buildings, validationHelper.buildingLimits(), errors, new ArrayList<>());
     if (!errors.isEmpty()) {
       throw errors.get(0);
     }

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ValidationHelper.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ValidationHelper.java
@@ -16,10 +16,17 @@
  */
 package nl.overheid.aerius.validation;
 
+import nl.overheid.aerius.shared.domain.ops.OPSLimits;
+import nl.overheid.aerius.shared.domain.v2.building.BuildingLimits;
+
 /**
- * Interface to help with validating sources.
+ * Interface to help with validating sources and buildings.
  */
 public interface ValidationHelper {
+
+  default BuildingLimits buildingLimits() {
+    return OPSLimits.INSTANCE;
+  }
 
   FarmLodgingValidationHelper farmLodgingValidation();
 

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/BuildingValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/BuildingValidatorTest.java
@@ -18,14 +18,21 @@ package nl.overheid.aerius.validation;
 
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 import nl.overheid.aerius.shared.domain.v2.building.Building;
 import nl.overheid.aerius.shared.domain.v2.building.BuildingFeature;
+import nl.overheid.aerius.shared.domain.v2.building.BuildingLimits;
 import nl.overheid.aerius.shared.domain.v2.geojson.LineString;
 import nl.overheid.aerius.shared.domain.v2.geojson.Point;
 import nl.overheid.aerius.shared.domain.v2.geojson.Polygon;
@@ -37,17 +44,39 @@ class BuildingValidatorTest {
   private static final String BUILDING_ID = "OurBuildingId";
   private static final String BUILDING_LABEL = "One More Building";
 
-  @Test
-  void testValidBuilding() {
-    final BuildingFeature building = createBuilding(1);
+  @ParameterizedTest
+  @MethodSource("casesForPolygonBuilding")
+  void testValidBuilding(final double height, final ImaerExceptionReason errorReason, final ImaerExceptionReason warningReason) {
+    final BuildingFeature building = createBuilding(height);
 
     final List<AeriusException> errors = new ArrayList<>();
     final List<AeriusException> warnings = new ArrayList<>();
 
-    BuildingValidator.validateBuildings(List.of(building), errors, warnings);
+    BuildingValidator.validateBuildings(List.of(building), limits(), errors, warnings);
 
-    assertEquals(List.of(), errors, "No errors");
-    assertEquals(List.of(), warnings, "No warnings");
+    if (errorReason == null) {
+      assertEquals(List.of(), errors, "No errors");
+    } else {
+      assertEquals(1, errors.size(), "Number of errors");
+      assertEquals(errorReason, errors.get(0).getReason(), "Error reason");
+      assertArrayEquals(new Object[] {BUILDING_LABEL}, errors.get(0).getArgs(), "Arguments");
+    }
+    if (warningReason == null) {
+      assertEquals(List.of(), warnings, "No warnings");
+    } else {
+      assertEquals(1, warnings.size(), "Number of warnings");
+      assertEquals(warningReason, warnings.get(0).getReason(), "Error reason");
+      assertArrayEquals(new Object[] {BUILDING_LABEL}, warnings.get(0).getArgs(), "Arguments");
+    }
+  }
+
+  private static Stream<Arguments> casesForPolygonBuilding() {
+    return Stream.of(
+        Arguments.of(-0.00001, ImaerExceptionReason.BUILDING_HEIGHT_TOO_LOW, null),
+        Arguments.of(0.0, null, ImaerExceptionReason.BUILDING_HEIGHT_ZERO),
+        Arguments.of(0.00001, null, null),
+        Arguments.of(2.0, null, null),
+        Arguments.of(2.00001, ImaerExceptionReason.BUILDING_HEIGHT_TOO_HIGH, null));
   }
 
   @Test
@@ -58,7 +87,7 @@ class BuildingValidatorTest {
     final List<AeriusException> errors = new ArrayList<>();
     final List<AeriusException> warnings = new ArrayList<>();
 
-    BuildingValidator.validateBuildings(List.of(building), errors, warnings);
+    BuildingValidator.validateBuildings(List.of(building), limits(), errors, warnings);
 
     assertEquals(1, errors.size(), "Number of errors");
     assertEquals(ImaerExceptionReason.GML_GEOMETRY_NOT_PERMITTED, errors.get(0).getReason(), "Error reason");
@@ -66,38 +95,39 @@ class BuildingValidatorTest {
     assertEquals(List.of(), warnings, "No warnings");
   }
 
-  @Test
-  void testBuildingZeroHeight() {
-    final BuildingFeature building = createBuilding(0);
+  @ParameterizedTest
+  @MethodSource("casesForCircularBuilding")
+  void testValidCircularBuilding(final double diameter, final boolean valid) {
+    final BuildingFeature building = createBuilding(1);
+    building.setGeometry(new Point(0, 0));
+    building.getProperties().setDiameter(diameter);
 
     final List<AeriusException> errors = new ArrayList<>();
     final List<AeriusException> warnings = new ArrayList<>();
 
-    BuildingValidator.validateBuildings(List.of(building), errors, warnings);
+    BuildingValidator.validateBuildings(List.of(building), limits(), errors, warnings);
 
-    assertEquals(List.of(), errors, "No errors");
-    assertEquals(1, warnings.size(), "Number of warnings");
-    assertEquals(ImaerExceptionReason.BUILDING_HEIGHT_ZERO, warnings.get(0).getReason(), "Error reason");
-    assertArrayEquals(new Object[] {BUILDING_LABEL}, warnings.get(0).getArgs(), "Arguments");
+    if (valid) {
+      assertEquals(List.of(), errors, "No errors");
+      assertEquals(List.of(), warnings, "No warnings");
+    } else {
+      assertEquals(1, errors.size(), "Number of errors");
+      assertEquals(ImaerExceptionReason.CIRCULAR_BUILDING_INCORRECT_DIAMETER, errors.get(0).getReason(), "Error reason");
+      assertArrayEquals(new Object[] {BUILDING_LABEL}, errors.get(0).getArgs(), "Arguments");
+      assertEquals(List.of(), warnings, "No warnings");
+    }
+  }
+
+  private static Stream<Arguments> casesForCircularBuilding() {
+    return Stream.of(
+        Arguments.of(0.0, false),
+        Arguments.of(0.00001, true),
+        Arguments.of(3.0, true),
+        Arguments.of(3.00001, false));
   }
 
   @Test
-  void testBuildingNegativeHeight() {
-    final BuildingFeature building = createBuilding(-1);
-
-    final List<AeriusException> errors = new ArrayList<>();
-    final List<AeriusException> warnings = new ArrayList<>();
-
-    BuildingValidator.validateBuildings(List.of(building), errors, warnings);
-
-    assertEquals(1, errors.size(), "Number of errors");
-    assertEquals(ImaerExceptionReason.BUILDING_HEIGHT_TOO_LOW, errors.get(0).getReason(), "Error reason");
-    assertArrayEquals(new Object[] {BUILDING_LABEL}, errors.get(0).getArgs(), "Arguments");
-    assertEquals(List.of(), warnings, "No warnings");
-  }
-
-  @Test
-  void testValidCircularBuilding() {
+  void testCircularBuildingNotAllowed() {
     final BuildingFeature building = createBuilding(1);
     building.setGeometry(new Point(0, 0));
     building.getProperties().setDiameter(1);
@@ -105,27 +135,25 @@ class BuildingValidatorTest {
     final List<AeriusException> errors = new ArrayList<>();
     final List<AeriusException> warnings = new ArrayList<>();
 
-    BuildingValidator.validateBuildings(List.of(building), errors, warnings);
+    final BuildingLimits limits = mock(BuildingLimits.class);
+    lenient().when(limits.isCircularBuildingSupported()).thenReturn(false);
 
-    assertEquals(List.of(), errors, "No errors");
+    BuildingValidator.validateBuildings(List.of(building), limits, errors, warnings);
+
+    assertEquals(1, errors.size(), "Number of errors");
+    assertEquals(ImaerExceptionReason.GML_GEOMETRY_NOT_PERMITTED, errors.get(0).getReason(), "Error reason");
+    assertArrayEquals(new Object[] {BUILDING_LABEL}, errors.get(0).getArgs(), "Arguments");
     assertEquals(List.of(), warnings, "No warnings");
   }
 
-  @Test
-  void testCircularBuildingIncorrectDiameter() {
-    final BuildingFeature building = createBuilding(1);
-    building.setGeometry(new Point(0, 0));
-    building.getProperties().setDiameter(0);
-
-    final List<AeriusException> errors = new ArrayList<>();
-    final List<AeriusException> warnings = new ArrayList<>();
-
-    BuildingValidator.validateBuildings(List.of(building), errors, warnings);
-
-    assertEquals(1, errors.size(), "Number of errors");
-    assertEquals(ImaerExceptionReason.CIRCULAR_BUILDING_INCORRECT_DIAMETER, errors.get(0).getReason(), "Error reason");
-    assertArrayEquals(new Object[] {BUILDING_LABEL}, errors.get(0).getArgs(), "Arguments");
-    assertEquals(List.of(), warnings, "No warnings");
+  private static BuildingLimits limits() {
+    final BuildingLimits limits = mock(BuildingLimits.class);
+    lenient().when(limits.isCircularBuildingSupported()).thenReturn(true);
+    lenient().when(limits.buildingHeightMinimum()).thenReturn(0.0);
+    lenient().when(limits.buildingHeightMaximum()).thenReturn(2.0);
+    lenient().when(limits.buildingDiameterMinimum()).thenReturn(0.0);
+    lenient().when(limits.buildingDiameterMaximum()).thenReturn(3.0);
+    return limits;
   }
 
   private static BuildingFeature createBuilding(final double height) {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/BuildingValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/BuildingValidatorTest.java
@@ -135,7 +135,7 @@ class BuildingValidatorTest {
     final List<AeriusException> errors = new ArrayList<>();
     final List<AeriusException> warnings = new ArrayList<>();
 
-    final BuildingLimits limits = mock(BuildingLimits.class);
+    final BuildingLimits limits = limits();
     lenient().when(limits.isCircularBuildingSupported()).thenReturn(false);
 
     BuildingValidator.validateBuildings(List.of(building), limits, errors, warnings);


### PR DESCRIPTION
This change also means validation on import gets a bit stricter, and OPS characteristics based applications won't allow circular buildings anymore (which they shouldn't anyway).