### PR TITLE
AER-2804 Added option to not add receptor hexagon representation in results in GML

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLWriter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLWriter.java
@@ -82,6 +82,7 @@ public class GMLWriter {
 
   private final AeriusGMLVersion version;
   private Boolean formattedOutput = Boolean.TRUE;
+  private boolean withRepresentation = true;
 
   public GMLWriter(final ReceptorGridSettings rgs, final ReferenceGenerator referenceGenerator) {
     this(rgs, referenceGenerator, LATEST_WRITER_VERSION);
@@ -100,6 +101,13 @@ public class GMLWriter {
    */
   public void setFormattedOutput(final Boolean formattedOutput) {
     this.formattedOutput = formattedOutput;
+  }
+
+  /**
+   * If called GML Receptors won't be generated with the hexagon representation geometry.
+   */
+  public void setNoReceptorRepresentation() {
+    this.withRepresentation = false;
   }
 
   /**
@@ -359,7 +367,7 @@ public class GMLWriter {
   }
 
   private InternalGMLWriter createInternalWriter() throws AeriusException {
-    return new InternalGMLWriter(receptorGridSettings, referenceGenerator, formattedOutput, version);
+    return new InternalGMLWriter(receptorGridSettings, referenceGenerator, formattedOutput, version, withRepresentation);
   }
 
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/InternalGMLWriter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/InternalGMLWriter.java
@@ -87,8 +87,9 @@ final class InternalGMLWriter {
   private final Boolean formattedOutput;
 
   InternalGMLWriter(final ReceptorGridSettings rgs, final ReferenceGenerator referenceGenerator, final Boolean formattedOutput,
-      final AeriusGMLVersion version) throws AeriusException {
-    writer = GMLVersionWriterFactory.createGMLVersionWriter(rgs.getZoomLevel1(), GMLSchema.getSRSName(rgs.getEPSG().getSrid()), version);
+      final AeriusGMLVersion version, final boolean withRepresentation) throws AeriusException {
+    writer = GMLVersionWriterFactory.createGMLVersionWriter(rgs.getZoomLevel1(), GMLSchema.getSRSName(rgs.getEPSG().getSrid()), version,
+        withRepresentation);
     this.referenceGenerator = referenceGenerator;
     this.schema = GMLVersionWriterFactory.getSchema(version);
     this.formattedOutput = formattedOutput;

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionWriterFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionWriterFactory.java
@@ -23,18 +23,19 @@ import nl.overheid.aerius.gml.v6_0.togml.GMLVersionWriterV60;
 import nl.overheid.aerius.shared.domain.geo.HexagonZoomLevel;
 import nl.overheid.aerius.shared.exception.AeriusException;
 
-public class GMLVersionWriterFactory {
+public final class GMLVersionWriterFactory {
+
+  private GMLVersionWriterFactory() {
+    // Util class
+  }
 
   public static GMLVersionWriter createGMLVersionWriter(final HexagonZoomLevel zoomLevel1, final String srsName,
-      final AeriusGMLVersion aeriusGMLVersion) {
-    switch (aeriusGMLVersion) {
-    case V5_1:
-      return new GMLVersionWriterV51(zoomLevel1, srsName);
-    case V6_0:
-      return new GMLVersionWriterV60(zoomLevel1, srsName);
-    default:
-      throw new IllegalArgumentException("Aerius GML version is not supported");
-    }
+      final AeriusGMLVersion aeriusGMLVersion, final boolean withRepresentation) {
+    return switch (aeriusGMLVersion) {
+      case V5_1 -> new GMLVersionWriterV51(zoomLevel1, srsName);
+      case V6_0 -> new GMLVersionWriterV60(zoomLevel1, srsName, withRepresentation);
+      default -> throw new IllegalArgumentException("Aerius GML version is not supported");
+    };
   }
 
   public static Schema getSchema(final AeriusGMLVersion aeriusGMLVersion) throws AeriusException {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v6_0/togml/GMLVersionWriterV60.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v6_0/togml/GMLVersionWriterV60.java
@@ -81,11 +81,11 @@ public class GMLVersionWriterV60 implements GMLVersionWriter {
   private final CIMLKMeasure2GML measure2gml;
   private final CIMLKDispersionLine2GML dispersionLine2gml;
 
-  public GMLVersionWriterV60(final HexagonZoomLevel zoomLevel1, final String srsName) {
+  public GMLVersionWriterV60(final HexagonZoomLevel zoomLevel1, final String srsName, final boolean withRepresentation) {
     geometry2gml = new Geometry2GML(srsName);
     source2gml = new Source2GML(geometry2gml);
     building2gml = new Building2GML(geometry2gml);
-    result2gml = new Result2GML(geometry2gml, zoomLevel1);
+    result2gml = new Result2GML(geometry2gml, zoomLevel1, withRepresentation);
     measure2gml = new CIMLKMeasure2GML(geometry2gml);
     dispersionLine2gml = new CIMLKDispersionLine2GML(geometry2gml);
   }

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLReaderTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLReaderTest.java
@@ -229,7 +229,7 @@ class GMLReaderTest {
     metaDataInput.getOptions().getRblCalculationOptions().setMonitorSrm2Year(MONITOR_SRM2_YEAR);
     metaDataInput.setResultsIncluded(true);
     final InternalGMLWriter writer = new InternalGMLWriter(gridSettings, GMLTestDomain.TEST_REFERENCE_GENERATOR, Boolean.TRUE,
-        GMLWriter.LATEST_WRITER_VERSION);
+        GMLWriter.LATEST_WRITER_VERSION, true);
     return writer.getWriter().metaData2GML(metaDataInput);
   }
 

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterPerformanceTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterPerformanceTest.java
@@ -50,7 +50,7 @@ class GMLWriterPerformanceTest {
   @Test
   void testConvertMetaData() throws IOException, AeriusException {
     final InternalGMLWriter writer = new InternalGMLWriter(GMLTestDomain.getExampleGridSettings(), GMLTestDomain.TEST_REFERENCE_GENERATOR,
-        Boolean.TRUE, GMLWriter.LATEST_WRITER_VERSION);
+        Boolean.TRUE, GMLWriter.LATEST_WRITER_VERSION, true);
 
     final int numberOfSources = 800000;
     final List<EmissionSourceFeature> sourceFeatures = new ArrayList<>(numberOfSources);

--- a/source/imaer-gml/src/test/resources/gml/v6_0/test_receptors_no_representation.gml
+++ b/source/imaer-gml/src/test/resources/gml/v6_0/test_receptors_no_representation.gml
@@ -1,0 +1,216 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<imaer:FeatureCollectionCalculator xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:imaer="http://imaer.aerius.nl/6.0" gml:id="NL.IMAER.Collection" xsi:schemaLocation="http://imaer.aerius.nl/6.0 https://imaer.aerius.nl/6.0/IMAER.xsd">
+    <imaer:metadata>
+        <imaer:AeriusCalculatorMetadata>
+            <imaer:project>
+                <imaer:ProjectMetadata>
+                    <imaer:year>2013</imaer:year>
+                </imaer:ProjectMetadata>
+            </imaer:project>
+            <imaer:calculation>
+                <imaer:CalculationMetadata>
+                    <imaer:method>NATURE_AREA</imaer:method>
+                    <imaer:substance>NOX</imaer:substance>
+                    <imaer:substance>NH3</imaer:substance>
+                    <imaer:substance>NO2</imaer:substance>
+                    <imaer:resultType>CONCENTRATION</imaer:resultType>
+                    <imaer:resultType>DEPOSITION</imaer:resultType>
+                    <imaer:maximumRange>3.0</imaer:maximumRange>
+                    <imaer:option>
+                        <imaer:CalculationOption>
+                            <imaer:key>monitor_srm2_year</imaer:key>
+                            <imaer:value>2030</imaer:value>
+                        </imaer:CalculationOption>
+                    </imaer:option>
+                    <imaer:otherSituation>
+                        <imaer:OtherSituationMetadata>
+                            <imaer:situationType>OFF_SITE_REDUCTION</imaer:situationType>
+                            <imaer:name>Our Other Situation</imaer:name>
+                            <imaer:reference>OtherReferenceThingy</imaer:reference>
+                        </imaer:OtherSituationMetadata>
+                    </imaer:otherSituation>
+                </imaer:CalculationMetadata>
+            </imaer:calculation>
+            <imaer:version>
+                <imaer:VersionMetadata>
+                    <imaer:aeriusVersion>V1.1</imaer:aeriusVersion>
+                    <imaer:databaseVersion>SomeDBVersion</imaer:databaseVersion>
+                </imaer:VersionMetadata>
+            </imaer:version>
+        </imaer:AeriusCalculatorMetadata>
+    </imaer:metadata>
+    <imaer:featureMember>
+        <imaer:ReceptorPoint receptorPointId="1" gml:id="CP.1">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>CP.1</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.1.POINT">
+                    <gml:pos>137558.0 456251.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NH3">
+                    <imaer:value>95.8</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NH3">
+                    <imaer:value>8546.77</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NOX">
+                    <imaer:value>3.001</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
+                    <imaer:value>968.3</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+        </imaer:ReceptorPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:CalculationPoint gml:id="CP.2">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>CP.2</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.2.POINT">
+                    <gml:pos>207413.0 475162.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NH3">
+                    <imaer:value>1574.4</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NH3">
+                    <imaer:value>787.2</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NOX">
+                    <imaer:value>98.4</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
+                    <imaer:value>49.2</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="PM10">
+                    <imaer:value>50380.8</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NO2">
+                    <imaer:value>12595.2</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="PM25">
+                    <imaer:value>201523.2</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:label>DB-team 1e depositie</imaer:label>
+        </imaer:CalculationPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:CalculationPoint gml:id="CP.3">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>CP.3</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.3.POINT">
+                    <gml:pos>207403.0 475102.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:label>DB-team 2e depositie</imaer:label>
+        </imaer:CalculationPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:SubPoint receptorPointId="1" subPointId="19" gml:id="SP.1_19">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>SP.1_19</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.1_19.POINT">
+                    <gml:pos>137548.0 137548.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NH3">
+                    <imaer:value>223.03</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NH3">
+                    <imaer:value>382.11</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NOX">
+                    <imaer:value>9.006</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
+                    <imaer:value>32.1</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:level>2</imaer:level>
+        </imaer:SubPoint>
+    </imaer:featureMember>
+    <imaer:featureMember>
+        <imaer:SubPoint receptorPointId="2" subPointId="19" gml:id="SP.2_19">
+            <imaer:identifier>
+                <imaer:NEN3610ID>
+                    <imaer:namespace>NL.IMAER</imaer:namespace>
+                    <imaer:localId>SP.2_19</imaer:localId>
+                </imaer:NEN3610ID>
+            </imaer:identifier>
+            <imaer:GM_Point>
+                <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="SP.2_19.POINT">
+                    <gml:pos>137538.0 456231.0</gml:pos>
+                </gml:Point>
+            </imaer:GM_Point>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NH3">
+                    <imaer:value>42.42</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NH3">
+                    <imaer:value>182.31</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="CONCENTRATION" substance="NOX">
+                    <imaer:value>5.0</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:result>
+                <imaer:CalculationResult resultType="DEPOSITION" substance="NOX">
+                    <imaer:value>22.3</imaer:value>
+                </imaer:CalculationResult>
+            </imaer:result>
+            <imaer:level>2</imaer:level>
+        </imaer:SubPoint>
+    </imaer:featureMember>
+</imaer:FeatureCollectionCalculator>


### PR DESCRIPTION
Change is backward compatible.