### PR TITLE
AER-2978 Possibility to use warnings for building upper limits

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/ops/OPSLimits.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/ops/OPSLimits.java
@@ -446,6 +446,11 @@ public final class OPSLimits implements BuildingLimits {
   }
 
   @Override
+  public boolean isBuildingUpperLimitWarning() {
+    return true;
+  }
+
+  @Override
   public int buildingDigitsPrecision() {
     return SOURCE_BUILDING_DIGITS_PRECISION;
   }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/building/BuildingLimits.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/building/BuildingLimits.java
@@ -28,6 +28,10 @@ public interface BuildingLimits extends Serializable {
     return false;
   }
 
+  default boolean isBuildingUpperLimitWarning() {
+    return false;
+  }
+
   int buildingDigitsPrecision();
 
   double buildingHeightMinimum();


### PR DESCRIPTION
NL (OPS) does not want errors for upper limits, but wants warnings instead. Bit annoying, but this solution should work for that requirement. Also applied it to diameter, though NL does not really use that. Felt too weird to call it 'isBuildingHeightUpperLimitWarning' however, so went with this.