### PR TITLE
Avoid emission calculation for 0 vehicles

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/emissions/ADMSRoadEmissionsCalculator.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/emissions/ADMSRoadEmissionsCalculator.java
@@ -84,7 +84,9 @@ class ADMSRoadEmissionsCalculator extends BaseRoadEmissionsCalculator<ADMSRoadEm
     final TrafficDirection direction = roadEmissionSource.getTrafficDirection();
     // ADMSRoad does not use stagnation (this is incorporated into the speed used).
     // However, the gradient depends on the direction
-    if (direction == TrafficDirection.A_TO_B) {
+    if (BigDecimal.ZERO.compareTo(numberOfVehiclesPerDay) == 0) {
+      results = new EnumMap<>(Substance.class);
+    } else if (direction == TrafficDirection.A_TO_B) {
       // If A to B, all vehicles go that way, calculate appropriately
       results = calculateAtoBEmissions(standardVehicles, standardVehicleCode, numberOfVehiclesPerDay, roadEmissionSource);
     } else if (direction == TrafficDirection.B_TO_A) {

--- a/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/emissions/ADMSRoadEmissionsCalculatorTest.java
+++ b/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/emissions/ADMSRoadEmissionsCalculatorTest.java
@@ -300,6 +300,10 @@ class ADMSRoadEmissionsCalculatorTest {
     valuesPerVehicleType.setVehiclesPerTimeUnit(2000);
     final String vehicleType = "HEAVY_FREIGHT";
     vehicles.getValuesPerVehicleTypes().put(vehicleType, valuesPerVehicleType);
+    final ValuesPerVehicleType valuesPerVehicleTypeZeroVehicles = new ValuesPerVehicleType();
+    valuesPerVehicleTypeZeroVehicles.setVehiclesPerTimeUnit(0);
+    final String vehicleTypeZeroVehicles = "TAXI";
+    vehicles.getValuesPerVehicleTypes().put(vehicleTypeZeroVehicles, valuesPerVehicleTypeZeroVehicles);
     final boolean strictEnforcement = vehicles.getStrictEnforcement();
     final int maximumSpeed = vehicles.getMaximumSpeed();
     final int gradientMatch = (int) gradient;


### PR DESCRIPTION
Not much point in doing interpolation if the result will just be multiplied with 0 anyway.

Performance change, shouldn't have effect on results.