### PR TITLE
AER-3128 Animal housing less animal type based

### DIFF
--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/test/TestValidationAndEmissionHelper.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/test/TestValidationAndEmissionHelper.java
@@ -815,12 +815,12 @@ public class TestValidationAndEmissionHelper implements ValidationHelper, Emissi
   }
 
   @Override
-  public String getAnimalBasicHousingCode(final String animalCode) {
-    return animalCode + ".100";
+  public String getAnimalBasicHousingCode(final String housingCode) {
+    return housingCode;
   }
 
   @Override
-  public Map<Substance, Double> getAdditionalHousingSystemReductionFractions(final String additionalSystemCode, final String animalCode) {
+  public Map<Substance, Double> getAdditionalHousingSystemReductionFractions(final String additionalSystemCode, final String housingCode) {
     return farmAnimalHousing(additionalSystemCode)
         .map(c -> Map.of(Substance.NH3, c.emissionFactor))
         .orElse(Map.of());

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/emissions/FarmAnimalHousingEmissionFactorSupplier.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/emissions/FarmAnimalHousingEmissionFactorSupplier.java
@@ -42,13 +42,14 @@ public interface FarmAnimalHousingEmissionFactorSupplier {
   boolean isAdditionalHousingSystemAirScrubber(String additionalSystemCode);
 
   /**
-   * Get the code of the basic housing system for an animal type.
+   * Get the code of the basic housing system for a housing system.
+   * Can return null, or the same housing code, to indicate that the housing system itself is a basic one.
    */
-  String getAnimalBasicHousingCode(String animalCode);
+  String getAnimalBasicHousingCode(String animalHousingCode);
 
   /**
    * Obtain the remaining fraction of emission for additonal system for animal housing.
    */
-  Map<Substance, Double> getAdditionalHousingSystemReductionFractions(String additionalSystemCode, String animalCode);
+  Map<Substance, Double> getAdditionalHousingSystemReductionFractions(String additionalSystemCode, String animalHousingCode);
 
 }

--- a/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/emissions/FarmAnimalHousingEmissionsCalculatorTest.java
+++ b/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/emissions/FarmAnimalHousingEmissionsCalculatorTest.java
@@ -325,7 +325,6 @@ class FarmAnimalHousingEmissionsCalculatorTest {
     housing.setNumberOfAnimals(1000);
     final String housingCode = "ABC";
     housing.setAnimalHousingCode(housingCode);
-    housing.setAnimalTypeCode("OWL");
 
     final Map<Substance, Double> emissionFactors = Map.of(Substance.NH3, 3.0);
     when(emissionFactorSupplier.getAnimalHousingEmissionFactors(housingCode)).thenReturn(emissionFactors);
@@ -338,14 +337,12 @@ class FarmAnimalHousingEmissionsCalculatorTest {
     housing.setNumberOfAnimals(1000);
     final String housingCode = "ABC";
     final String basicCode = "DEF";
-    final String animalCode = "OWL";
     housing.setAnimalHousingCode(housingCode);
-    housing.setAnimalTypeCode(animalCode);
 
     final Map<Substance, Double> emissionFactors = Map.of(Substance.NH3, 1.0, Substance.PM10, 10.0);
     final Map<Substance, Double> emissionFactorsConstrained = Map.of(Substance.NH3, 8.0, Substance.PM10, 80.0);
     lenient().when(emissionFactorSupplier.getAnimalHousingEmissionFactors(housingCode)).thenReturn(emissionFactors);
-    lenient().when(emissionFactorSupplier.getAnimalBasicHousingCode(animalCode)).thenReturn(basicCode);
+    lenient().when(emissionFactorSupplier.getAnimalBasicHousingCode(housingCode)).thenReturn(basicCode);
     lenient().when(emissionFactorSupplier.getAnimalHousingEmissionFactors(basicCode)).thenReturn(emissionFactorsConstrained);
 
     return housing;
@@ -361,7 +358,7 @@ class FarmAnimalHousingEmissionsCalculatorTest {
     additionalSystem.setAdditionalSystemCode(systemCode);
 
     final Map<Substance, Double> emissionFactors = Map.of(Substance.NH3, 0.4, Substance.PM10, 0.6);
-    when(emissionFactorSupplier.getAdditionalHousingSystemReductionFractions(systemCode, housing.getAnimalTypeCode())).thenReturn(emissionFactors);
+    when(emissionFactorSupplier.getAdditionalHousingSystemReductionFractions(systemCode, housing.getAnimalHousingCode())).thenReturn(emissionFactors);
     lenient().when(emissionFactorSupplier.isAdditionalHousingSystemAirScrubber(systemCode)).thenReturn(airScrubber);
 
     housing.getAdditionalSystems().add(additionalSystem);
@@ -373,7 +370,7 @@ class FarmAnimalHousingEmissionsCalculatorTest {
     additionalSystem.setAdditionalSystemCode(systemCode);
 
     final Map<Substance, Double> emissionFactors = Map.of(Substance.NH3, 0.05);
-    when(emissionFactorSupplier.getAdditionalHousingSystemReductionFractions(systemCode, housing.getAnimalTypeCode())).thenReturn(emissionFactors);
+    when(emissionFactorSupplier.getAdditionalHousingSystemReductionFractions(systemCode, housing.getAnimalHousingCode())).thenReturn(emissionFactors);
 
     housing.getAdditionalSystems().add(additionalSystem);
   }
@@ -392,7 +389,6 @@ class FarmAnimalHousingEmissionsCalculatorTest {
     housing.setNumberOfDays(175);
     final String housingCode = "ABC";
     housing.setAnimalHousingCode(housingCode);
-    housing.setAnimalTypeCode("OWL");
 
     final Map<Substance, Double> emissionFactors = Map.of(Substance.NH3, 0.02);
     when(emissionFactorSupplier.getAnimalHousingEmissionFactors(housingCode)).thenReturn(emissionFactors);


### PR DESCRIPTION
Basic housing is now based on animal housing category instead of the animal type. This is due to some animal types having multiple basic animal housing categories. Similarly, additional system factors are now based on animal housing category instead of the animal type. This is due to having different reduction factors for some animal housing + additional system combinations. Implementations will have to be adjusted accordingly.