### PR TITLE
AER-3433 keep track of calculated snapshot values

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculatedSnapshotValues.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculatedSnapshotValues.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.shared.domain.calculation;
+
+import java.io.Serializable;
+
+/**
+ * Values that were calculated at the moment of calculation, and can be different if recalculated again.
+ *
+ * For instance, a value that can be calculated can depend on the number of projects in archive.
+ * At another moment, the number of projects might have changed.
+ */
+public class CalculatedSnapshotValues implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  private String developmentPressureClassification;
+
+  public String getDevelopmentPressureClassification() {
+    return developmentPressureClassification;
+  }
+
+  public void setDevelopmentPressureClassification(final String developmentPressureClassification) {
+    this.developmentPressureClassification = developmentPressureClassification;
+  }
+
+}

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationSetOptions.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationSetOptions.java
@@ -29,7 +29,7 @@ import nl.overheid.aerius.shared.domain.result.EmissionResultKey;
  */
 public class CalculationSetOptions implements Serializable {
 
-  private static final long serialVersionUID = 5L;
+  private static final long serialVersionUID = 6L;
 
   private int calculationSetOptionsId;
   private CalculationMethod calculationMethod = CalculationMethod.FORMAL_ASSESSMENT;
@@ -41,6 +41,7 @@ public class CalculationSetOptions implements Serializable {
   private OwN2000CalculationOptions owN2000CalculationOptions = new OwN2000CalculationOptions();
   private RBLCalculationOptions rblCalculationOptions = new RBLCalculationOptions();
   private NCACalculationOptions ncaCalculationOptions = new NCACalculationOptions();
+  private CalculatedSnapshotValues calculatedSnapshotValues = new CalculatedSnapshotValues();
   private Serializable experimentalOptions;
 
   /**
@@ -144,6 +145,10 @@ public class CalculationSetOptions implements Serializable {
 
   public NCACalculationOptions getNcaCalculationOptions() {
     return ncaCalculationOptions;
+  }
+
+  public CalculatedSnapshotValues getCalculatedSnapshotValues() {
+    return calculatedSnapshotValues;
   }
 
   /**

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/util/OptionsMetadataUtil.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/util/OptionsMetadataUtil.java
@@ -113,6 +113,9 @@ public final class OptionsMetadataUtil {
     PERMIT_AREA,
     DEVELOPMENT_PRESSURE_SOURCE_IDS,
 
+    /* Calculated snapshot values related */
+    DEVELOPMENT_PRESSURE_CLASSIFICATION,
+
     /* Road NOX - NO2 calculation related */
     ROAD_LOCAL_FRACTION_NO2_RECEPTORS_OPTION,
     ROAD_LOCAL_FRACTION_NO2_POINTS_OPTION,
@@ -179,6 +182,7 @@ public final class OptionsMetadataUtil {
     if (theme == Theme.NCA) {
       final NCACalculationOptions ncaCalculationOptions = options.getNcaCalculationOptions();
       ncaOptionsFromMap(ncaCalculationOptions, map, prefixedOptionsMap);
+      options.getCalculatedSnapshotValues().setDevelopmentPressureClassification(map.get(Option.DEVELOPMENT_PRESSURE_CLASSIFICATION));
     }
   }
 
@@ -193,6 +197,8 @@ public final class OptionsMetadataUtil {
       addIntValue(mapToAddTo, Option.MONITOR_SRM2_YEAR, options.getRblCalculationOptions().getMonitorSrm2Year(), addDefaults);
     } else if (theme == Theme.NCA) {
       ncaOptionsToMap(mapToAddTo, options.getNcaCalculationOptions(), addDefaults);
+      addValue(mapToAddTo, Option.DEVELOPMENT_PRESSURE_CLASSIFICATION, options.getCalculatedSnapshotValues().getDevelopmentPressureClassification(),
+          addDefaults);
     }
     addConnectSuppliedOptions(options.getConnectSuppliedOptions(), mapToAddTo, addDefaults);
     return mapToAddTo;

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/util/OptionsMetadataUtilTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/util/OptionsMetadataUtilTest.java
@@ -224,6 +224,7 @@ class OptionsMetadataUtilTest {
         .priestleyTaylorParameter(1.3)
         .build();
     adms.setMetSiteCharacteristics(Map.of("2022", msc, "2023", msc));
+    options.getCalculatedSnapshotValues().setDevelopmentPressureClassification("SOME_CLASS");
     final Map<String, String> result = OptionsMetadataUtil.optionsToMap(Theme.NCA, options, false);
 
     assertEquals("5.0.0.1", result.get("adms_version"), "adms_version should be set");
@@ -248,6 +249,7 @@ class OptionsMetadataUtilTest {
         "road_local_fraction_no2_receptors_option should be set");
     assertEquals("ONE_CUSTOM_VALUE", result.get("road_local_fraction_no2_points_option"), "road_local_fraction_no2_points_option should be set");
     assertEquals("0.4", result.get("road_local_fraction_no2_custom_value"), "road_local_fraction_no2 should be set");
+    assertEquals("SOME_CLASS", result.get("development_pressure_classification"), "development_pressure_classification should be set");
   }
 
   @Test
@@ -309,6 +311,7 @@ class OptionsMetadataUtilTest {
         .priestleyTaylorParameter(1.3)
         .build();
     adms.setMetSiteCharacteristics(Map.of("2022", msc, "2023", msc));
+    options.getCalculatedSnapshotValues().setDevelopmentPressureClassification("SOME_CLASS");
 
     final Map<String, String> result1 = OptionsMetadataUtil.optionsToMap(Theme.NCA, options, false);
     final CalculationSetOptions roundTripOptions = new CalculationSetOptions();


### PR DESCRIPTION
Reasoning for putting it in CalculationSetOptions and the generic metadata section in IMAER is that its least changes. Conceptually it makes less sense as it's not a value that a user should generally alter/supply. But that's similar to OPS version that's also present in options/metadata I guess? Not too sure about both the reasoning and the term CalculatedSnapshotValues, suggestions are welcome.