### PR TITLE
AER-3132 Warning when subsource has no emissions

### DIFF
--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
@@ -64,6 +64,7 @@ import nl.overheid.aerius.shared.domain.v2.source.InlandShippingEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.MaritimeShippingEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.MooringInlandShippingEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.MooringMaritimeShippingEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.base.AbstractSubSource;
 import nl.overheid.aerius.shared.domain.v2.source.shipping.inland.InlandWaterway;
 import nl.overheid.aerius.shared.emissions.EmissionsUpdater;
 import nl.overheid.aerius.shared.exception.AeriusException;
@@ -257,8 +258,12 @@ public final class AssertGML {
         || source instanceof MooringInlandShippingEmissionSource
         || source instanceof MaritimeShippingEmissionSource
         || source instanceof MooringMaritimeShippingEmissionSource) {
+      final EmissionSourceWithSubSources<?> sourceWithSubSources = (EmissionSourceWithSubSources<?>) source;
       for (final Substance substance : Substance.values()) {
-        object.getProperties().getEmissions().put(substance, ((EmissionSourceWithSubSources<?>) source).getSubSources().size() *
+        for (final AbstractSubSource subSource : sourceWithSubSources.getSubSources()) {
+          subSource.getEmissions().put(substance, substance.getId() * 1.234);
+        }
+        source.getEmissions().put(substance, sourceWithSubSources.getSubSources().size() *
             substance.getId() * 1.234);
       }
     } else {

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/EmissionSourceVisitor.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/EmissionSourceVisitor.java
@@ -31,9 +31,7 @@ public interface EmissionSourceVisitor<T> {
   @Deprecated
   T visit(FarmLodgingEmissionSource emissionSource, IsFeature feature) throws AeriusException;
 
-  default T visit(final FarmAnimalHousingEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
-    return null;
-  }
+  T visit(FarmAnimalHousingEmissionSource emissionSource, IsFeature feature) throws AeriusException;
 
   T visit(FarmlandEmissionSource emissionSource, IsFeature feature) throws AeriusException;
 

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/exception/ImaerExceptionReason.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/exception/ImaerExceptionReason.java
@@ -674,6 +674,13 @@ public enum ImaerExceptionReason implements Reason {
    */
   UNEXPECTED_FRACTION_VALUE(5252),
 
+  /**
+   * Warning: the emission values of a subsource are zero.
+   *
+   * @param 0 The label of the source that has a subsource with zero emissions.
+   */
+  SUB_SOURCE_NO_EMISSION(5253),
+
   // SRM related errors.
 
   /**

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/SubSourceExpectsEmissionsVisitor.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/SubSourceExpectsEmissionsVisitor.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.validation;
+
+import nl.overheid.aerius.shared.domain.v2.geojson.IsFeature;
+import nl.overheid.aerius.shared.domain.v2.source.ADMSRoadEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.ColdStartEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceVisitor;
+import nl.overheid.aerius.shared.domain.v2.source.FarmAnimalHousingEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.FarmLodgingEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.FarmlandEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.GenericEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.InlandShippingEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.ManureStorageEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.MaritimeShippingEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.MooringInlandShippingEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.MooringMaritimeShippingEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.OffRoadMobileEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.SRM1RoadEmissionSource;
+import nl.overheid.aerius.shared.domain.v2.source.SRM2RoadEmissionSource;
+import nl.overheid.aerius.shared.exception.AeriusException;
+
+/**
+ * Visitor telling per emissionsource type if subsources are expected to have emissions or not.
+ *
+ * If the source type has no subsources, it shouldn't really matter what is returned.
+ *
+ * Road sources are generally expected not to have emissions on subsource level.
+ */
+class SubSourceExpectsEmissionsVisitor implements EmissionSourceVisitor<Boolean> {
+
+  @Override
+  public Boolean visit(final FarmAnimalHousingEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return true;
+  }
+
+  @Override
+  public Boolean visit(final FarmLodgingEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return true;
+  }
+
+  @Override
+  public Boolean visit(final FarmlandEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return true;
+  }
+
+  @Override
+  public Boolean visit(final ManureStorageEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return true;
+  }
+
+  @Override
+  public Boolean visit(final OffRoadMobileEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return true;
+  }
+
+  @Override
+  public Boolean visit(final ColdStartEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return true;
+  }
+
+  @Override
+  public Boolean visit(final SRM1RoadEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return false;
+  }
+
+  @Override
+  public Boolean visit(final SRM2RoadEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return false;
+  }
+
+  @Override
+  public Boolean visit(final ADMSRoadEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return false;
+  }
+
+  @Override
+  public Boolean visit(final InlandShippingEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return true;
+  }
+
+  @Override
+  public Boolean visit(final MooringInlandShippingEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return true;
+  }
+
+  @Override
+  public Boolean visit(final MaritimeShippingEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return true;
+  }
+
+  @Override
+  public Boolean visit(final MooringMaritimeShippingEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return true;
+  }
+
+  @Override
+  public Boolean visit(final GenericEmissionSource emissionSource, final IsFeature feature) throws AeriusException {
+    return true;
+  }
+
+}


### PR DESCRIPTION
Using visitor to tell which subsources are expected to have emissions, beats having instanceof checks and is more explicit. Easy to adjust as well if it turns out most shipping sources have no emissions anyway if that turns out to be a thing.