### PR TITLE
AER-3666 Change precision for ADMS building values

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/adms/ADMSLimits.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/adms/ADMSLimits.java
@@ -79,7 +79,7 @@ public final class ADMSLimits implements BuildingLimits {
   public static final long SOURCE_L1_MAXIMUM = 1_000;
   public static final long SOURCE_L1_DEFAULT = 1;
 
-  private static final int BUILDING_DIGITS_PRECISION = 3;
+  private static final int BUILDING_DIGITS_PRECISION = 1;
 
   public static final double BUILDING_HEIGHT_MINIMUM = 0.001;
   public static final double BUILDING_HEIGHT_MAXIMUM = 500;


### PR DESCRIPTION
As far as I could tell, this is only used in frontend for display purposes.