### PR TITLE
Avoid including an old commons-io version

### DIFF
--- a/source/imaer-gml/pom.xml
+++ b/source/imaer-gml/pom.xml
@@ -78,6 +78,17 @@
       <groupId>com.github.rwitzel.streamflyer</groupId>
       <artifactId>streamflyer-core</artifactId>
       <version>${streamflyer.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-io</groupId>
+          <artifactId>commons-io</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>${commons-io.version}</version>
     </dependency>
 
     <!-- Unit Test -->

--- a/source/pom.xml
+++ b/source/pom.xml
@@ -55,6 +55,7 @@
     <gwt-maven-plugin.version>1.1.0</gwt-maven-plugin.version>
     <gml-schema.version>5.0.1</gml-schema.version>
     <streamflyer.version>1.2.0</streamflyer.version>
+    <commons-io.version>2.18.0</commons-io.version>
     <xml-resolver.version>1.2</xml-resolver.version>
     <!-- Switching to JTS 1.20.0 introduces a change in results (length of geometries rounding) -->
     <jts.version>1.19.0</jts.version>


### PR DESCRIPTION
The way we use streamflyer we don't actually use commons-io in that library, but we do use it ourselves. Would rather get rid of streamflyer at some point, but that's more complicated.