### PR TITLE
AER-3735 default characteristics also determined by geometry type

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/AbstractGML2Source.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/AbstractGML2Source.java
@@ -127,7 +127,7 @@ public abstract class AbstractGML2Source<T extends IsGmlEmissionSource, S extend
         || returnSource instanceof MooringMaritimeShippingEmissionSource
         || returnSource instanceof OffRoadMobileEmissionSource
         || returnSource instanceof ADMSRoadEmissionSource)) {
-      final S sectorCharacteristics = conversionData.determineDefaultCharacteristicsBySectorId(sectorId);
+      final S sectorCharacteristics = conversionData.determineDefaultCharacteristicsBySectorId(sectorId, geometry.type());
       if (returnSource instanceof final ColdStartEmissionSource coldStart && coldStart.isVehicleBasedCharacteristics()) {
         // NO-OP, allow characteristics to be null for cold start
       } else if (source.getCharacteristics() == null) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLCharacteristicsSupplier.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLCharacteristicsSupplier.java
@@ -18,6 +18,7 @@ package nl.overheid.aerius.gml.base;
 
 import nl.overheid.aerius.shared.domain.v2.characteristics.CharacteristicsType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.geojson.GeometryType;
 
 /**
  * Supplier for Source characteristics.
@@ -26,8 +27,20 @@ public interface GMLCharacteristicsSupplier {
 
   /**
    * Determine the default characteristics for a sector (based on AERIUS sector ID).
+   *
+   * @deprecated use/implement the version with geometry type, this version will be removed in a future version
    */
-  <S extends SourceCharacteristics> S determineDefaultCharacteristicsBySectorId(int sectorId);
+  @Deprecated
+  default <S extends SourceCharacteristics> S determineDefaultCharacteristicsBySectorId(final int sectorId) {
+    return null;
+  }
+
+  /**
+   * Determine the default characteristics for a sector (based on AERIUS sector ID and geometry type).
+   */
+  default <S extends SourceCharacteristics> S determineDefaultCharacteristicsBySectorId(final int sectorId, final GeometryType geometryType) {
+    return determineDefaultCharacteristicsBySectorId(sectorId);
+  }
 
   /**
    * @return returns the data type of the characteristics.

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLConversionData.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/GMLConversionData.java
@@ -35,6 +35,7 @@ import nl.overheid.aerius.shared.domain.v2.characteristics.CharacteristicsType;
 import nl.overheid.aerius.shared.domain.v2.characteristics.OPSSourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
 import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
+import nl.overheid.aerius.shared.domain.v2.geojson.GeometryType;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.domain.v2.source.InlandMaritimeShippingEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.InlandShippingEmissionSource;
@@ -237,5 +238,9 @@ public class GMLConversionData {
 
   public <S extends SourceCharacteristics> S determineDefaultCharacteristicsBySectorId(final int sectorId) {
     return characteristicsSupplier.determineDefaultCharacteristicsBySectorId(sectorId);
+  }
+
+  public <S extends SourceCharacteristics> S determineDefaultCharacteristicsBySectorId(final int sectorId, final GeometryType geometryType) {
+    return characteristicsSupplier.determineDefaultCharacteristicsBySectorId(sectorId, geometryType);
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v31/GML2OffRoad.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v31/GML2OffRoad.java
@@ -26,6 +26,7 @@ import nl.overheid.aerius.gml.base.IsGmlProperty;
 import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.base.geo.GML2Geometry;
 import nl.overheid.aerius.gml.base.source.IsGmlEmission;
+import nl.overheid.aerius.shared.domain.v2.geojson.GeometryType;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.domain.v2.source.GenericEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.OffRoadMobileEmissionSource;
@@ -99,7 +100,7 @@ public class GML2OffRoad<T extends IsGmlOffRoadMobileEmissionSource> extends Abs
     newSource.setSectorId(sectorId);
     newSource.setLabel(constructLabel(source.getLabel(), customMobileSource.getDescription()));
     newSource.setCharacteristics(gml2SourceCharacteristics.fromGML(customMobileSource.getCharacteristics(),
-        getConversionData().determineDefaultCharacteristicsBySectorId(sectorId), null));
+        getConversionData().determineDefaultCharacteristicsBySectorId(sectorId, GeometryType.POINT), null));
     for (final IsGmlProperty<IsGmlEmission> emissionProperty : customMobileSource.getEmissions()) {
       final IsGmlEmission emission = emissionProperty.getProperty();
       newSource.getEmissions().put(emission.getSubstance(), emission.getValue());

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v31/GML2OffRoad.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v31/GML2OffRoad.java
@@ -26,7 +26,7 @@ import nl.overheid.aerius.gml.base.IsGmlProperty;
 import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.base.geo.GML2Geometry;
 import nl.overheid.aerius.gml.base.source.IsGmlEmission;
-import nl.overheid.aerius.shared.domain.v2.geojson.GeometryType;
+import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.domain.v2.source.GenericEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.OffRoadMobileEmissionSource;
@@ -99,15 +99,16 @@ public class GML2OffRoad<T extends IsGmlOffRoadMobileEmissionSource> extends Abs
     final int sectorId = getConversionData().getSectorId(source.getSectorId(), source.getLabel());
     newSource.setSectorId(sectorId);
     newSource.setLabel(constructLabel(source.getLabel(), customMobileSource.getDescription()));
+    final Geometry geometry = gml2Geometry.getGeometry(source);
     newSource.setCharacteristics(gml2SourceCharacteristics.fromGML(customMobileSource.getCharacteristics(),
-        getConversionData().determineDefaultCharacteristicsBySectorId(sectorId, GeometryType.POINT), null));
+        getConversionData().determineDefaultCharacteristicsBySectorId(sectorId, geometry.type()), null));
     for (final IsGmlProperty<IsGmlEmission> emissionProperty : customMobileSource.getEmissions()) {
       final IsGmlEmission emission = emissionProperty.getProperty();
       newSource.getEmissions().put(emission.getSubstance(), emission.getValue());
     }
     final EmissionSourceFeature feature = new EmissionSourceFeature();
     feature.setProperties(newSource);
-    feature.setGeometry(gml2Geometry.getGeometry(source));
+    feature.setGeometry(geometry);
     getConversionData().getExtraSources().add(feature);
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v40/GML2OffRoad.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v40/GML2OffRoad.java
@@ -25,7 +25,7 @@ import nl.overheid.aerius.gml.base.IsGmlProperty;
 import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.base.geo.GML2Geometry;
 import nl.overheid.aerius.gml.base.source.IsGmlEmission;
-import nl.overheid.aerius.shared.domain.v2.geojson.GeometryType;
+import nl.overheid.aerius.shared.domain.v2.geojson.Geometry;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.domain.v2.source.GenericEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.OffRoadMobileEmissionSource;
@@ -92,15 +92,16 @@ public class GML2OffRoad<T extends IsGmlOffRoadMobileEmissionSource> extends Abs
     final int sectorId = getConversionData().getSectorId(source.getSectorId(), source.getLabel());
     newSource.setSectorId(sectorId);
     newSource.setLabel(constructLabel(source.getLabel(), customMobileSource.getDescription()));
+    final Geometry geometry = gml2Geometry.getGeometry(source);
     newSource.setCharacteristics(gml2SourceCharacteristics.fromGML(customMobileSource.getCharacteristics(),
-        getConversionData().determineDefaultCharacteristicsBySectorId(sectorId, GeometryType.POINT), null));
+        getConversionData().determineDefaultCharacteristicsBySectorId(sectorId, geometry.type()), null));
     for (final IsGmlProperty<IsGmlEmission> emissionProperty : customMobileSource.getEmissions()) {
       final IsGmlEmission emission = emissionProperty.getProperty();
       newSource.getEmissions().put(emission.getSubstance(), emission.getValue());
     }
     final EmissionSourceFeature feature = new EmissionSourceFeature();
     feature.setProperties(newSource);
-    feature.setGeometry(gml2Geometry.getGeometry(source));
+    feature.setGeometry(geometry);
     getConversionData().getExtraSources().add(feature);
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v40/GML2OffRoad.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/mobile/v40/GML2OffRoad.java
@@ -25,6 +25,7 @@ import nl.overheid.aerius.gml.base.IsGmlProperty;
 import nl.overheid.aerius.gml.base.characteristics.GML2SourceCharacteristics;
 import nl.overheid.aerius.gml.base.geo.GML2Geometry;
 import nl.overheid.aerius.gml.base.source.IsGmlEmission;
+import nl.overheid.aerius.shared.domain.v2.geojson.GeometryType;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.domain.v2.source.GenericEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.OffRoadMobileEmissionSource;
@@ -92,7 +93,7 @@ public class GML2OffRoad<T extends IsGmlOffRoadMobileEmissionSource> extends Abs
     newSource.setSectorId(sectorId);
     newSource.setLabel(constructLabel(source.getLabel(), customMobileSource.getDescription()));
     newSource.setCharacteristics(gml2SourceCharacteristics.fromGML(customMobileSource.getCharacteristics(),
-        getConversionData().determineDefaultCharacteristicsBySectorId(sectorId), null));
+        getConversionData().determineDefaultCharacteristicsBySectorId(sectorId, GeometryType.POINT), null));
     for (final IsGmlProperty<IsGmlEmission> emissionProperty : customMobileSource.getEmissions()) {
       final IsGmlEmission emission = emissionProperty.getProperty();
       newSource.getEmissions().put(emission.getSubstance(), emission.getValue());

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/AssertGML.java
@@ -218,7 +218,7 @@ public final class AssertGML {
     when(gmlHelper.getLegacyMobileSourceOffRoadConversions()).thenReturn(TestValidationAndEmissionHelper.legacyMobileSourceOffRoadConversions());
     when(gmlHelper.getLegacyPlanConversions()).thenReturn(TestValidationAndEmissionHelper.legacyPlanConversions());
     when(gmlHelper.getLegacyFarmLodgingConversions()).thenReturn(TestValidationAndEmissionHelper.legacyFarmLodgingConversions());
-    when(gmlHelper.determineDefaultCharacteristicsBySectorId(anyInt())).thenAnswer((i) -> determineDefaultCharacteristics());
+    when(gmlHelper.determineDefaultCharacteristicsBySectorId(anyInt(), any())).thenAnswer((i) -> determineDefaultCharacteristics());
     when(gmlHelper.getValidationHelper()).thenReturn(valiationAndEmissionHelper);
     when(gmlHelper.getDefaultSector()).thenReturn(new Sector(GMLTestDomain.DEFAULT_SECTOR_ID, SectorGroup.INDUSTRY, ""));
     when(gmlHelper.isValidSectorId(anyInt())).thenReturn(true);


### PR DESCRIPTION
For ADMS it matters what the geometry type is. Or rather, it matters what the ADMS source type is, but the default for that can be based on geometry type. And since geometry type is fairly generic... Default methods in GMLCharacteristicsSupplier for easier conversion (that's the idea behind it at least).