### PR TITLE
AER-3888 Force gml id when reading GML.

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReader.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReader.java
@@ -36,6 +36,7 @@ import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
 import nl.overheid.aerius.shared.domain.v2.scenario.Definitions;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.exception.AeriusException;
+import nl.overheid.aerius.util.gml.GMLIdUtil;
 
 /**
  * Class to read data from a feature collection that was created from an IMAER GML.
@@ -138,6 +139,7 @@ public final class GMLReader {
       emissionSourceList.addAll(conversionData.getMaritimeInlandRoutes().keySet());
       emissionSourceList.addAll(conversionData.getMaritimeMaritimeRoutes().keySet());
     }
+    GMLIdUtil.toValidGmlIds(emissionSourceList, GMLIdUtil.SOURCE_PREFIX);
     return emissionSourceList;
   }
 

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/InternalGMLWriter.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/InternalGMLWriter.java
@@ -57,6 +57,7 @@ import nl.overheid.aerius.shared.domain.v2.point.CalculationPointFeature;
 import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
 import nl.overheid.aerius.shared.exception.AeriusException;
 import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
+import nl.overheid.aerius.util.gml.GMLIdUtil;
 
 /**
  * Class to create GML content from data objects.
@@ -221,6 +222,8 @@ final class InternalGMLWriter {
 
   List<FeatureMember> emissionSourcesToFeatures(final List<EmissionSourceFeature> sources)
       throws AeriusException {
+    GMLIdUtil.toValidGmlIds(sources, GMLIdUtil.SOURCE_PREFIX);
+
     final List<FeatureMember> featureMembers = new ArrayList<>();
     for (final EmissionSourceFeature source : sources) {
       featureMembers.addAll(writer.source2GML(source, EMISSION_SUBSTANCES));
@@ -230,6 +233,8 @@ final class InternalGMLWriter {
 
   List<FeatureMember> buildingsToFeatures(final List<BuildingFeature> buildings)
       throws AeriusException {
+    GMLIdUtil.toValidGmlIds(buildings, GMLIdUtil.BUILDING_PREFIX);
+
     final List<FeatureMember> featureMembers = new ArrayList<>(buildings.size());
     for (final BuildingFeature building : buildings) {
       featureMembers.add(writer.building2GML(building));
@@ -239,6 +244,8 @@ final class InternalGMLWriter {
 
   List<FeatureMember> cimlkMeasuresToFeatures(final List<CIMLKMeasureFeature> measures)
       throws AeriusException {
+    GMLIdUtil.toValidGmlIds(measures, GMLIdUtil.MEASURE_PREFIX);
+
     final List<FeatureMember> featureMembers = new ArrayList<>(measures.size());
     for (final CIMLKMeasureFeature measure : measures) {
       featureMembers.add(writer.cimlkMeasure2GML(measure));

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/GML2CIMLKDispersionLine.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/GML2CIMLKDispersionLine.java
@@ -54,7 +54,7 @@ public class GML2CIMLKDispersionLine {
     final String roadId = gmlDispersionLine.getRoad().getReferredId();
     final String calculationPointId = gmlDispersionLine.getCalculationPoint().getReferredId();
 
-    dispersionLine.setRoadGmlId(roadId);
+    dispersionLine.setGmlId(roadId);
     dispersionLine.setCalculationPointGmlId(calculationPointId);
 
     final CIMLKDispersionLineFeature feature = new CIMLKDispersionLineFeature();

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/Building2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/Building2GML.java
@@ -20,7 +20,6 @@ import nl.overheid.aerius.gml.base.geo.Geometry2GML;
 import nl.overheid.aerius.gml.v5_1.building.Building;
 import nl.overheid.aerius.shared.domain.v2.building.BuildingFeature;
 import nl.overheid.aerius.shared.exception.AeriusException;
-import nl.overheid.aerius.util.gml.GMLIdUtil;
 
 /**
  *
@@ -42,10 +41,9 @@ final class Building2GML {
   public Building toGML(final BuildingFeature feature) throws AeriusException {
     final Building gmlBuilding = new Building();
     final nl.overheid.aerius.shared.domain.v2.building.Building building = feature.getProperties();
-    final String id = GMLIdUtil.toValidGmlId(building.getGmlId(), GMLIdUtil.BUILDING_PREFIX);
 
     gmlBuilding.setGeometry(geometry2gml, feature.getGeometry());
-    gmlBuilding.setId(id);
+    gmlBuilding.setId(building.getGmlId());
     gmlBuilding.setLabel(building.getLabel());
     gmlBuilding.setHeight(building.getHeight());
     gmlBuilding.setDiameter(building.isCircle() ? building.getDiameter() : null);

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/CIMLKDispersionLine2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/CIMLKDispersionLine2GML.java
@@ -45,10 +45,11 @@ final class CIMLKDispersionLine2GML {
     final SRM1RoadDispersionLine gmlDispersionLine = new SRM1RoadDispersionLine();
     final CIMLKDispersionLine dispersionLine = dispersionLineFeature.getProperties();
     final String calculationPointId = GMLIdUtil.toValidGmlId(dispersionLine.getCalculationPointGmlId(), GMLIdUtil.POINT_PREFIX);
-    final String roadId = GMLIdUtil.toValidGmlId(dispersionLine.getRoadGmlId(), GMLIdUtil.SOURCE_PREFIX);
+    final String roadId = GMLIdUtil.toValidGmlId(dispersionLine.getGmlId(), GMLIdUtil.SOURCE_PREFIX);
     final String id = "DL." + calculationPointId + "." + roadId;
 
     gmlDispersionLine.setId(id);
+    dispersionLine.setGmlId(id);
     gmlDispersionLine.setDescription(dispersionLine.getDescription());
     gmlDispersionLine.setLabel(dispersionLine.getLabel());
     gmlDispersionLine.setJurisdictionId(dispersionLine.getJurisdictionId());

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/CIMLKMeasure2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/CIMLKMeasure2GML.java
@@ -29,7 +29,6 @@ import nl.overheid.aerius.shared.domain.v2.cimlk.CIMLKMeasure;
 import nl.overheid.aerius.shared.domain.v2.cimlk.CIMLKMeasureFeature;
 import nl.overheid.aerius.shared.domain.v2.source.road.StandardVehicleMeasure;
 import nl.overheid.aerius.shared.exception.AeriusException;
-import nl.overheid.aerius.util.gml.GMLIdUtil;
 
 /**
  *
@@ -51,10 +50,9 @@ final class CIMLKMeasure2GML {
   public SRM1RoadMeasureArea toGML(final CIMLKMeasureFeature feature) throws AeriusException {
     final SRM1RoadMeasureArea gmlMeasure = new SRM1RoadMeasureArea();
     final CIMLKMeasure measure = feature.getProperties();
-    final String id = GMLIdUtil.toValidGmlId(measure.getGmlId(), GMLIdUtil.MEASURE_PREFIX);
 
     gmlMeasure.setGeometry(geometry2gml, feature.getGeometry());
-    gmlMeasure.setId(id);
+    gmlMeasure.setId(measure.getGmlId());
     gmlMeasure.setDescription(measure.getDescription());
     gmlMeasure.setLabel(measure.getLabel());
     gmlMeasure.setJurisdictionId(measure.getJurisdictionId());

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/Source2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v5_1/togml/Source2GML.java
@@ -46,7 +46,6 @@ import nl.overheid.aerius.shared.domain.v2.source.OffRoadMobileEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.SRM1RoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.SRM2RoadEmissionSource;
 import nl.overheid.aerius.shared.exception.AeriusException;
-import nl.overheid.aerius.util.gml.GMLIdUtil;
 
 /**
  * Util class to convert {@link EmissionSource} to GML object.
@@ -80,13 +79,10 @@ final class Source2GML implements EmissionSourceVisitor<nl.overheid.aerius.gml.v
   private nl.overheid.aerius.gml.v5_1.source.EmissionSource toGMLDefault(final EmissionSourceFeature sourceFeature,
       final Substance[] substances) throws AeriusException {
     final EmissionSource source = sourceFeature.getProperties();
-    //use a specific prefix for ID to achieve unique IDs
-    final String gmlId = GMLIdUtil.toValidGmlId(source.getGmlId(), GMLIdUtil.SOURCE_PREFIX, sourceFeature.getId());
-    source.setGmlId(gmlId);
     final nl.overheid.aerius.gml.v5_1.source.EmissionSource returnSource = sourceFeature.accept(this);
     //set the generic properties.
     returnSource.setGeometry(geometry2gml, sourceFeature.getGeometry());
-    returnSource.setId(gmlId);
+    returnSource.setId(source.getGmlId());
 
     returnSource.setLabel(source.getLabel());
     returnSource.setDescription(source.getDescription());

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v6_0/togml/Building2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v6_0/togml/Building2GML.java
@@ -20,7 +20,6 @@ import nl.overheid.aerius.gml.base.geo.Geometry2GML;
 import nl.overheid.aerius.gml.v6_0.building.Building;
 import nl.overheid.aerius.shared.domain.v2.building.BuildingFeature;
 import nl.overheid.aerius.shared.exception.AeriusException;
-import nl.overheid.aerius.util.gml.GMLIdUtil;
 
 /**
  *
@@ -42,10 +41,9 @@ final class Building2GML {
   public Building toGML(final BuildingFeature feature) throws AeriusException {
     final Building gmlBuilding = new Building();
     final nl.overheid.aerius.shared.domain.v2.building.Building building = feature.getProperties();
-    final String id = GMLIdUtil.toValidGmlId(building.getGmlId(), GMLIdUtil.BUILDING_PREFIX);
 
     gmlBuilding.setGeometry(geometry2gml, feature.getGeometry());
-    gmlBuilding.setId(id);
+    gmlBuilding.setId(building.getGmlId());
     gmlBuilding.setLabel(building.getLabel());
     gmlBuilding.setHeight(building.getHeight());
     gmlBuilding.setDiameter(building.isCircle() ? building.getDiameter() : null);

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v6_0/togml/CIMLKDispersionLine2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v6_0/togml/CIMLKDispersionLine2GML.java
@@ -45,7 +45,7 @@ final class CIMLKDispersionLine2GML {
     final SRM1RoadDispersionLine gmlDispersionLine = new SRM1RoadDispersionLine();
     final CIMLKDispersionLine dispersionLine = dispersionLineFeature.getProperties();
     final String calculationPointId = GMLIdUtil.toValidGmlId(dispersionLine.getCalculationPointGmlId(), GMLIdUtil.POINT_PREFIX);
-    final String roadId = GMLIdUtil.toValidGmlId(dispersionLine.getRoadGmlId(), GMLIdUtil.SOURCE_PREFIX);
+    final String roadId = GMLIdUtil.toValidGmlId(dispersionLine.getGmlId(), GMLIdUtil.SOURCE_PREFIX);
     final String id = "DL." + calculationPointId + "." + roadId;
 
     gmlDispersionLine.setId(id);

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v6_0/togml/Source2GML.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/v6_0/togml/Source2GML.java
@@ -45,7 +45,6 @@ import nl.overheid.aerius.shared.domain.v2.source.OffRoadMobileEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.SRM1RoadEmissionSource;
 import nl.overheid.aerius.shared.domain.v2.source.SRM2RoadEmissionSource;
 import nl.overheid.aerius.shared.exception.AeriusException;
-import nl.overheid.aerius.util.gml.GMLIdUtil;
 
 /**
  * Util class to convert {@link EmissionSource} to GML object.
@@ -79,13 +78,10 @@ final class Source2GML implements EmissionSourceVisitor<nl.overheid.aerius.gml.v
   private nl.overheid.aerius.gml.v6_0.source.EmissionSource toGMLDefault(final EmissionSourceFeature sourceFeature,
       final Substance[] substances) throws AeriusException {
     final EmissionSource source = sourceFeature.getProperties();
-    //use a specific prefix for ID to achieve unique IDs
-    final String gmlId = GMLIdUtil.toValidGmlId(source.getGmlId(), GMLIdUtil.SOURCE_PREFIX, sourceFeature.getId());
-    source.setGmlId(gmlId);
     final nl.overheid.aerius.gml.v6_0.source.EmissionSource returnSource = sourceFeature.accept(this);
     //set the generic properties.
     returnSource.setGeometry(geometry2gml, sourceFeature.getGeometry());
-    returnSource.setId(gmlId);
+    returnSource.setId(source.getGmlId());
 
     returnSource.setLabel(source.getLabel());
     returnSource.setDescription(source.getDescription());

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/building/Building.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/building/Building.java
@@ -16,11 +16,11 @@
  */
 package nl.overheid.aerius.shared.domain.v2.building;
 
-import java.io.Serializable;
+import nl.overheid.aerius.shared.domain.v2.geojson.GmlIdProperties;
 
-public class Building implements Serializable {
+public class Building implements GmlIdProperties {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   private String gmlId;
   private String label;
@@ -33,10 +33,12 @@ public class Building implements Serializable {
    */
   private double diameter;
 
+  @Override
   public String getGmlId() {
     return gmlId;
   }
 
+  @Override
   public void setGmlId(final String gmlId) {
     this.gmlId = gmlId;
   }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/cimlk/CIMLKDispersionLine.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/cimlk/CIMLKDispersionLine.java
@@ -16,11 +16,11 @@
  */
 package nl.overheid.aerius.shared.domain.v2.cimlk;
 
-import java.io.Serializable;
+import nl.overheid.aerius.shared.domain.v2.geojson.GmlIdProperties;
 
-public class CIMLKDispersionLine implements Serializable {
+public class CIMLKDispersionLine implements GmlIdProperties {
 
-  private static final long serialVersionUID = 3L;
+  private static final long serialVersionUID = 4L;
 
   private String roadGmlId;
   private String calculationPointGmlId;
@@ -30,11 +30,29 @@ public class CIMLKDispersionLine implements Serializable {
   private CIMLKTreeProfile treeProfile;
   private String description;
 
+  /**
+   * @deprecated use {@link #getGmlId()}.
+   */
+  @Deprecated
   public String getRoadGmlId() {
+    return getGmlId();
+  }
+
+  @Override
+  public String getGmlId() {
     return roadGmlId;
   }
 
+  /**
+   * @deprecated use {@link #setGmlId(String)}.
+   */
+  @Deprecated
   public void setRoadGmlId(final String roadGmlId) {
+    setGmlId(roadGmlId);
+  }
+
+  @Override
+  public void setGmlId(final String roadGmlId) {
     this.roadGmlId = roadGmlId;
   }
 

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/cimlk/CIMLKMeasure.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/cimlk/CIMLKMeasure.java
@@ -16,15 +16,15 @@
  */
 package nl.overheid.aerius.shared.domain.v2.cimlk;
 
-import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
+import nl.overheid.aerius.shared.domain.v2.geojson.GmlIdProperties;
 import nl.overheid.aerius.shared.domain.v2.source.road.StandardVehicleMeasure;
 
-public class CIMLKMeasure implements Serializable {
+public class CIMLKMeasure implements GmlIdProperties {
 
-  private static final long serialVersionUID = 3L;
+  private static final long serialVersionUID = 4L;
 
   private String gmlId;
   private Integer jurisdictionId;
@@ -33,10 +33,12 @@ public class CIMLKMeasure implements Serializable {
 
   private List<StandardVehicleMeasure> vehicleMeasures = new ArrayList<>();
 
+  @Override
   public String getGmlId() {
     return gmlId;
   }
 
+  @Override
   public void setGmlId(final String gmlId) {
     this.gmlId = gmlId;
   }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/point/CalculationPoint.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/point/CalculationPoint.java
@@ -16,7 +16,6 @@
  */
 package nl.overheid.aerius.shared.domain.v2.point;
 
-import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -27,6 +26,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 import nl.overheid.aerius.shared.domain.result.EmissionResultKey;
+import nl.overheid.aerius.shared.domain.v2.geojson.GmlIdProperties;
 import nl.overheid.aerius.shared.domain.v2.geojson.IsFeature;
 import nl.overheid.aerius.shared.exception.AeriusException;
 
@@ -38,9 +38,9 @@ import nl.overheid.aerius.shared.exception.AeriusException;
     @Type(value = CIMLKCalculationPoint.class, name = CalculationPointType.Names.NSL_CALCULATION_POINT),
     @Type(value = SubPoint.class, name = CalculationPointType.Names.SUB_POINT)
 })
-public abstract class CalculationPoint implements Serializable {
+public abstract class CalculationPoint implements GmlIdProperties {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   private String gmlId;
   private String label;
@@ -48,10 +48,12 @@ public abstract class CalculationPoint implements Serializable {
   private Integer jurisdictionId;
   private Map<EmissionResultKey, Double> results = new HashMap<>();
 
+  @Override
   public String getGmlId() {
     return gmlId;
   }
 
+  @Override
   public void setGmlId(final String gmlId) {
     this.gmlId = gmlId;
   }

--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/EmissionSource.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/source/EmissionSource.java
@@ -16,11 +16,8 @@
  */
 package nl.overheid.aerius.shared.domain.v2.source;
 
-import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-
-import jakarta.validation.Valid;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonSubTypes.Type;
@@ -29,8 +26,11 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 
 import nl.overheid.aerius.shared.domain.Substance;
 import nl.overheid.aerius.shared.domain.v2.characteristics.SourceCharacteristics;
+import nl.overheid.aerius.shared.domain.v2.geojson.GmlIdProperties;
 import nl.overheid.aerius.shared.domain.v2.geojson.IsFeature;
 import nl.overheid.aerius.shared.exception.AeriusException;
+
+import jakarta.validation.Valid;
 
 @JsonTypeInfo(property = "emissionSourceType", use = Id.NAME)
 @JsonSubTypes({
@@ -49,9 +49,9 @@ import nl.overheid.aerius.shared.exception.AeriusException;
     @Type(value = MaritimeMaritimeShippingEmissionSource.class, name = EmissionSourceType.Names.SHIPPING_MARITIME_MARITIME),
     @Type(value = MooringMaritimeShippingEmissionSource.class, name = EmissionSourceType.Names.SHIPPING_MARITIME_DOCKED),
 })
-public abstract class EmissionSource implements Serializable {
+public abstract class EmissionSource implements GmlIdProperties {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   private String gmlId;
   private int sectorId;
@@ -61,10 +61,12 @@ public abstract class EmissionSource implements Serializable {
   private SourceCharacteristics characteristics;
   private Map<Substance, Double> emissions = new HashMap<>();
 
+  @Override
   public String getGmlId() {
     return gmlId;
   }
 
+  @Override
   public void setGmlId(final String gmlId) {
     this.gmlId = gmlId;
   }

--- a/source/imaer-shared/src/test/resources/json/CIMLKDispersionLine.json
+++ b/source/imaer-shared/src/test/resources/json/CIMLKDispersionLine.json
@@ -12,6 +12,7 @@
     "label" : "Some dispersion line",
     "roadProfile" : "ONE_SIDE_BUILDINGS",
     "treeProfile" : "SEPARATED",
-    "description" : "this is optional"
+    "description" : "this is optional",
+    "gmlId" : "ES.1"
   }
 }

--- a/source/imaer-shared/src/test/resources/json/ScenarioSituationCIMLK.json
+++ b/source/imaer-shared/src/test/resources/json/ScenarioSituationCIMLK.json
@@ -159,7 +159,8 @@
         "label" : "Some dispersion line",
         "roadProfile" : "ONE_SIDE_BUILDINGS",
         "treeProfile" : "SEPARATED",
-        "description" : "this is optional"
+        "description" : "this is optional",
+        "gmlId" : "ES.1"
       }
     } ]
   }

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/util/gml/GMLIdUtil.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/util/gml/GMLIdUtil.java
@@ -16,8 +16,12 @@
  */
 package nl.overheid.aerius.util.gml;
 
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import nl.overheid.aerius.shared.domain.v2.geojson.Feature;
+import nl.overheid.aerius.shared.domain.v2.geojson.GmlIdProperties;
 
 /**
  * Util class for working with GML ids.
@@ -36,6 +40,18 @@ public final class GMLIdUtil {
 
   private GMLIdUtil() {
     // Util class
+  }
+
+  /**
+   * Util to force a GML id on all features in the list if they don't have a GML id yet.
+   *
+   * @param features feature to set the gml id on
+   * @param prefix prefix related to the typo of feature
+   */
+  public static <T extends GmlIdProperties, F extends Feature<T, ?>> void toValidGmlIds(final List<F> features, final String prefix) {
+    for (final F feature : features) {
+      feature.getProperties().setGmlId(GMLIdUtil.toValidGmlId(feature.getProperties().getGmlId(), prefix, feature.getId()));
+    }
   }
 
   /**

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/CimlkCohesionValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/CimlkCohesionValidator.java
@@ -126,10 +126,10 @@ public class CimlkCohesionValidator {
           .toList();
       // Use a fake ID in this case to simulate the composite ID.
       importedDispersionLines.stream()
-          .map(dispersionLine -> dispersionLine.getCalculationPointGmlId() + ID_SEPARATOR + dispersionLine.getRoadGmlId())
+          .map(dispersionLine -> dispersionLine.getCalculationPointGmlId() + ID_SEPARATOR + dispersionLine.getGmlId())
           .forEach(dispersionId -> dispersionLineIds.merge(dispersionId, 1, (oldValue, value) -> oldValue + value));
       importedDispersionLines.stream()
-          .map(CIMLKDispersionLine::getRoadGmlId)
+          .map(CIMLKDispersionLine::getGmlId)
           .forEach(roadId -> dispersionLinesPerRoadId.merge(roadId, 1, (oldValue, value) -> oldValue + value));
       this.dispersionLines.addAll(importedDispersionLines);
     }
@@ -199,29 +199,29 @@ public class CimlkCohesionValidator {
     for (final CIMLKDispersionLine dispersionLineWithoutPoint : dispersionLineWithoutPoints) {
       tracker.addError(new AeriusException(ImaerExceptionReason.COHESION_REFERENCE_DISPERSION_LINE_MISSING_POINT,
           dispersionLineWithoutPoint.getCalculationPointGmlId(),
-          dispersionLineWithoutPoint.getRoadGmlId()));
+          dispersionLineWithoutPoint.getGmlId()));
     }
     final List<CIMLKDispersionLine> dispersionLineWithoutSegments = tracker.dispersionLines.stream()
-        .filter(dispersionLine -> !tracker.srm1SourceIds.contains(dispersionLine.getRoadGmlId()))
+        .filter(dispersionLine -> !tracker.srm1SourceIds.contains(dispersionLine.getGmlId()))
         .collect(Collectors.toList());
     for (final CIMLKDispersionLine dispersionLineWithoutSegment : dispersionLineWithoutSegments) {
       tracker.addError(new AeriusException(ImaerExceptionReason.COHESION_REFERENCE_DISPERSION_LINE_MISSING_ROAD,
           dispersionLineWithoutSegment.getCalculationPointGmlId(),
-          dispersionLineWithoutSegment.getRoadGmlId()));
+          dispersionLineWithoutSegment.getGmlId()));
     }
     tracker.dispersionLines.forEach(dispersionLine -> checkDispersionlinePerpendicular(dispersionLine, tracker));
   }
 
   private static void checkDispersionlinePerpendicular(final CIMLKDispersionLine dispersionLine,
       final CohesionTracker tracker) {
-    final EmissionSourceFeature sourceFeature = tracker.sources.get(dispersionLine.getRoadGmlId());
+    final EmissionSourceFeature sourceFeature = tracker.sources.get(dispersionLine.getGmlId());
     final CalculationPointFeature pointFeature = tracker.points.get(dispersionLine.getCalculationPointGmlId());
     try {
       if (sourceFeature != null && pointFeature != null && isSrm1Source(sourceFeature.getProperties())
           && !GeometryUtil.isPerpendicularAlongLine(GeometryUtil.getGeometry(sourceFeature.getGeometry()), pointFeature.getGeometry())) {
         tracker.addWarning(new AeriusException(ImaerExceptionReason.COHESION_DISPERSION_LINE_NOT_PERPENDICULAR,
             dispersionLine.getCalculationPointGmlId(),
-            dispersionLine.getRoadGmlId()));
+            dispersionLine.getGmlId()));
       }
     } catch (final AeriusException e) {
       tracker.addError(e);

--- a/source/imaer-util/src/main/java/nl/overheid/aerius/validation/SituationCohesionValidator.java
+++ b/source/imaer-util/src/main/java/nl/overheid/aerius/validation/SituationCohesionValidator.java
@@ -21,8 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.function.Function;
-import java.util.stream.Collectors;
+import java.util.Objects;
 
 import nl.overheid.aerius.shared.domain.v2.building.Building;
 import nl.overheid.aerius.shared.domain.v2.building.BuildingFeature;
@@ -41,7 +40,7 @@ import nl.overheid.aerius.shared.exception.ImaerExceptionReason;
 public final class SituationCohesionValidator {
 
   private static final class CohesionTracker {
-    private final Map<String, EmissionSourceFeature> sources = new HashMap<>();
+    private final List<EmissionSourceFeature> sources = new ArrayList<>();
 
     private final Map<String, Integer> sourceIds = new HashMap<>();
     private final Map<String, Integer> buildingIds = new HashMap<>();
@@ -63,8 +62,7 @@ public final class SituationCohesionValidator {
     }
 
     private void addSources(final List<EmissionSourceFeature> sourcesToAdd) {
-      sources.putAll(sourcesToAdd.stream()
-          .collect(Collectors.toMap(feature -> feature.getProperties().getGmlId(), Function.identity(), (oldValue, value) -> oldValue)));
+      sources.addAll(sourcesToAdd);
       sourcesToAdd.stream()
           .map(EmissionSourceFeature::getProperties)
           .map(EmissionSource::getGmlId)
@@ -136,7 +134,7 @@ public final class SituationCohesionValidator {
   }
 
   private static void checkReferencesForSources(final CohesionTracker tracker) {
-    for (final EmissionSourceFeature source : tracker.sources.values()) {
+    for (final EmissionSourceFeature source : tracker.sources) {
       if (source.getProperties() == null || source.getProperties().getCharacteristics() == null) {
         continue;
       }

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/util/gml/GMLIdUtilTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/util/gml/GMLIdUtilTest.java
@@ -18,17 +18,41 @@ package nl.overheid.aerius.util.gml;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
+
+import nl.overheid.aerius.shared.domain.v2.source.EmissionSourceFeature;
+import nl.overheid.aerius.shared.domain.v2.source.GenericEmissionSource;
 
 /**
  * Test for {@link GMLIdUtil}.
  */
-public class GMLIdUtilTest {
+class GMLIdUtilTest {
 
   private static final String TEST_PREFIX = "ABC";
 
   @Test
-  public void testToValidGmlIdWithoutBackup() {
+  void testToValidGmlIds() {
+    final EmissionSourceFeature source1 = createFeature("3", "ES.3");
+    final EmissionSourceFeature source2 = createFeature("2", null);
+    final List<EmissionSourceFeature> features = List.of(source1, source2);
+
+    GMLIdUtil.toValidGmlIds(features, GMLIdUtil.SOURCE_PREFIX);
+    assertEquals("ES.3", source1.getProperties().getGmlId(), "GML id should not be changed.");
+    assertEquals("ES.2", source2.getProperties().getGmlId(), "GML id should be set.");
+  }
+
+  private static EmissionSourceFeature createFeature(final String id, final String gmlId) {
+    final EmissionSourceFeature source = new EmissionSourceFeature();
+    source.setId(id);
+    source.setProperties(new GenericEmissionSource());
+    source.getProperties().setGmlId(gmlId);
+    return source;
+  }
+
+  @Test
+  void testToValidGmlIdWithoutBackup() {
     assertEquals(TEST_PREFIX + ".1", GMLIdUtil.toValidGmlId(null, "ABC"), "ID null");
     assertEquals(TEST_PREFIX + ".1", GMLIdUtil.toValidGmlId("", "ABC"), "ID empty");
     assertEquals(TEST_PREFIX + ".324", GMLIdUtil.toValidGmlId("324", "ABC"), "ID only numbers");
@@ -38,7 +62,7 @@ public class GMLIdUtilTest {
   }
 
   @Test
-  public void testToValidGmlIdWithBackup() {
+  void testToValidGmlIdWithBackup() {
     assertEquals(TEST_PREFIX + ".9", GMLIdUtil.toValidGmlId(null, "ABC", "9"), "ID null");
     assertEquals(TEST_PREFIX + ".9", GMLIdUtil.toValidGmlId("", "ABC", "9"), "ID empty");
     assertEquals(TEST_PREFIX + ".324", GMLIdUtil.toValidGmlId("324", "ABC", "9"), "ID only numbers");

--- a/source/imaer-util/src/test/java/nl/overheid/aerius/validation/CimlkCohesionValidatorTest.java
+++ b/source/imaer-util/src/test/java/nl/overheid/aerius/validation/CimlkCohesionValidatorTest.java
@@ -201,7 +201,7 @@ class CimlkCohesionValidatorTest {
     final ScenarioSituation situation = new ScenarioSituation();
     final CIMLKDispersionLine dispersionLine = new CIMLKDispersionLine();
     dispersionLine.setCalculationPointGmlId(DEFAULT_POINT_ID);
-    dispersionLine.setRoadGmlId(DEFAULT_ROAD_ID);
+    dispersionLine.setGmlId(DEFAULT_ROAD_ID);
     final CIMLKDispersionLineFeature dispersionLineFeature = new CIMLKDispersionLineFeature();
     dispersionLineFeature.setProperties(dispersionLine);
     situation.getCimlkDispersionLinesList().add(dispersionLineFeature);
@@ -226,7 +226,7 @@ class CimlkCohesionValidatorTest {
     final ScenarioSituation situation = new ScenarioSituation();
     final CIMLKDispersionLine dispersionLine = new CIMLKDispersionLine();
     dispersionLine.setCalculationPointGmlId(DEFAULT_POINT_ID);
-    dispersionLine.setRoadGmlId(DEFAULT_ROAD_ID);
+    dispersionLine.setGmlId(DEFAULT_ROAD_ID);
     final CIMLKDispersionLineFeature dispersionLineFeature = new CIMLKDispersionLineFeature();
     dispersionLineFeature.setProperties(dispersionLine);
     situation.getCimlkDispersionLinesList().add(dispersionLineFeature);
@@ -251,7 +251,7 @@ class CimlkCohesionValidatorTest {
     final ScenarioSituation situation = new ScenarioSituation();
     final CIMLKDispersionLine dispersionLine = new CIMLKDispersionLine();
     dispersionLine.setCalculationPointGmlId(DEFAULT_POINT_ID);
-    dispersionLine.setRoadGmlId(DEFAULT_ROAD_ID);
+    dispersionLine.setGmlId(DEFAULT_ROAD_ID);
     final CIMLKDispersionLineFeature dispersionLineFeature = new CIMLKDispersionLineFeature();
     dispersionLineFeature.setProperties(dispersionLine);
     situation.getCimlkDispersionLinesList().add(dispersionLineFeature);
@@ -276,7 +276,7 @@ class CimlkCohesionValidatorTest {
     final ScenarioSituation situation = new ScenarioSituation();
     final CIMLKDispersionLine dispersionLine = new CIMLKDispersionLine();
     dispersionLine.setCalculationPointGmlId(DEFAULT_POINT_ID);
-    dispersionLine.setRoadGmlId(DEFAULT_ROAD_ID);
+    dispersionLine.setGmlId(DEFAULT_ROAD_ID);
     final CIMLKDispersionLineFeature dispersionLineFeature = new CIMLKDispersionLineFeature();
     dispersionLineFeature.setProperties(dispersionLine);
     situation.getCimlkDispersionLinesList().add(dispersionLineFeature);
@@ -301,7 +301,7 @@ class CimlkCohesionValidatorTest {
     final ScenarioSituation situation = new ScenarioSituation();
     final CIMLKDispersionLine dispersionLine = new CIMLKDispersionLine();
     dispersionLine.setCalculationPointGmlId(DEFAULT_POINT_ID);
-    dispersionLine.setRoadGmlId(DEFAULT_ROAD_ID);
+    dispersionLine.setGmlId(DEFAULT_ROAD_ID);
     final CIMLKDispersionLineFeature dispersionLineFeature = new CIMLKDispersionLineFeature();
     dispersionLineFeature.setProperties(dispersionLine);
     situation.getCimlkDispersionLinesList().add(dispersionLineFeature);
@@ -346,13 +346,13 @@ class CimlkCohesionValidatorTest {
     final ScenarioSituation situation = new ScenarioSituation();
     final CIMLKDispersionLine dispersionLine1 = new CIMLKDispersionLine();
     dispersionLine1.setCalculationPointGmlId(DEFAULT_POINT_ID);
-    dispersionLine1.setRoadGmlId(DEFAULT_ROAD_ID);
+    dispersionLine1.setGmlId(DEFAULT_ROAD_ID);
     final CIMLKDispersionLineFeature dispersionLineFeature1 = new CIMLKDispersionLineFeature();
     dispersionLineFeature1.setProperties(dispersionLine1);
     situation.getCimlkDispersionLinesList().add(dispersionLineFeature1);
     final CIMLKDispersionLine dispersionLine2 = new CIMLKDispersionLine();
     dispersionLine2.setCalculationPointGmlId(DEFAULT_POINT_ID);
-    dispersionLine2.setRoadGmlId(DEFAULT_ROAD_ID);
+    dispersionLine2.setGmlId(DEFAULT_ROAD_ID);
     final CIMLKDispersionLineFeature dispersionLineFeature2 = new CIMLKDispersionLineFeature();
     dispersionLineFeature2.setProperties(dispersionLine2);
     situation.getCimlkDispersionLinesList().add(dispersionLineFeature2);
@@ -377,7 +377,7 @@ class CimlkCohesionValidatorTest {
     final ScenarioSituation situation1 = new ScenarioSituation();
     final CIMLKDispersionLine dispersionLine1 = new CIMLKDispersionLine();
     dispersionLine1.setCalculationPointGmlId(DEFAULT_POINT_ID);
-    dispersionLine1.setRoadGmlId(DEFAULT_ROAD_ID);
+    dispersionLine1.setGmlId(DEFAULT_ROAD_ID);
     final CIMLKDispersionLineFeature dispersionLineFeature1 = new CIMLKDispersionLineFeature();
     dispersionLineFeature1.setProperties(dispersionLine1);
     situation1.getCimlkDispersionLinesList().add(dispersionLineFeature1);
@@ -386,7 +386,7 @@ class CimlkCohesionValidatorTest {
     final ScenarioSituation situation2 = new ScenarioSituation();
     final CIMLKDispersionLine dispersionLine2 = new CIMLKDispersionLine();
     dispersionLine2.setCalculationPointGmlId(DEFAULT_POINT_ID);
-    dispersionLine2.setRoadGmlId(DEFAULT_ROAD_ID);
+    dispersionLine2.setGmlId(DEFAULT_ROAD_ID);
     final CIMLKDispersionLineFeature dispersionLineFeature2 = new CIMLKDispersionLineFeature();
     dispersionLineFeature2.setProperties(dispersionLine2);
     situation2.getCimlkDispersionLinesList().add(dispersionLineFeature2);

--- a/source/shared-geo/pom.xml
+++ b/source/shared-geo/pom.xml
@@ -17,13 +17,13 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
   <parent>
     <groupId>nl.aerius</groupId>
     <artifactId>imaer-parent</artifactId>
     <version>6.0.1-4-SNAPSHOT</version>
   </parent>
-
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>shared-geo</artifactId>
   <name>Shared :: geo utils</name>

--- a/source/shared-geo/src/main/java/nl/overheid/aerius/shared/domain/v2/geojson/Feature.java
+++ b/source/shared-geo/src/main/java/nl/overheid/aerius/shared/domain/v2/geojson/Feature.java
@@ -20,9 +20,9 @@ import java.io.Serializable;
 
 import jakarta.validation.Valid;
 
-public class Feature<T extends Serializable, G extends Geometry> implements Serializable, IsFeature {
+public class Feature<T extends GmlIdProperties, G extends Geometry> implements Serializable, IsFeature {
 
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
 
   private String type = "Feature";
   private String id;

--- a/source/shared-geo/src/main/java/nl/overheid/aerius/shared/domain/v2/geojson/GmlIdProperties.java
+++ b/source/shared-geo/src/main/java/nl/overheid/aerius/shared/domain/v2/geojson/GmlIdProperties.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.shared.domain.v2.geojson;
+
+import java.io.Serializable;
+
+/**
+ * Feature properties object that implements a gml id.
+ */
+public interface GmlIdProperties extends Serializable {
+
+  String getGmlId();
+
+  void setGmlId(final String gmlId);
+}


### PR DESCRIPTION
This is to set gml on older maritime routes migrated to newer version in which they are separate emission sources. Before they didn't get a gmlId. Theoretically this is not a problem because when writing a GML they get an gml id anyway. But to make code more consistent they also get an gml id when reading. This will also solve issue where old maritime mooring with route could be imported, but not being imported because the sources with null gml id's are registered as being duplicated. The code was also refactored to make setting gml ids more generic and moved out version specific writers.