### PR TITLE
AER-3873 - Make heat content validation more specific

### DIFF
--- a/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/OPSSourceCharacteristics.java
+++ b/source/imaer-shared/src/main/java/nl/overheid/aerius/shared/domain/v2/characteristics/OPSSourceCharacteristics.java
@@ -19,6 +19,7 @@ package nl.overheid.aerius.shared.domain.v2.characteristics;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.AssertTrue;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
@@ -96,14 +97,27 @@ public class OPSSourceCharacteristics extends SourceCharacteristics {
     this.heatContentType = heatContentType;
   }
 
-  @Min(value = OPSLimits.SOURCE_HEAT_CONTENT_MINIMUM, message = "ops heat_content > " + OPSLimits.SOURCE_HEAT_CONTENT_MINIMUM)
-  @Max(value = OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM, message = "ops heat_content < " + OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM)
   public Double getHeatContent() {
     return heatContent;
   }
 
   public void setHeatContent(final Double heatContent) {
     this.heatContent = heatContent;
+  }
+
+  @JsonIgnore
+  @AssertTrue(message = "for NOT_FORCED heat content types, ops heat_content must be present and between "
+      + OPSLimits.SOURCE_HEAT_CONTENT_MINIMUM + " and " + OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM)
+  public boolean isHeatContentValid() {
+    if (heatContentType == HeatContentType.FORCED) {
+      return true;
+    }
+    if (heatContent == null) {
+      return false;
+    }
+    final boolean withinMinimum = heatContent >= OPSLimits.SOURCE_HEAT_CONTENT_MINIMUM;
+    final boolean withinMaximum = heatContent <= OPSLimits.SOURCE_HEAT_CONTENT_MAXIMUM;
+    return withinMinimum && withinMaximum;
   }
 
   public Double getEmissionTemperature() {


### PR DESCRIPTION
This change is actually somewhat debatable; the previous implementation was simpler and arguably more robust, however strictly speaking it was too broad by also validating the heat content when the heat content type is set to FORCED (in which case heat content is not used, but the outflow values are).

The implementation in this PR makes the validation assert precisely the valid/invalid conditions, although on the surface it is slightly more complex.