### PR TITLE
Consistent naming for MetDatasetType

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/MetDatasetType.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/MetDatasetType.java
@@ -24,7 +24,7 @@ import java.util.Locale;
 public enum MetDatasetType {
 
   OBS_RAW_GT_90PCT(false),
-  OBS_I_GT_75P(false),
+  OBS_I_GT_75PCT(false),
   OBS_WINDS_GT_90PCT(false),
   NWP_3KM2(true);
 


### PR DESCRIPTION
Better keep it consistent while we still can.