### PR TITLE
AER-2977 Geometry validation for ADMS + max vertices

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/adms/ADMSLimits.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/adms/ADMSLimits.java
@@ -133,6 +133,8 @@ public final class ADMSLimits implements BuildingLimits {
   public static final boolean SPATIALLY_VARYING_ROUGHNESS_DEFAULT = true;
   public static final boolean ADMS_COMPLEX_TERRAIN_DEFAULT = false;
 
+  public static final int MAX_POLYGON_CONVEX_VERTICES = 50;
+
   private static final int ADMS_MAX_BUILDINGS_PER_SITUATION = 50;
 
   public static final ADMSLimits INSTANCE = new ADMSLimits();

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/exception/ImaerExceptionReason.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/exception/ImaerExceptionReason.java
@@ -550,6 +550,12 @@ public enum ImaerExceptionReason implements Reason {
    * @param 3 the system definition code of the lodging that was converted.
    */
   GML_CONVERTED_LODGING_TO_CUSTOM(5265),
+  /**
+   * Geometry contains too many vertices.
+   *
+   * @param 0 the ID of the source with too many vertices.
+   */
+  GEOMETRY_TOO_MANY_VERTICES(5271),
 
 
   // Cohesion (between files) errors.

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ADMSCharacteristicsValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/ADMSCharacteristicsValidator.java
@@ -21,8 +21,13 @@ import java.util.List;
 import nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.characteristics.adms.ADMSLimits;
 import nl.overheid.aerius.shared.domain.v2.characteristics.adms.SourceType;
+import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
+import nl.overheid.aerius.shared.domain.v2.geojson.LineString;
+import nl.overheid.aerius.shared.domain.v2.geojson.Point;
+import nl.overheid.aerius.shared.domain.v2.geojson.Polygon;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
+import nl.overheid.aerius.util.GeometryUtil;
 
 /**
  * Class to validate ADMS source characteristics
@@ -34,25 +39,28 @@ class ADMSCharacteristicsValidator extends CharacteristicsValidator<ADMSSourceCh
   }
 
   @Override
-  boolean validate(final ADMSSourceCharacteristics characteristics) {
-    boolean valid = true;
-    if (characteristics.getSourceType() != SourceType.VOLUME && characteristics.getSourceType() != SourceType.ROAD) {
-      valid = validateADMSHeatContent(characteristics);
-    }
+  boolean validate(final ADMSSourceCharacteristics characteristics, final Geometry sourceGeometry) {
+    boolean valid = validateGeometry(characteristics, sourceGeometry);
+    valid = validateADMSHeatContent(characteristics) && valid;
     validateADMSVolumeHeight(characteristics);
     return valid;
   }
 
   private boolean validateADMSHeatContent(final ADMSSourceCharacteristics characteristics) {
     boolean valid = true;
-    if (characteristics.getSpecificHeatCapacity() < ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM
-        || characteristics.getSpecificHeatCapacity() > ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM) {
+    if (expectValidHeatContent(characteristics.getSourceType()) &&
+        (characteristics.getSpecificHeatCapacity() < ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM
+            || characteristics.getSpecificHeatCapacity() > ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM)) {
       errors.add(new AeriusException(ImaerExceptionReason.HEAT_CAPACITY_OUT_OF_RANGE, sourceId,
           String.valueOf(characteristics.getSpecificHeatCapacity()), String.valueOf(ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MINIMUM),
           String.valueOf(ADMSLimits.SOURCE_SPECIFIC_HEAT_CAPACITY_MAXIMUM)));
       valid = false;
     }
     return valid;
+  }
+
+  private boolean expectValidHeatContent(final SourceType sourceType) {
+    return sourceType != SourceType.VOLUME && sourceType != SourceType.ROAD;
   }
 
   /**
@@ -65,4 +73,64 @@ class ADMSCharacteristicsValidator extends CharacteristicsValidator<ADMSSourceCh
       warnings.add(new AeriusException(ImaerExceptionReason.SOURCE_VOLUME_FLOATING, sourceId));
     }
   }
+
+  private boolean validateGeometry(final ADMSSourceCharacteristics characteristics, final Geometry sourceGeometry) {
+    return switch (characteristics.getSourceType()) {
+    case POINT, JET -> validPointGeometry(sourceGeometry);
+    case LINE, ROAD -> validLineGeometry(sourceGeometry);
+    case AREA, VOLUME -> validPolygonGeometry(sourceGeometry);
+    };
+  }
+
+  private boolean validPointGeometry(final Geometry sourceGeometry) {
+    boolean valid = true;
+    if (!(sourceGeometry instanceof Point)) {
+      errors.add(new AeriusException(ImaerExceptionReason.GML_GEOMETRY_NOT_PERMITTED, sourceId));
+      valid = false;
+    }
+    return valid;
+  }
+
+  private boolean validLineGeometry(final Geometry sourceGeometry) {
+    boolean valid = true;
+    if (!(sourceGeometry instanceof LineString)) {
+      errors.add(new AeriusException(ImaerExceptionReason.GML_GEOMETRY_NOT_PERMITTED, sourceId));
+      valid = false;
+    }
+    return valid;
+  }
+
+  private boolean validPolygonGeometry(final Geometry sourceGeometry) {
+    boolean valid = true;
+    if (sourceGeometry instanceof final Polygon polygon) {
+      valid = validPolygon(polygon);
+    } else {
+      errors.add(new AeriusException(ImaerExceptionReason.GML_GEOMETRY_NOT_PERMITTED, sourceId));
+      valid = false;
+    }
+    return valid;
+  }
+
+  private boolean validPolygon(final Polygon polygon) {
+    boolean valid = true;
+    // Quick check on nr of vertices. Convex hull always has same or less number of vertices as the original polygon.
+    // So if original already has less than maximum, the convex hull will also be less.
+    // + 1 as the begin and end point should be the same and only unique points should be considered anyway.
+    if (polygon.getCoordinates()[0].length > ADMSLimits.MAX_POLYGON_CONVEX_VERTICES + 1) {
+      try {
+        // Convert to convex hull and check nr of vertices again. If this is above the maximum, then it's invalid.
+        // SRID doesn't matter too much in this case.
+        final Polygon convexHull = GeometryUtil.toConvexHull(polygon, 0);
+        if (convexHull.getCoordinates()[0].length > ADMSLimits.MAX_POLYGON_CONVEX_VERTICES + 1) {
+          errors.add(new AeriusException(ImaerExceptionReason.GEOMETRY_TOO_MANY_VERTICES, sourceId));
+          valid = false;
+        }
+      } catch (final AeriusException e) {
+        errors.add(e);
+        valid = false;
+      }
+    }
+    return valid;
+  }
+
 }

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/CharacteristicsValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/CharacteristicsValidator.java
@@ -19,6 +19,7 @@ package nl.overheid.aerius.validation;
 import java.util.List;
 
 import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.exception.AeriusException;
 
 /**
@@ -41,8 +42,9 @@ abstract class CharacteristicsValidator<T extends SourceCharacteristics> {
    * If no validation errors should return true.
    *
    * @param characteristics characteristics to validate
+   * @param sourceGeometry the geometry of the associated source
    * @return true if no validation errors
    */
-  abstract boolean validate(final T characteristics);
+  abstract boolean validate(final T characteristics, final Geometry sourceGeometry);
 
 }

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/OPSCharacteristicsValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/OPSCharacteristicsValidator.java
@@ -21,6 +21,7 @@ import java.util.List;
 import nl.overheid.aerius.shared.domain.ops.OPSLimits;
 import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 
@@ -34,7 +35,7 @@ class OPSCharacteristicsValidator extends CharacteristicsValidator<OPSSourceChar
   }
 
   @Override
-  boolean validate(final OPSSourceCharacteristics characteristics) {
+  boolean validate(final OPSSourceCharacteristics characteristics, final Geometry sourceGeometry) {
     boolean valid = true;
     if (characteristics.getHeatContentType() == HeatContentType.NOT_FORCED) {
       valid = validateOPSForcedHeatContent(characteristics);

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/SourceValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/SourceValidator.java
@@ -49,7 +49,7 @@ abstract class SourceValidator<T extends EmissionSource> {
    */
   final boolean validate(final T source, final IsFeature feature) {
     boolean valid = validateGeometry(feature.getGeometry());
-    valid = validateCharacteristics(source.getCharacteristics(), source.getGmlId()) && valid;
+    valid = validateCharacteristics(source.getCharacteristics(), feature.getGeometry(), source.getGmlId()) && valid;
     valid = validate(source) && valid;
     return valid;
   }
@@ -69,11 +69,11 @@ abstract class SourceValidator<T extends EmissionSource> {
     return true;
   }
 
-  protected boolean validateCharacteristics(final SourceCharacteristics characteristics, final String sourceId) {
-    if (characteristics instanceof OPSSourceCharacteristics) {
-      return new OPSCharacteristicsValidator(errors, warnings, sourceId).validate((OPSSourceCharacteristics) characteristics);
-    } else if (characteristics instanceof ADMSSourceCharacteristics) {
-      return new ADMSCharacteristicsValidator(errors, warnings, sourceId).validate((ADMSSourceCharacteristics) characteristics);
+  protected boolean validateCharacteristics(final SourceCharacteristics characteristics, final Geometry sourceGeometry, final String sourceId) {
+    if (characteristics instanceof final OPSSourceCharacteristics opsChars) {
+      return new OPSCharacteristicsValidator(errors, warnings, sourceId).validate(opsChars, sourceGeometry);
+    } else if (characteristics instanceof final ADMSSourceCharacteristics admsChars) {
+      return new ADMSCharacteristicsValidator(errors, warnings, sourceId).validate(admsChars, sourceGeometry);
     } else {
       return true;
     }

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/ADMSCharacteristicsValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/ADMSCharacteristicsValidatorTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +35,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 import nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.characteristics.adms.ADMSLimits;
 import nl.overheid.aerius.shared.domain.v2.characteristics.adms.SourceType;
+import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
+import nl.overheid.aerius.shared.domain.v2.geojson.LineString;
+import nl.overheid.aerius.shared.domain.v2.geojson.Point;
+import nl.overheid.aerius.shared.domain.v2.geojson.Polygon;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 
@@ -46,14 +52,15 @@ class ADMSCharacteristicsValidatorTest {
   @Test
   void testValidADMSCharacteristics() {
     final ADMSSourceCharacteristics characteristics = new ADMSSourceCharacteristics();
-    characteristics.setSourceType(SourceType.POINT);
+    final SourceType sourceType = SourceType.POINT;
+    characteristics.setSourceType(sourceType);
     characteristics.setSpecificHeatCapacity(30.0);
 
     final List<AeriusException> errors = new ArrayList<>();
     final List<AeriusException> warnings = new ArrayList<>();
     final ADMSCharacteristicsValidator validator = new ADMSCharacteristicsValidator(errors, warnings, SOURCE_ID);
 
-    final boolean valid = validator.validate(characteristics);
+    final boolean valid = validator.validate(characteristics, mockValidGeometry(sourceType));
 
     assertTrue(valid, "Valid test case");
     assertEquals(List.of(), errors, "No errors");
@@ -71,7 +78,7 @@ class ADMSCharacteristicsValidatorTest {
     final List<AeriusException> warnings = new ArrayList<>();
     final ADMSCharacteristicsValidator validator = new ADMSCharacteristicsValidator(errors, warnings, SOURCE_ID);
 
-    final boolean valid = validator.validate(characteristics);
+    final boolean valid = validator.validate(characteristics, mockValidGeometry(sourceType));
 
     if (expectedValid) {
       assertTrue(valid, "Valid test case");
@@ -116,13 +123,168 @@ class ADMSCharacteristicsValidatorTest {
     final List<AeriusException> warnings = new ArrayList<>();
     final ADMSCharacteristicsValidator validator = new ADMSCharacteristicsValidator(errors, warnings, SOURCE_ID);
 
-    assertTrue(validator.validate(characteristics), "Should not give validation error on height check");
+    assertTrue(validator.validate(characteristics, mockValidGeometry(sourceType)), "Should not give validation error on height check");
     if (warning) {
       assertEquals(1, warnings.size(), "Number of warning");
       assertEquals(ImaerExceptionReason.SOURCE_VOLUME_FLOATING, warnings.get(0).getReason(), "Expected source volume floating warning.");
     } else {
       assertTrue(warnings.isEmpty(), "Didn't expect any warnings");
     }
+  }
+
+  @ParameterizedTest
+  @MethodSource("casesForGeometry")
+  void testADMSGeometry(final SourceType sourceType, final Geometry geometry, final boolean expectedValid) {
+    final ADMSSourceCharacteristics characteristics = new ADMSSourceCharacteristics();
+    characteristics.setSourceType(sourceType);
+    characteristics.setSpecificHeatCapacity(30.0);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+    final ADMSCharacteristicsValidator validator = new ADMSCharacteristicsValidator(errors, warnings, SOURCE_ID);
+
+    final boolean valid = validator.validate(characteristics, geometry);
+
+    if (expectedValid) {
+      assertTrue(valid, "Valid test case");
+      assertEquals(List.of(), errors, "No errors");
+      assertEquals(List.of(), warnings, "No warnings");
+    } else {
+      assertFalse(valid, "Invalid test case");
+      assertEquals(1, errors.size(), "Number of errors");
+      assertEquals(ImaerExceptionReason.GML_GEOMETRY_NOT_PERMITTED, errors.get(0).getReason(), "Error reason");
+      assertArrayEquals(new Object[] {
+          SOURCE_ID
+      }, errors.get(0).getArgs(), "Arguments");
+    }
+  }
+
+  private static Stream<Arguments> casesForGeometry() {
+    return Stream.of(
+        Arguments.of(SourceType.POINT, mockPoint(), true),
+        Arguments.of(SourceType.POINT, mockLineString(), false),
+        Arguments.of(SourceType.POINT, mockPolygon(), false),
+        Arguments.of(SourceType.AREA, mockPoint(), false),
+        Arguments.of(SourceType.AREA, mockLineString(), false),
+        Arguments.of(SourceType.AREA, mockPolygon(), true),
+        Arguments.of(SourceType.VOLUME, mockPoint(), false),
+        Arguments.of(SourceType.VOLUME, mockLineString(), false),
+        Arguments.of(SourceType.VOLUME, mockPolygon(), true),
+        Arguments.of(SourceType.LINE, mockPoint(), false),
+        Arguments.of(SourceType.LINE, mockLineString(), true),
+        Arguments.of(SourceType.LINE, mockPolygon(), false),
+        Arguments.of(SourceType.ROAD, mockPoint(), false),
+        Arguments.of(SourceType.ROAD, mockLineString(), true),
+        Arguments.of(SourceType.ROAD, mockPolygon(), false));
+  }
+
+  @ParameterizedTest
+  @MethodSource("casesForGeometryPolygonVertices")
+  void testADMSGeometryPolygonVertices(final Polygon geometry, final boolean expectedValid) {
+    final ADMSSourceCharacteristics characteristics = new ADMSSourceCharacteristics();
+    characteristics.setSourceType(SourceType.AREA);
+    characteristics.setSpecificHeatCapacity(30.0);
+
+    final List<AeriusException> errors = new ArrayList<>();
+    final List<AeriusException> warnings = new ArrayList<>();
+    final ADMSCharacteristicsValidator validator = new ADMSCharacteristicsValidator(errors, warnings, SOURCE_ID);
+
+    final boolean valid = validator.validate(characteristics, geometry);
+
+    if (expectedValid) {
+      assertTrue(valid, "Valid test case");
+      assertEquals(List.of(), errors, "No errors");
+      assertEquals(List.of(), warnings, "No warnings");
+    } else {
+      assertFalse(valid, "Invalid test case");
+      assertEquals(1, errors.size(), "Number of errors");
+      assertEquals(ImaerExceptionReason.GEOMETRY_TOO_MANY_VERTICES, errors.get(0).getReason(), "Error reason");
+      assertArrayEquals(new Object[] {
+          SOURCE_ID
+      }, errors.get(0).getArgs(), "Arguments");
+    }
+  }
+
+  private static Stream<Arguments> casesForGeometryPolygonVertices() {
+    return Stream.of(
+        Arguments.of(mockPolygon(), true),
+        Arguments.of(mockPolygonConvexHullValid(), true),
+        Arguments.of(mockPolygonConvexHullInvalid(), false));
+  }
+
+  private static Geometry mockValidGeometry(final SourceType sourceType) {
+    return switch (sourceType) {
+    case POINT, JET -> mockPoint();
+    case LINE, ROAD -> mockLineString();
+    case AREA, VOLUME -> mockPolygon();
+    };
+  }
+
+  private static Geometry mockPoint() {
+    return mock(Point.class);
+  }
+
+  private static Geometry mockLineString() {
+    return mock(LineString.class);
+  }
+
+  private static Polygon mockPolygon() {
+    return mockPolygon(new double[][][] {{{0, 0}, {0, 1}, {1, 0}, {0, 0}}});
+  }
+
+  /*
+   * Closed parabola.
+   * General idea with 7 points:
+   *     9              (3*3 - 0*0)
+   *   8   8            (3*3 - 1*1)
+   *
+   *
+   *  5     5           (3*3 - 2*2)
+   *
+   *
+   *
+   *
+   * 0_______0          (3*3 - 3*3)
+   */
+  private static Polygon mockPolygonConvexHullInvalid() {
+    final List<double[]> coords = new ArrayList<>();
+    // 51 unique points
+    for (int i = -25; i <= 25; i++) {
+      coords.add(new double[] {i, 50 * 50 - i * i});
+    }
+    // Ensure it's closed by adding last again
+    coords.add(coords.get(0));
+    final double[][][] polygonCoords = new double[][][] {coords.toArray(new double[coords.size()][])};
+    return mockPolygon(polygonCoords);
+  }
+
+  /*
+   * Box with a section cut out. Convex hull should be the box.
+   * General idea with 7 points:
+   * 4   4           (-2,4), (2,4)
+   *
+   *
+   *  1 1            (-1,1), (1,1)
+   * 0 0 0           (-2,0), (0,0), (2,0)
+   */
+  private static Polygon mockPolygonConvexHullValid() {
+    final List<double[]> coords = new ArrayList<>();
+    // 51 unique points
+    coords.add(new double[] {-24, 0});
+    for (int i = -24; i <= 24; i++) {
+      coords.add(new double[] {i, i * i});
+    }
+    coords.add(new double[] {24, 0});
+    // Ensure it's closed
+    coords.add(coords.get(0));
+    final double[][][] polygonCoords = new double[][][] {coords.toArray(new double[51][])};
+    return mockPolygon(polygonCoords);
+  }
+
+  private static Polygon mockPolygon(final double[][][] coordinates) {
+    final Polygon mocked = mock(Polygon.class);
+    when(mocked.getCoordinates()).thenReturn(coordinates);
+    return mocked;
   }
 
   private static Stream<Arguments> casesForADMSVerticalDimensionHeight() {

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/OPSCharacteristicsValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/OPSCharacteristicsValidatorTest.java
@@ -20,6 +20,7 @@ import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -33,6 +34,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import nl.overheid.aerius.shared.domain.ops.OPSLimits;
 import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 
@@ -53,7 +55,7 @@ class OPSCharacteristicsValidatorTest {
     final List<AeriusException> warnings = new ArrayList<>();
     final OPSCharacteristicsValidator validator = new OPSCharacteristicsValidator(errors, warnings, SOURCE_ID);
 
-    final boolean valid = validator.validate(characteristics);
+    final boolean valid = validator.validate(characteristics, mockGeometry());
 
     assertTrue(valid, "Valid test case");
     assertEquals(List.of(), errors, "No errors");
@@ -69,7 +71,7 @@ class OPSCharacteristicsValidatorTest {
     final List<AeriusException> warnings = new ArrayList<>();
     final OPSCharacteristicsValidator validator = new OPSCharacteristicsValidator(errors, warnings, SOURCE_ID);
 
-    final boolean valid = validator.validate(characteristics);
+    final boolean valid = validator.validate(characteristics, mockGeometry());
 
     assertFalse(valid, "Invalid test case");
     assertEquals(1, errors.size(), "Number of errors");
@@ -89,7 +91,7 @@ class OPSCharacteristicsValidatorTest {
     final List<AeriusException> warnings = new ArrayList<>();
     final OPSCharacteristicsValidator validator = new OPSCharacteristicsValidator(errors, warnings, SOURCE_ID);
 
-    final boolean valid = validator.validate(characteristics);
+    final boolean valid = validator.validate(characteristics, mockGeometry());
 
     assertFalse(valid, "Invalid test case");
     assertEquals(1, errors.size(), "Number of errors");
@@ -110,7 +112,7 @@ class OPSCharacteristicsValidatorTest {
     final List<AeriusException> warnings = new ArrayList<>();
     final OPSCharacteristicsValidator validator = new OPSCharacteristicsValidator(errors, warnings, SOURCE_ID);
 
-    final boolean valid = validator.validate(characteristics);
+    final boolean valid = validator.validate(characteristics, mockGeometry());
 
     if (expectedValid) {
       assertTrue(valid, "Valid test case");
@@ -146,12 +148,16 @@ class OPSCharacteristicsValidatorTest {
     final List<AeriusException> warnings = new ArrayList<>();
     final OPSCharacteristicsValidator validator = new OPSCharacteristicsValidator(errors, warnings, SOURCE_ID);
 
-    final boolean valid = validator.validate(characteristics);
+    final boolean valid = validator.validate(characteristics, mockGeometry());
 
     // Shouldn't be validating heat content when it's not used.
     assertTrue(valid, "Valid test case");
     assertEquals(List.of(), errors, "No errors");
     assertEquals(List.of(), warnings, "No warnings");
+  }
+
+  private Geometry mockGeometry() {
+    return mock(Geometry.class);
   }
 
 }


### PR DESCRIPTION
That is, when characteristics dictate certain source types, the geometry should match it.
Also added a test on maximum vertices in the case of a polygon (area or surface).