### PR TITLE
Refactor ReceptorGridSettings into an enum

### DIFF
--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
@@ -95,8 +95,6 @@ public final class AssertGML {
 
   private static final String REGEX_FEATURE_COLLECTION_ELEMENT = "<imaer:FeatureCollectionCalculator[^>]*>";
 
-  private static final ReceptorGridSettings RECEPTOR_GRID_SETTINGS = GMLTestDomain.getExampleGridSettings();
-
   /**
    * Due to {@link GMLReaderFactory}'s instance aproach, we need to keep a static reference to the current characteristics type.
    */
@@ -201,7 +199,7 @@ public final class AssertGML {
   static GMLHelper mockGMLHelper(final CharacteristicsType ct) throws AeriusException {
     final GMLHelper gmlHelper = mock(GMLHelper.class);
     currentCharacteristicsType = ct;
-    when(gmlHelper.getReceptorGridSettings()).thenReturn(RECEPTOR_GRID_SETTINGS);
+    when(gmlHelper.getReceptorGridSettings()).thenReturn(ReceptorGridSettings.NL);
     mockEmissionSourceGeometryLimits(gmlHelper);
     when(gmlHelper.getCharacteristicsType()).thenAnswer((i) -> currentCharacteristicsType);
     final TestValidationAndEmissionHelper valiationAndEmissionHelper = new TestValidationAndEmissionHelper(

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLOldVersionTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLOldVersionTest.java
@@ -45,13 +45,13 @@ import org.slf4j.LoggerFactory;
 import nl.overheid.aerius.gml.base.AeriusGMLVersion;
 import nl.overheid.aerius.gml.base.MetaDataInput;
 import nl.overheid.aerius.shared.domain.Substance;
+import nl.overheid.aerius.shared.domain.geo.ReceptorGridSettings;
 import nl.overheid.aerius.shared.domain.scenario.SituationType;
 import nl.overheid.aerius.shared.domain.v2.importer.ImportParcel;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
-import nl.overheid.aerius.test.GMLTestDomain;
 
 /**
  * Test class that reads an old version GML and compares it to the current version of that same GML.
@@ -179,7 +179,7 @@ class GMLOldVersionTest {
       }
     }
     //for good measure, try to export to a current-gen version
-    final GMLWriter writer = new GMLWriter(GMLTestDomain.getExampleGridSettings(), r -> Optional.empty());
+    final GMLWriter writer = new GMLWriter(ReceptorGridSettings.NL, r -> Optional.empty());
     try (ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
       writer.writeEmissionSources(bos, oldSources, getMetaDataInput(oldResult));
     }

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLReaderTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLReaderTest.java
@@ -36,7 +36,6 @@ import java.util.Map;
 
 import javax.xml.namespace.NamespaceContext;
 
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,13 +83,6 @@ class GMLReaderTest {
   private static final String SITUATION_NAME = "Situatie 1";
   private static final SituationType SITUATION_TYPE = SituationType.PROPOSED;
   private static final Integer MONITOR_SRM2_YEAR = 2030;
-
-  private static ReceptorGridSettings gridSettings;
-
-  @BeforeAll
-  static void setUpBeforeClass() throws IOException {
-    gridSettings = GMLTestDomain.getExampleGridSettings();
-  }
 
   @Test
   void testConvertToEmissionSources() throws IOException, AeriusException {
@@ -228,7 +220,7 @@ class GMLReaderTest {
     metaDataInput.getOptions().setCalculationMethod(CalculationMethod.FORMAL_ASSESSMENT);
     metaDataInput.getOptions().getRblCalculationOptions().setMonitorSrm2Year(MONITOR_SRM2_YEAR);
     metaDataInput.setResultsIncluded(true);
-    final InternalGMLWriter writer = new InternalGMLWriter(gridSettings, GMLTestDomain.TEST_REFERENCE_GENERATOR, Boolean.TRUE,
+    final InternalGMLWriter writer = new InternalGMLWriter(ReceptorGridSettings.NL, GMLTestDomain.TEST_REFERENCE_GENERATOR, Boolean.TRUE,
         GMLWriter.LATEST_WRITER_VERSION, true);
     return writer.getWriter().metaData2GML(metaDataInput);
   }
@@ -332,7 +324,7 @@ class GMLReaderTest {
     offRoadMobileSourceMap.put("101", new Conversion("BA-B-E3", true));
     codeMaps.put(GMLLegacyCodeType.ON_ROAD_MOBILE_SOURCE, offRoadMobileSourceMap);
     when(mockHelper.getLegacyCodes(any())).thenReturn(codeMaps);
-    when(mockHelper.getReceptorGridSettings()).thenReturn(gridSettings);
+    when(mockHelper.getReceptorGridSettings()).thenReturn(ReceptorGridSettings.NL);
     return mockHelper;
   }
 

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLRoundtripTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLRoundtripTest.java
@@ -47,6 +47,7 @@ import nl.overheid.aerius.importer.ImportOption;
 import nl.overheid.aerius.shared.domain.Substance;
 import nl.overheid.aerius.shared.domain.Theme;
 import nl.overheid.aerius.shared.domain.calculation.CalculationSetOptions;
+import nl.overheid.aerius.shared.domain.geo.ReceptorGridSettings;
 import nl.overheid.aerius.shared.domain.result.EmissionResultKey;
 import nl.overheid.aerius.shared.domain.result.EmissionResultType;
 import nl.overheid.aerius.shared.domain.scenario.SituationType;
@@ -259,7 +260,7 @@ class GMLRoundtripTest {
       final AeriusGMLVersion targetGMLVersion) {
     try {
       final ImportParcel result = getImportResult(versionString, TEST_FOLDER, file, ct, file.contains("archive"));
-      final GMLWriter gmlc = new GMLWriter(GMLTestDomain.getExampleGridSettings(), GMLTestDomain.TEST_REFERENCE_GENERATOR, targetGMLVersion);
+      final GMLWriter gmlc = new GMLWriter(ReceptorGridSettings.NL, GMLTestDomain.TEST_REFERENCE_GENERATOR, targetGMLVersion);
       revertAutoCorrections(result);
       final GMLScenario scenario = GMLScenario.Builder
           .create(result, result.getSituation())

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterPerformanceTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterPerformanceTest.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 
 import nl.overheid.aerius.gml.base.FeatureMember;
 import nl.overheid.aerius.shared.domain.Substance;
+import nl.overheid.aerius.shared.domain.geo.ReceptorGridSettings;
 import nl.overheid.aerius.shared.domain.v2.base.TimeUnit;
 import nl.overheid.aerius.shared.domain.v2.geojson.LineString;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
@@ -49,8 +50,8 @@ class GMLWriterPerformanceTest {
 
   @Test
   void testConvertMetaData() throws IOException, AeriusException {
-    final InternalGMLWriter writer = new InternalGMLWriter(GMLTestDomain.getExampleGridSettings(), GMLTestDomain.TEST_REFERENCE_GENERATOR,
-        Boolean.TRUE, GMLWriter.LATEST_WRITER_VERSION, true);
+    final InternalGMLWriter writer = new InternalGMLWriter(ReceptorGridSettings.NL, GMLTestDomain.TEST_REFERENCE_GENERATOR, Boolean.TRUE,
+        GMLWriter.LATEST_WRITER_VERSION, true);
 
     final int numberOfSources = 800000;
     final List<EmissionSourceFeature> sourceFeatures = new ArrayList<>(numberOfSources);

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLWriterTest.java
@@ -86,12 +86,10 @@ class GMLWriterTest {
   private static final String SITUATION_REFERENCE = "SomeReference001";
   private static final SituationType SITUATION_TYPE = SituationType.PROPOSED;
 
-  private static final ReceptorGridSettings RECEPTOR_GRID_SETTINGS = GMLTestDomain.getExampleGridSettings();
-
   @ParameterizedTest
   @ValueSource(strings = {SOURCES_ONLY_FILE, SOURCES_ONLY_FILE_UNFORMATTED})
   void testConvertSources(final String gmlFilename) throws IOException, AeriusException {
-    final GMLWriter builder = new GMLWriter(RECEPTOR_GRID_SETTINGS, GMLTestDomain.TEST_REFERENCE_GENERATOR);
+    final GMLWriter builder = new GMLWriter(ReceptorGridSettings.NL, GMLTestDomain.TEST_REFERENCE_GENERATOR);
     builder.setFormattedOutput(SOURCES_ONLY_FILE.equals(gmlFilename));
     final List<EmissionSourceFeature> sources = getExampleEmissionSources();
     final String result = getConversionResult(builder, sources);
@@ -108,7 +106,7 @@ class GMLWriterTest {
 
   @Test
   void testConvertInvalidSources() throws IOException, AeriusException {
-    final GMLWriter converter = new GMLWriter(RECEPTOR_GRID_SETTINGS, GMLTestDomain.TEST_REFERENCE_GENERATOR);
+    final GMLWriter converter = new GMLWriter(ReceptorGridSettings.NL, GMLTestDomain.TEST_REFERENCE_GENERATOR);
     final List<EmissionSourceFeature> sources1 = getExampleEmissionSources();
     sources1.get(0).setGeometry(null);
 
@@ -126,7 +124,7 @@ class GMLWriterTest {
 
   @Test
   void testConvertMetaData() throws IOException, AeriusException {
-    final GMLWriter writer = new GMLWriter(RECEPTOR_GRID_SETTINGS, r -> Optional.of("test"));
+    final GMLWriter writer = new GMLWriter(ReceptorGridSettings.NL, r -> Optional.of("test"));
     final ScenarioMetaData metaData = getScenarioMetaData();
     final String originalReference = SITUATION_REFERENCE;
     final List<EmissionSourceFeature> sourceList = new ArrayList<>();
@@ -240,7 +238,7 @@ class GMLWriterTest {
     metaDataInput.setReference(null);
     metaDataInput.setSituationType(null);
     metaDataInput.setResultsIncluded(true);
-    final GMLWriter writer = new GMLWriter(RECEPTOR_GRID_SETTINGS, GMLTestDomain.TEST_REFERENCE_GENERATOR);
+    final GMLWriter writer = new GMLWriter(ReceptorGridSettings.NL, GMLTestDomain.TEST_REFERENCE_GENERATOR);
     if (ConvertReceptorsOptions.NO_REPRESENTATION.in(options)) {
       writer.setNoReceptorRepresentation();
     }
@@ -369,7 +367,7 @@ class GMLWriterTest {
 
   @Test
   void testConvertMixedFeatures() throws IOException, AeriusException {
-    final GMLWriter builder = new GMLWriter(RECEPTOR_GRID_SETTINGS, GMLTestDomain.TEST_REFERENCE_GENERATOR);
+    final GMLWriter builder = new GMLWriter(ReceptorGridSettings.NL, GMLTestDomain.TEST_REFERENCE_GENERATOR);
     final List<EmissionSourceFeature> emissionSources = getExampleEmissionSources();
     final ArrayList<CalculationPointFeature> receptors = getExampleAeriusPoints(true, false, false);
     String result;

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/test/GMLTestDomain.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/test/GMLTestDomain.java
@@ -20,11 +20,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import nl.overheid.aerius.geo.shared.BBox;
 import nl.overheid.aerius.gml.ReferenceGenerator;
 import nl.overheid.aerius.shared.domain.Substance;
-import nl.overheid.aerius.shared.domain.geo.HexagonZoomLevel;
-import nl.overheid.aerius.shared.domain.geo.ReceptorGridSettings;
 import nl.overheid.aerius.shared.domain.ops.DiurnalVariation;
 import nl.overheid.aerius.shared.domain.result.EmissionResultKey;
 import nl.overheid.aerius.shared.domain.v2.characteristics.HeatContentType;
@@ -34,7 +31,6 @@ import nl.overheid.aerius.shared.domain.v2.geojson.Point;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.domain.v2.source.GenericEmissionSource;
-import nl.overheid.aerius.shared.geo.EPSG;
 
 /**
  * Convenience class to avoid having to write the same test code over and over again.
@@ -131,15 +127,4 @@ public class GMLTestDomain {
     emissionSourceList.add(getSource(2, point2, "ExampleSource2", source2));
     return emissionSourceList;
   }
-
-  public static ReceptorGridSettings getExampleGridSettings() {
-    final BBox bbox = new BBox(3604.0, 287959.0, 296800.0, 629300.0);
-    final ArrayList<HexagonZoomLevel> zoomLevels = new ArrayList<HexagonZoomLevel>();
-    for (int i = 1; i <= 5; i++) {
-      zoomLevels.add(new HexagonZoomLevel(i, 10000));
-    }
-    final int hexHor = 1529;
-    return new ReceptorGridSettings(bbox, EPSG.RDNEW, hexHor, zoomLevels);
-  }
-
 }

--- a/source/imaer-gml/src/test/resources/gml/v5_1/roundtrip/archive_metadata.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_1/roundtrip/archive_metadata.gml
@@ -44,14 +44,14 @@
             </imaer:identifier>
             <imaer:GM_Point>
                 <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.1.POINT">
-                    <gml:pos>3604.0 287959.0</gml:pos>
+                    <gml:pos>3604.0 296800.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
             <imaer:representation>
                 <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="NL.IMAER.REPR.1">
                     <gml:exterior>
                         <gml:LinearRing>
-                            <gml:posList>3635.0 288013.0 3666.0 287959.0 3635.0 287905.0 3573.0 287905.0 3542.0 287959.0 3573.0 288013.0 3635.0 288013.0</gml:posList>
+                            <gml:posList>3635.0 296854.0 3666.0 296800.0 3635.0 296746.0 3573.0 296746.0 3542.0 296800.0 3573.0 296854.0 3635.0 296854.0</gml:posList>
                         </gml:LinearRing>
                     </gml:exterior>
                 </gml:Polygon>
@@ -88,14 +88,14 @@
             </imaer:identifier>
             <imaer:GM_Point>
                 <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.2.POINT">
-                    <gml:pos>3790.12097182042 287959.0</gml:pos>
+                    <gml:pos>3790.12097182042 296800.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
             <imaer:representation>
                 <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="NL.IMAER.REPR.2">
                     <gml:exterior>
                         <gml:LinearRing>
-                            <gml:posList>3821.0 288013.0 3852.0 287959.0 3821.0 287905.0 3759.0 287905.0 3728.0 287959.0 3759.0 288013.0 3821.0 288013.0</gml:posList>
+                            <gml:posList>3821.0 296854.0 3852.0 296800.0 3821.0 296746.0 3759.0 296746.0 3728.0 296800.0 3759.0 296854.0 3821.0 296854.0</gml:posList>
                         </gml:LinearRing>
                     </gml:exterior>
                 </gml:Polygon>

--- a/source/imaer-gml/src/test/resources/gml/v6_0/roundtrip/archive_metadata.gml
+++ b/source/imaer-gml/src/test/resources/gml/v6_0/roundtrip/archive_metadata.gml
@@ -45,14 +45,14 @@
             </imaer:identifier>
             <imaer:GM_Point>
                 <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.1.POINT">
-                    <gml:pos>3604.0 287959.0</gml:pos>
+                    <gml:pos>3604.0 296800.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
             <imaer:representation>
                 <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="NL.IMAER.REPR.1">
                     <gml:exterior>
                         <gml:LinearRing>
-                            <gml:posList>3635.0 288013.0 3666.0 287959.0 3635.0 287905.0 3573.0 287905.0 3542.0 287959.0 3573.0 288013.0 3635.0 288013.0</gml:posList>
+                            <gml:posList>3635.0 296854.0 3666.0 296800.0 3635.0 296746.0 3573.0 296746.0 3542.0 296800.0 3573.0 296854.0 3635.0 296854.0</gml:posList>
                         </gml:LinearRing>
                     </gml:exterior>
                 </gml:Polygon>
@@ -89,14 +89,14 @@
             </imaer:identifier>
             <imaer:GM_Point>
                 <gml:Point srsName="urn:ogc:def:crs:EPSG::28992" gml:id="CP.2.POINT">
-                    <gml:pos>3790.12097182042 287959.0</gml:pos>
+                    <gml:pos>3790.12097182042 296800.0</gml:pos>
                 </gml:Point>
             </imaer:GM_Point>
             <imaer:representation>
                 <gml:Polygon srsName="urn:ogc:def:crs:EPSG::28992" gml:id="NL.IMAER.REPR.2">
                     <gml:exterior>
                         <gml:LinearRing>
-                            <gml:posList>3821.0 288013.0 3852.0 287959.0 3821.0 287905.0 3759.0 287905.0 3728.0 287959.0 3759.0 288013.0 3821.0 288013.0</gml:posList>
+                            <gml:posList>3821.0 296854.0 3852.0 296800.0 3821.0 296746.0 3759.0 296746.0 3728.0 296800.0 3759.0 296854.0 3821.0 296854.0</gml:posList>
                         </gml:LinearRing>
                     </gml:exterior>
                 </gml:Polygon>

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/geo/ReceptorGridSettings.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/geo/ReceptorGridSettings.java
@@ -16,7 +16,6 @@
  */
 package nl.overheid.aerius.shared.domain.geo;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -28,9 +27,15 @@ import nl.overheid.aerius.shared.geo.EPSG;
 /**
  * Application settings related to the variables of the receptor grid used as basis of the application.
  */
-public final class ReceptorGridSettings implements Serializable {
-
-  private static final long serialVersionUID = 1L;
+public enum ReceptorGridSettings {
+  /**
+   * The Netherlands
+   */
+  NL(EPSG.RDNEW, 1529, 5, 10_000, new BBox(3604.0, 296800.0, 287959.0, 629300.0)),
+  /**
+   * United Kingdom
+   */
+  UK(EPSG.BNG, 1785, 7, 40_000, new BBox(-4_000.0, 4_000.0, 660_000.0, 1_222_000.0));
 
   private BBox boundingBox;
   private EPSG epsg;
@@ -45,21 +50,31 @@ public final class ReceptorGridSettings implements Serializable {
   /**
    * Constructor
    *
-   * @param boundingBox Bounding box of the receptor grid
    * @param epsg EPSG code of the receptor grid
    * @param hexagonHorizontal Number of horizontal hexagons
-   * @param hexagonZoomLevels Number of hexagon zoom levels
+   * @param maxZoomLevels Maximum number of zoom levels
+   * @param minSurfaceArea Minimum surface are of zoom level 1
+   * @param boundingBox Bounding box of the receptor grid
    */
-  public ReceptorGridSettings(final BBox boundingBox, final EPSG epsg, final int hexagonHorizontal,
-      final ArrayList<HexagonZoomLevel> hexagonZoomLevels) {
-    this.boundingBox = boundingBox;
+  ReceptorGridSettings(final EPSG epsg, final int hexagonHorizontal, final int maxZoomLevels, final int minSurfaceArea, final BBox boundingBox) {
+    final List<HexagonZoomLevel> zoomLevels = new ArrayList<>();
+
+    for (int i = 1; i <= maxZoomLevels; i++) {
+      zoomLevels.add(new HexagonZoomLevel(i, minSurfaceArea));
+    }
     this.epsg = epsg;
     this.hexHor = hexagonHorizontal;
-    this.hexagonZoomLevels = hexagonZoomLevels;
+    this.hexagonZoomLevels = zoomLevels;
+    this.boundingBox = boundingBox;
   }
 
-  /** Needed for GWT. */
-  protected ReceptorGridSettings() {
+  public static ReceptorGridSettings valueByEPSG(final EPSG epsg) {
+    for (final ReceptorGridSettings rgs : values()) {
+      if (rgs.getEPSG() == epsg) {
+        return rgs;
+      }
+    }
+    return null;
   }
 
   /**

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/geo/ReceptorGridSettings.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/geo/ReceptorGridSettings.java
@@ -31,7 +31,7 @@ public enum ReceptorGridSettings {
   /**
    * The Netherlands
    */
-  NL(EPSG.RDNEW, 1529, 5, 10_000, new BBox(3604.0, 296800.0, 287959.0, 629300.0)),
+  NL(EPSG.RDNEW, 1529, 5, 10_000, new BBox(3_604.0, 296_800.0, 287_959.0, 629_300.0)),
   /**
    * United Kingdom
    */

--- a/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/geometry/ReceptorUtilTest.java
+++ b/source/imaer-shared/src/test/java/nl/overheid/aerius/shared/geometry/ReceptorUtilTest.java
@@ -20,7 +20,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.ArrayList;
 import java.util.Random;
 
 import org.junit.jupiter.api.Assertions;
@@ -28,13 +27,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-import nl.overheid.aerius.geo.shared.BBox;
 import nl.overheid.aerius.shared.domain.geo.HexagonZoomLevel;
 import nl.overheid.aerius.shared.domain.geo.ReceptorGridSettings;
 import nl.overheid.aerius.shared.domain.v2.geojson.Point;
 import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
 import nl.overheid.aerius.shared.domain.v2.point.ReceptorPoint;
-import nl.overheid.aerius.shared.geo.EPSG;
 
 /**
  * Test class for {@link ReceptorUtil}.
@@ -54,12 +51,8 @@ class ReceptorUtilTest {
       {4706906, 123279.78488053002, 462176.3125076431},
       {9184376, 227135.287156324, 619493.35052661}};
 
-  private static final HexagonZoomLevel ZOOM_LEVEL_1 = new HexagonZoomLevel(1, 10_000);
-  private static final BBox RECEPTOR_BBOX = new BBox(3604, 296800, 287959, 629300);
-
-  private static final ArrayList<HexagonZoomLevel> hexagonZoomLevels = createZoomLevels();
-  private static final ReceptorGridSettings RGS = new ReceptorGridSettings(RECEPTOR_BBOX, EPSG.RDNEW, 1529, hexagonZoomLevels);
-  private static final ReceptorUtil RECEPTOR_UTIL = new ReceptorUtil(RGS);
+  private static final ReceptorUtil RECEPTOR_UTIL = new ReceptorUtil(ReceptorGridSettings.NL);
+  private static final HexagonZoomLevel ZOOM_LEVEL_1 = ReceptorGridSettings.NL.getZoomLevel1();
 
   @Test
   void testRPFromAndToRandom() {
@@ -91,16 +84,6 @@ class ReceptorUtilTest {
       Assertions.assertEquals(r4.getX(), r4.getX(), ZOOM_LEVEL_1.getHexagonRadius(), "Random check for values X coord (exact)");
       Assertions.assertEquals(r4.getY(), r4.getY(), ZOOM_LEVEL_1.getHexagonHeight() / 2, "Random check for values Y coord (exact)");
     }
-  }
-
-  private static ArrayList<HexagonZoomLevel> createZoomLevels() {
-    final ArrayList<HexagonZoomLevel> zoomLevels = new ArrayList<>();
-    zoomLevels.add(ZOOM_LEVEL_1);
-    zoomLevels.add(new HexagonZoomLevel(2, 40_000));
-    zoomLevels.add(new HexagonZoomLevel(3, 160_000));
-    zoomLevels.add(new HexagonZoomLevel(4, 640_000));
-    zoomLevels.add(new HexagonZoomLevel(5, 2_560_000));
-    return zoomLevels;
   }
 
   @Test
@@ -184,8 +167,8 @@ class ReceptorUtilTest {
 
     for (int i = 2; i < 5; i++) {
       final HexagonZoomLevel zoomLevel = new HexagonZoomLevel(i, ZOOM_LEVEL_1.getSurfaceLevel1());
-      assertTrue(RECEPTOR_UTIL.isReceptorAtZoomLevel(inPoint, zoomLevel), "Point should be return as a receptor at zoomLevel " + i);
-      assertFalse(RECEPTOR_UTIL.isReceptorAtZoomLevel(outPoint, zoomLevel), "Point should be return not as a receptor at zoomLevel " + i);
+      assertTrue(RECEPTOR_UTIL.isReceptorAtZoomLevel(inPoint, zoomLevel), "Point should return as a receptor at zoomLevel " + i);
+      assertFalse(RECEPTOR_UTIL.isReceptorAtZoomLevel(outPoint, zoomLevel), "Point should not return as a receptor at zoomLevel " + i);
     }
   }
 


### PR DESCRIPTION
Since the values of ReceptorGridSettings don't change they can be hard-coded. Breaking change: Changes `RecetorSettingsGrid` from a class into a enum.