### PR TITLE
AER-3516 Implemented reading spread with legacy support

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionReaderFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLVersionReaderFactory.java
@@ -18,6 +18,10 @@ package nl.overheid.aerius.gml.base;
 
 import javax.xml.validation.Schema;
 
+import nl.overheid.aerius.gml.base.characteristics.GML2ADMSSourceCharacteristics;
+import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
+import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.characteristics.CharacteristicsType;
 import nl.overheid.aerius.shared.exception.AeriusException;
 
 /**
@@ -80,10 +84,31 @@ public abstract class GMLVersionReaderFactory {
     return schema;
   }
 
-  /**
-   *
-   * @param conversionData
-   * @return
-   */
-  public abstract GMLVersionReader createReader(final GMLConversionData conversionData);
+  public GMLVersionReader createReader(final GMLConversionData conversionData) {
+    return createReader(conversionData, gml2SourceCharacteristics(conversionData));
+  }
+
+  protected GMLVersionReader createReader(final GMLConversionData conversionData, final GML2SourceCharacteristics<?> sourceCharacteristics) {
+    throw new UnsupportedOperationException("Either override this createReader, or the calling createReader method");
+  }
+
+  protected GML2SourceCharacteristics<?> gml2SourceCharacteristics(final GMLConversionData conversionData) {
+    final CharacteristicsType ct = conversionData.getCharacteristicsType();
+
+    if (ct == CharacteristicsType.OPS) {
+      return createGML2OPSSourceCharacteristics(conversionData);
+    } else if (ct == CharacteristicsType.ADMS) {
+      return createGML2ADMSSourceCharacteristics(conversionData);
+    } else {
+      throw new IllegalArgumentException("Can't read GML for characteristics of type " + ct + ". This is not implemented.");
+    }
+  }
+
+  protected GML2OPSSourceCharacteristics createGML2OPSSourceCharacteristics(final GMLConversionData conversionData) {
+    return new GML2OPSSourceCharacteristics(conversionData, false);
+  }
+
+  protected GML2ADMSSourceCharacteristics createGML2ADMSSourceCharacteristics(final GMLConversionData conversionData) {
+    return new GML2ADMSSourceCharacteristics(conversionData);
+  }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2ADMSSourceCharacteristics.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2ADMSSourceCharacteristics.java
@@ -24,6 +24,7 @@ import nl.overheid.aerius.shared.domain.v2.characteristics.adms.BuoyancyType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.adms.EffluxType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.adms.ReleaseTemperatureAndPressure;
 import nl.overheid.aerius.shared.domain.v2.characteristics.adms.SourceType;
+import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 
@@ -40,7 +41,7 @@ public class GML2ADMSSourceCharacteristics
   @Override
   protected nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics fromGMLSpecific(
       final IsGmlSourceCharacteristics characteristics,
-      final nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics sectorCharacteristics) throws AeriusException {
+      final nl.overheid.aerius.shared.domain.v2.characteristics.ADMSSourceCharacteristics sectorCharacteristics, Geometry geometry) throws AeriusException {
     final IsGmlADMSSourceCharacteristics gmlADMSCharacteristics = (IsGmlADMSSourceCharacteristics) characteristics;
     final ADMSSourceCharacteristics returnCharacteristics = getDefaultCharacteristics();
     returnCharacteristics.setHeight(gmlADMSCharacteristics.getHeight());

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2SourceCharacteristics.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2SourceCharacteristics.java
@@ -41,14 +41,14 @@ public abstract class GML2SourceCharacteristics<T extends SourceCharacteristics>
 
   public T fromGML(final IsGmlSourceCharacteristics characteristics, final T sectorCharacteristics,
       final Geometry geometry) throws AeriusException {
-    final T returnCharacteristics = fromGMLSpecific(characteristics, sectorCharacteristics);
+    final T returnCharacteristics = fromGMLSpecific(characteristics, sectorCharacteristics, geometry);
 
     fromGMLToBuildingProperties(characteristics, returnCharacteristics, geometry);
     return returnCharacteristics;
   }
 
-  protected abstract T fromGMLSpecific(final IsGmlSourceCharacteristics characteristics,
-      final T sectorCharacteristics) throws AeriusException;
+  protected abstract T fromGMLSpecific(final IsGmlSourceCharacteristics characteristics, final T sectorCharacteristics, Geometry geometry)
+      throws AeriusException;
 
   private void fromGMLToBuildingProperties(final IsGmlSourceCharacteristics characteristics,
       final SourceCharacteristics returnCharacteristics, final Geometry geometry) throws AeriusException {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2SourceCharacteristicsV31.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/GML2SourceCharacteristicsV31.java
@@ -30,7 +30,7 @@ public class GML2SourceCharacteristicsV31 extends GML2OPSSourceCharacteristics {
   private static final double EMISSION_TEMPERATURE_DEFAULT = 11.85;
 
   public GML2SourceCharacteristicsV31(final GMLConversionData conversionData) {
-    super(conversionData);
+    super(conversionData, true);
   }
 
   @Override

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/OPSSpreadUtil.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/characteristics/OPSSpreadUtil.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.gml.base.characteristics;
+
+import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
+import nl.overheid.aerius.shared.domain.v2.geojson.LineString;
+import nl.overheid.aerius.shared.domain.v2.geojson.Point;
+
+/**
+ * Utility to handle the legacy variant of handling the OPS spread value.
+ *
+ * In older versions of OPS the spread parameter in the input data for point sources was ignored and calculated within OPS as being half the
+ * emission height.
+ * With newer OPS versions (since 5.3.1) the spread value in the OPS input file is read and not calculated.
+ * This means the application should pass the desired spread value.
+ * For older IMAER versions (prior to 6) for point sources it means that value is derived from the emission height.
+ * Even if the spread value of a point source is set in the IMAER file it will be ignored.
+ * For none point sources and if spread was not set in older IMAER versions (< 6.0)the sector default will be used.
+ * This is compatible with how it worked prior to this change.
+ * For newer IMAER versions (>= 6.0) if the spread is not present it will be half of the emission height.
+ */
+final class OPSSpreadUtil {
+
+  private final boolean legacySpread;
+
+  public OPSSpreadUtil(final boolean legacySpread) {
+    this.legacySpread = legacySpread;
+  }
+
+  public Double getSpread(final IsGmlBaseOPSSourceCharacteristics characteristics, final Double defaultSpread, final Geometry geometry) {
+    final Double spread = characteristics.getSpread();
+    final double emissionHeight = characteristics.getEmissionHeight();
+
+    if (legacySpread) {
+      if (geometry instanceof Point || geometry instanceof LineString) {
+        return getSourceSpread(null, emissionHeight, defaultSpread);
+      } else {
+        return getLegacySpread(characteristics, defaultSpread);
+      }
+    } else {
+      return getSourceSpread(spread, emissionHeight, defaultSpread);
+    }
+  }
+
+  private static Double getLegacySpread(final IsGmlBaseOPSSourceCharacteristics characteristics, final Double defaultSpread) {
+    final Double spread = characteristics.getSpread();
+
+    return spread == null ? defaultSpread : spread;
+  }
+
+  private static Double getSourceSpread(final Double spread, final double emissionHeight, final Double defaultSpread) {
+    return spread == null ? (emissionHeight > 0 ? emissionHeight / 2.0 : defaultSpread) : spread;
+  }
+}

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v0_5/GMLReader.java
@@ -29,7 +29,7 @@ import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 /**
  * {@link GMLVersionReader} for AERIUS GML version 0.5.
  */
-public class GMLReader implements GMLVersionReader {
+final class GMLReader implements GMLVersionReader {
 
   private final GML2Source gml2Source;
   private final GML2Result gml2Result;

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_0/GMLReader.java
@@ -29,7 +29,7 @@ import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 /**
  * {@link GMLVersionReader} for AERIUS GML version 2.0.
  */
-public class GMLReader implements GMLVersionReader {
+final class GMLReader implements GMLVersionReader {
 
   private final GML2Source gml2Source;
   private final GML2Result gml2Result;

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_1/GMLReader.java
@@ -29,7 +29,7 @@ import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 /**
  * {@link GMLVersionReader} for AERIUS GML version 2.1.
  */
-public class GMLReader implements GMLVersionReader {
+final class GMLReader implements GMLVersionReader {
 
   private final GML2Source gml2Source;
   private final GML2Result gml2Result;

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v2_2/GMLReader.java
@@ -29,7 +29,7 @@ import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 /**
  * {@link GMLVersionReader} for AERIUS GML version 2.2.
  */
-public class GMLReader implements GMLVersionReader {
+final class GMLReader implements GMLVersionReader {
 
   private final GML2Source gml2Source;
   private final GML2Result gml2Result;

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_0/GMLReader.java
@@ -37,7 +37,7 @@ import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 /**
  * {@link GMLVersionReader} for AERIUS GML version 3.0.
  */
-public class GMLReader implements GMLVersionReader {
+final class GMLReader implements GMLVersionReader {
 
   private final GML2Source gml2Source;
   private final GML2Result gml2Result;

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v3_1/GMLReader.java
@@ -37,7 +37,7 @@ import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 /**
  * {@link GMLVersionReader} for AERIUS GML version 3.0.
  */
-public class GMLReader implements GMLVersionReader {
+final class GMLReader implements GMLVersionReader {
 
   private final GML2Source gml2Source;
   private final GML2Result gml2Result;

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GMLReader.java
@@ -42,7 +42,7 @@ import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 /**
  * {@link GMLVersionReader} for AERIUS GML version 4.0.
  */
-public class GMLReader<S extends SourceCharacteristics> implements GMLVersionReader {
+final class GMLReader<S extends SourceCharacteristics> implements GMLVersionReader {
 
   private final GML2Source<S> gml2Source;
   private final GML2Building gml2Building;

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GMLReaderFactoryV40.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v4_0/GMLReaderFactoryV40.java
@@ -25,8 +25,6 @@ import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.v4_0.base.CalculatorSchema;
 import nl.overheid.aerius.gml.v4_0.collection.FeatureCollectionImpl;
-import nl.overheid.aerius.shared.domain.v2.characteristics.CharacteristicsType;
-import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 import nl.overheid.aerius.shared.exception.AeriusException;
 
 /**
@@ -44,22 +42,12 @@ public class GMLReaderFactoryV40 extends GMLVersionReaderFactory {
   }
 
   @Override
-  public GMLVersionReader createReader(final GMLConversionData conversionData) {
-    return createReader(conversionData, gml2SourceCharacteristics(conversionData));
+  protected GMLVersionReader createReader(final GMLConversionData conversionData, final GML2SourceCharacteristics<?> sourceCharacteristics) {
+    return new GMLReader<>(conversionData, sourceCharacteristics);
   }
 
-  private static <T extends SourceCharacteristics> GMLReader<T> createReader(final GMLConversionData conversionData,
-      final GML2SourceCharacteristics<T> gml2SourceCharacteristics) {
-    return new GMLReader<>(conversionData, gml2SourceCharacteristics);
-  }
-
-  private static GML2SourceCharacteristics<? extends SourceCharacteristics> gml2SourceCharacteristics(final GMLConversionData conversionData) {
-    final CharacteristicsType ct = conversionData.getCharacteristicsType();
-
-    if (ct == CharacteristicsType.OPS) {
-      return new GML2OPSSourceCharacteristics(conversionData);
-    } else {
-      throw new IllegalArgumentException("Can't read GML for characteristics of type " + ct + ". This is not implemented.");
-    }
+  @Override
+  protected GML2OPSSourceCharacteristics createGML2OPSSourceCharacteristics(final GMLConversionData conversionData) {
+    return new GML2OPSSourceCharacteristics(conversionData, true);
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/GMLReader.java
@@ -42,7 +42,7 @@ import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 /**
  * {@link GMLVersionReader} for AERIUS GML version 5.0.
  */
-public class GMLReader<S extends SourceCharacteristics> implements GMLVersionReader {
+final class GMLReader<S extends SourceCharacteristics> implements GMLVersionReader {
 
   private final GML2Source<S> gml2Source;
   private final GML2Building gml2Building;

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/GMLReaderFactoryV50.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_0/GMLReaderFactoryV50.java
@@ -21,13 +21,10 @@ import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLLegacyCodesSupplier;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
 import nl.overheid.aerius.gml.base.GMLVersionReaderFactory;
-import nl.overheid.aerius.gml.base.characteristics.GML2ADMSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.v5_0.base.CalculatorSchema;
 import nl.overheid.aerius.gml.v5_0.collection.FeatureCollectionImpl;
-import nl.overheid.aerius.shared.domain.v2.characteristics.CharacteristicsType;
-import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 import nl.overheid.aerius.shared.exception.AeriusException;
 
 /**
@@ -45,24 +42,12 @@ public class GMLReaderFactoryV50 extends GMLVersionReaderFactory {
   }
 
   @Override
-  public GMLVersionReader createReader(final GMLConversionData conversionData) {
-    return createReader(conversionData, gml2SourceCharacteristics(conversionData));
+  protected GMLVersionReader createReader(final GMLConversionData conversionData, final GML2SourceCharacteristics<?> sourceCharacteristics) {
+    return new GMLReader<>(conversionData, sourceCharacteristics);
   }
 
-  private static <T extends SourceCharacteristics> GMLReader<T> createReader(final GMLConversionData conversionData,
-      final GML2SourceCharacteristics<T> gml2SourceCharacteristics) {
-    return new GMLReader<>(conversionData, gml2SourceCharacteristics);
-  }
-
-  private static GML2SourceCharacteristics<? extends SourceCharacteristics> gml2SourceCharacteristics(final GMLConversionData conversionData) {
-    final CharacteristicsType ct = conversionData.getCharacteristicsType();
-
-    if (ct == CharacteristicsType.OPS) {
-      return new GML2OPSSourceCharacteristics(conversionData);
-    } else if (ct == CharacteristicsType.ADMS) {
-      return new GML2ADMSSourceCharacteristics(conversionData);
-    } else {
-      throw new IllegalArgumentException("Can't read GML for characteristics of type " + ct + ". This is not implemented.");
-    }
+  @Override
+  protected GML2OPSSourceCharacteristics createGML2OPSSourceCharacteristics(final GMLConversionData conversionData) {
+    return new GML2OPSSourceCharacteristics(conversionData, true);
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/GMLReaderFactoryV51.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/GMLReaderFactoryV51.java
@@ -21,13 +21,10 @@ import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLLegacyCodesSupplier;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
 import nl.overheid.aerius.gml.base.GMLVersionReaderFactory;
-import nl.overheid.aerius.gml.base.characteristics.GML2ADMSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.v5_1.base.CalculatorSchema;
 import nl.overheid.aerius.gml.v5_1.collection.FeatureCollectionImpl;
-import nl.overheid.aerius.shared.domain.v2.characteristics.CharacteristicsType;
-import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 import nl.overheid.aerius.shared.exception.AeriusException;
 
 /**
@@ -45,24 +42,12 @@ public class GMLReaderFactoryV51 extends GMLVersionReaderFactory {
   }
 
   @Override
-  public GMLVersionReader createReader(final GMLConversionData conversionData) {
-    return createReader(conversionData, gml2SourceCharacteristics(conversionData));
+  protected GMLVersionReader createReader(final GMLConversionData conversionData, final GML2SourceCharacteristics<?> sourceCharacteristics) {
+    return new GMLReader<>(conversionData, sourceCharacteristics);
   }
 
-  private static <T extends SourceCharacteristics> GMLReader<T> createReader(final GMLConversionData conversionData,
-      final GML2SourceCharacteristics<T> gml2SourceCharacteristics) {
-    return new GMLReader<>(conversionData, gml2SourceCharacteristics);
-  }
-
-  private static GML2SourceCharacteristics<? extends SourceCharacteristics> gml2SourceCharacteristics(final GMLConversionData conversionData) {
-    final CharacteristicsType ct = conversionData.getCharacteristicsType();
-
-    if (ct == CharacteristicsType.OPS) {
-      return new GML2OPSSourceCharacteristics(conversionData);
-    } else if (ct == CharacteristicsType.ADMS) {
-      return new GML2ADMSSourceCharacteristics(conversionData);
-    } else {
-      throw new IllegalArgumentException("Can't read GML for characteristics of type " + ct + ". This is not implemented.");
-    }
+  @Override
+  protected GML2OPSSourceCharacteristics createGML2OPSSourceCharacteristics(final GMLConversionData conversionData) {
+    return new GML2OPSSourceCharacteristics(conversionData, true);
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v6_0/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v6_0/GMLReader.java
@@ -42,7 +42,7 @@ import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 /**
  * {@link GMLVersionReader} for AERIUS GML version 6.0.
  */
-public class GMLReader<S extends SourceCharacteristics> implements GMLVersionReader {
+final class GMLReader<S extends SourceCharacteristics> implements GMLVersionReader {
 
   private final GML2Source<S> gml2Source;
   private final GML2Building gml2Building;

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v6_0/GMLReaderFactoryV60.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v6_0/GMLReaderFactoryV60.java
@@ -21,13 +21,10 @@ import nl.overheid.aerius.gml.base.GMLConversionData;
 import nl.overheid.aerius.gml.base.GMLLegacyCodesSupplier;
 import nl.overheid.aerius.gml.base.GMLVersionReader;
 import nl.overheid.aerius.gml.base.GMLVersionReaderFactory;
-import nl.overheid.aerius.gml.base.characteristics.GML2ADMSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.characteristics.GML2OPSSourceCharacteristics;
 import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.v6_0.base.CalculatorSchema;
 import nl.overheid.aerius.gml.v6_0.collection.FeatureCollectionImpl;
-import nl.overheid.aerius.shared.domain.v2.characteristics.CharacteristicsType;
-import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 import nl.overheid.aerius.shared.exception.AeriusException;
 
 /**
@@ -37,6 +34,7 @@ public class GMLReaderFactoryV60 extends GMLVersionReaderFactory {
 
   /**
    * Constructor.
+   *
    * @param legacyCodesSupplier
    * @throws AeriusException error
    */
@@ -45,24 +43,12 @@ public class GMLReaderFactoryV60 extends GMLVersionReaderFactory {
   }
 
   @Override
-  public GMLVersionReader createReader(final GMLConversionData conversionData) {
-    return createReader(conversionData, gml2SourceCharacteristics(conversionData));
+  public GMLVersionReader createReader(final GMLConversionData conversionData, final GML2SourceCharacteristics<?> sourceCharacteristics) {
+    return new GMLReader<>(conversionData, sourceCharacteristics);
   }
 
-  private static <T extends SourceCharacteristics> GMLReader<T> createReader(final GMLConversionData conversionData,
-      final GML2SourceCharacteristics<T> gml2SourceCharacteristics) {
-    return new GMLReader<>(conversionData, gml2SourceCharacteristics);
-  }
-
-  private static GML2SourceCharacteristics<? extends SourceCharacteristics> gml2SourceCharacteristics(final GMLConversionData conversionData) {
-    final CharacteristicsType ct = conversionData.getCharacteristicsType();
-
-    if (ct == CharacteristicsType.OPS) {
-      return new GML2OPSSourceCharacteristics(conversionData);
-    } else if (ct == CharacteristicsType.ADMS) {
-      return new GML2ADMSSourceCharacteristics(conversionData);
-    } else {
-      throw new IllegalArgumentException("Can't read GML for characteristics of type " + ct + ". This is not implemented.");
-    }
+  @Override
+  protected GML2OPSSourceCharacteristics createGML2OPSSourceCharacteristics(final GMLConversionData conversionData) {
+    return new GML2OPSSourceCharacteristics(conversionData, true);
   }
 }

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/base/characteristics/OPSSpreadUtilTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/base/characteristics/OPSSpreadUtilTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.gml.base.characteristics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.lenient;
+
+import java.util.List;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
+import nl.overheid.aerius.shared.domain.v2.geojson.LineString;
+import nl.overheid.aerius.shared.domain.v2.geojson.Point;
+import nl.overheid.aerius.shared.domain.v2.geojson.Polygon;
+
+/**
+ * Test class for {@link OPSSpreadUtil}.
+ */
+@ExtendWith(MockitoExtension.class)
+class OPSSpreadUtilTest {
+
+  // Note. For this test: SPREAD != HALF_EMISSION_HEIGHT != DEFAULT_SPREAD
+  private static final double SPREAD = 3.0;
+  private static final double EMISSION_HEIGHT = 50.0;
+  private static final double HALF_EMISSION_HEIGHT = EMISSION_HEIGHT / 2.0;
+  private static final Double DEFAULT_SPREAD = 10.0;
+
+  private @Mock IsGmlBaseOPSSourceCharacteristics characteristics;
+
+  @ParameterizedTest
+  @MethodSource("data")
+  void testLegacySpread(final Double spread, final boolean legacySpread, final Geometry geometry, final double expected) {
+    final OPSSpreadUtil util = new OPSSpreadUtil(legacySpread);
+    lenient().doReturn(EMISSION_HEIGHT).when(characteristics).getEmissionHeight();
+    doReturn(spread).when(characteristics).getSpread();
+    final Double computedSpread = util.getSpread(characteristics, DEFAULT_SPREAD, geometry);
+
+    assertEquals(expected, computedSpread, 0.0001, "Not the expected spread value");
+  }
+
+  private static List<Arguments> data() {
+    return List.of(
+        // No Legacy, no spread -> spread derived from emission height
+        Arguments.of(null, false, new Point(), HALF_EMISSION_HEIGHT),
+        Arguments.of(null, false, new LineString(), HALF_EMISSION_HEIGHT),
+        Arguments.of(null, false, new Polygon(), HALF_EMISSION_HEIGHT),
+        // No legacy but with spread value -> take spread value
+        Arguments.of(SPREAD, false, new Point(), SPREAD),
+        Arguments.of(SPREAD, false, new LineString(), SPREAD),
+        Arguments.of(SPREAD, false, new Polygon(), SPREAD),
+        // Legacy, and no spread. For point/line there was no value set in the past
+        // and we now need to derive it ourselves from emission height
+        Arguments.of(null, true, new Point(), HALF_EMISSION_HEIGHT),
+        Arguments.of(null, true, new LineString(), HALF_EMISSION_HEIGHT),
+        // Legacy but for polygon, when no spread set it used to take sector default
+        Arguments.of(null, true, new Polygon(), DEFAULT_SPREAD),
+        // Legacy and spread value set, but for point/line was not supported
+        // Therefore we ignore spread and calculate it based on emission height.
+        Arguments.of(SPREAD, true, new Point(), HALF_EMISSION_HEIGHT),
+        Arguments.of(SPREAD, true, new LineString(), HALF_EMISSION_HEIGHT),
+        // Legacy with spread and polygon -> take the given spread
+        Arguments.of(SPREAD, true, new Polygon(), SPREAD));
+  }
+}


### PR DESCRIPTION
In new OPS version spread for points should be passed by the user. This means if no spread was given it should be getting half the emission height. In GML the spread can be present, but for point and lines it was not specified what the value meant as it was not used. Therefore we should treat the spread value in older GML's as a random value, and always derive the spread from the emission height. This change adds support for either reading the spread or deriving it from emission height (legacy). For now all versions of GML will use the legacy variant, as all versions are also available in production.

As of this moment there is not support for writing the spread to the GML for point/line sources, as it will not be possible to determine if it was legacy or set correctly since the GML version is not changed, and there are already GMLs generated in production with the legacy situation. To be able to correctly set the spread some new version of IMAER must be made.