### PR TITLE
AER-3679 Explicitly state that maximum range is relevant

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLCalculationSetOptionsReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLCalculationSetOptionsReader.java
@@ -58,7 +58,7 @@ public class GMLCalculationSetOptionsReader {
     if (calculationMetaData.getOptions() != null) {
       final Map<String, String> optionsMap = new HashMap<>();
 
-      // Use forEach to remove duplicate entries.
+      // Add to map to remove duplicate entries.
       calculationMetaData.getOptions().stream()
           .map(IsGmlProperty::getProperty)
           .forEach(p -> optionsMap.put(p.getKey(), p.getValue()));
@@ -67,6 +67,7 @@ public class GMLCalculationSetOptionsReader {
     setCalculationMethod(calculationMetaData, options);
     setCalculationJobType(calculationMetaData, options);
     options.setCalculateMaximumRange(calculationMetaData.getMaximumRange() == null ? 0.0 : calculationMetaData.getMaximumRange());
+    options.setMaximumRangeRelevant(calculationMetaData.getMaximumRange() != null);
     return options;
   }
 

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterTest.java
@@ -118,7 +118,7 @@ class GMLWriterTest {
         "Emissionsource not allowed to have no geometry.");
 
     final List<EmissionSourceFeature> sources2 = getExampleEmissionSources();
-    ((GenericEmissionSource) sources2.get(0).getProperties()).getEmissions().clear();
+    sources2.get(0).getProperties().getEmissions().clear();
     //source has no emission, it'll just be exported with 0.0 emissions for all substances.
     //this used to be an error situation, now it's treated as a work-in-progress export.
     assertNotNull(getConversionResult(converter, sources2), "Expect source to be written to file while having no emissions");
@@ -183,6 +183,7 @@ class GMLWriterTest {
   private CalculationSetOptions getCalculationOptions() {
     final CalculationSetOptions options = new CalculationSetOptions();
     options.setCalculationMethod(CalculationMethod.NATURE_AREA);
+    options.setMaximumRangeRelevant(true);
     options.setCalculateMaximumRange(3);
     options.getRblCalculationOptions().setMonitorSrm2Year(2030);
     options.getSubstances().add(Substance.NOX);

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationSetOptions.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/calculation/CalculationSetOptions.java
@@ -29,12 +29,13 @@ import nl.overheid.aerius.shared.domain.result.EmissionResultKey;
  */
 public class CalculationSetOptions implements Serializable {
 
-  private static final long serialVersionUID = 6L;
+  private static final long serialVersionUID = 7L;
 
   private int calculationSetOptionsId;
   private CalculationMethod calculationMethod = CalculationMethod.FORMAL_ASSESSMENT;
   private CalculationJobType calculationJobType;
   private double calculateMaximumRange;
+  private boolean maximumRangeRelevant;
   private boolean useInCombinationArchive;
   private final ArrayList<Substance> substances = new ArrayList<>();
   private final Set<EmissionResultKey> emissionResultKeys = new HashSet<>();
@@ -91,12 +92,15 @@ public class CalculationSetOptions implements Serializable {
   }
 
   /**
-   * Returns true if the maximum range value is used by the calculation method. Meaning those types use the maximum range value to determine the
-   * distance to calculate.
+   * Returns true if the maximum range is relevant for the calculation.
    * @return true if relevant
    */
   public boolean isMaximumRangeRelevant() {
-    return calculationMethod == CalculationMethod.NATURE_AREA || calculationMethod == CalculationMethod.QUICK_RUN;
+    return maximumRangeRelevant;
+  }
+
+  public void setMaximumRangeRelevant(final boolean maximumRangeRelevant) {
+    this.maximumRangeRelevant = maximumRangeRelevant;
   }
 
   /**


### PR DESCRIPTION
As it was, the calculation method was in charge of determining if the maximum range was relevant. UK however allows users to input the maximum range for FORMAL_ASSESSMENT, so this no longer holds.
Should be safe to do it like this: the option should be explicitly set when calculating in calculator, and that should override any value that was erronously read. The default value (false) also makes sense for NL, where the only options at the moment are custom points and formal assessment anyway.