### PR TITLE
Maven release github action

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Set up Java & Maven
         uses: actions/setup-java@v5

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -4,10 +4,10 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Release version (e.g. 1.2.0)'
+        description: 'Release version (e.g. 6.0.1-7)'
         required: true
       next_dev_version:
-        description: 'Next development version (e.g. 1.3.0-SNAPSHOT)'
+        description: 'Next development version (e.g. 6.0.1-8-SNAPSHOT)'
         required: true
 
 jobs:

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -1,0 +1,71 @@
+name: Maven Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release version (e.g. 1.2.0)'
+        required: true
+      next_dev_version:
+        description: 'Next development version (e.g. 1.3.0-SNAPSHOT)'
+        required: true
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Java & Maven
+        uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Configure git author
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Set release version
+        run: |
+          mvn --batch-mode versions:set \
+            -DnewVersion=${{ github.event.inputs.release_version }} \
+            -DgenerateBackupPoms=false
+
+      # At this point, all internal SNAPSHOT refs should be resolved and updated to the release version.
+      # Any remaining SNAPSHOT are genuine external dependencies that should not be a snapshot.
+      - name: Check for SNAPSHOT dependencies
+        run: |
+          mvn --batch-mode enforcer:enforce -Denforcer.rules=requireReleaseDeps
+
+      - name: Commit release version
+        run: |
+          git add -A
+          git commit -m "Release: set version to ${{ github.event.inputs.release_version }}"
+          git push origin HEAD
+
+      - name: Tag release commit
+        run: |
+          git tag -a "${{ github.event.inputs.release_version }}" \
+            -m "Release ${{ github.event.inputs.release_version }}"
+          git push origin "${{ github.event.inputs.release_version }}"
+
+      - name: Set next development version
+        run: |
+          mvn --batch-mode versions:set \
+            -DnewVersion=${{ github.event.inputs.next_dev_version }} \
+            -DgenerateBackupPoms=false
+
+      - name: Commit next development version
+        run: |
+          git add -A
+          git commit -m "Release: set next development version to ${{ github.event.inputs.next_dev_version }}"
+          git push origin HEAD

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -18,12 +18,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Set up Java & Maven
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -36,18 +36,22 @@ jobs:
 
       - name: Set release version
         run: |
-          mvn --batch-mode versions:set \
+          mvn --batch-mode --no-transfer-progress \
             -DnewVersion=${{ github.event.inputs.release_version }} \
             -DgenerateBackupPoms=false \
-            -Psonar
+            -Psonar \
+            -f source/pom.xml \
+            versions:set
 
       # At this point, all internal SNAPSHOT refs should be resolved and updated to the release version.
       # Any remaining SNAPSHOT are genuine external dependencies that should not be a snapshot.
       - name: Check for SNAPSHOT dependencies
         run: |
-          mvn --batch-mode enforcer:enforce \
+          mvn --batch-mode --no-transfer-progress \
           -Denforcer.rules=requireReleaseDeps \
-          -Psonar
+          -Psonar \
+          -f source/pom.xml \
+           enforcer:enforce
 
       - name: Commit release version
         run: |
@@ -55,18 +59,22 @@ jobs:
           git commit -m "Release: set version to ${{ github.event.inputs.release_version }}"
           git push origin HEAD
 
-      - name: Tag release commit
+      - name: Create release in github, tagging the commit.
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
         run: |
-          git tag -a "${{ github.event.inputs.release_version }}" \
-            -m "Release ${{ github.event.inputs.release_version }}"
-          git push origin "${{ github.event.inputs.release_version }}"
+          gh release create ${{ github.event.inputs.release_version }} \
+            -t "Release ${{ github.event.inputs.release_version }}" \
+            --generate-notes
 
       - name: Set next development version
         run: |
-          mvn --batch-mode versions:set \
+          mvn --batch-mode --no-transfer-progress \
             -DnewVersion=${{ github.event.inputs.next_dev_version }} \
             -DgenerateBackupPoms=false \
-            -Psonar
+            -Psonar \
+            -f source/pom.xml \
+            versions:set
 
       - name: Commit next development version
         run: |

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -38,13 +38,16 @@ jobs:
         run: |
           mvn --batch-mode versions:set \
             -DnewVersion=${{ github.event.inputs.release_version }} \
-            -DgenerateBackupPoms=false
+            -DgenerateBackupPoms=false \
+            -Psonar
 
       # At this point, all internal SNAPSHOT refs should be resolved and updated to the release version.
       # Any remaining SNAPSHOT are genuine external dependencies that should not be a snapshot.
       - name: Check for SNAPSHOT dependencies
         run: |
-          mvn --batch-mode enforcer:enforce -Denforcer.rules=requireReleaseDeps
+          mvn --batch-mode enforcer:enforce \
+          -Denforcer.rules=requireReleaseDeps \
+          -Psonar
 
       - name: Commit release version
         run: |
@@ -62,7 +65,8 @@ jobs:
         run: |
           mvn --batch-mode versions:set \
             -DnewVersion=${{ github.event.inputs.next_dev_version }} \
-            -DgenerateBackupPoms=false
+            -DgenerateBackupPoms=false \
+            -Psonar
 
       - name: Commit next development version
         run: |

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -31,8 +31,8 @@ jobs:
 
       - name: Configure git author
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com"
 
       - name: Set release version
         run: |

--- a/source/pom.xml
+++ b/source/pom.xml
@@ -125,6 +125,26 @@
           </execution>
         </executions>
       </plugin>
+      
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-no-snapshot-deps</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireReleaseDeps>
+                  <onlyWhenRelease>true</onlyWhenRelease>
+                </requireReleaseDeps>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
 
   </build>


### PR DESCRIPTION
In an attempt to automate releases a bit more, reckon that for our public repositories we might as well use a github action.

Could move part of this to our github-actions repo as well, but perhaps first lets check if it actually works the way we want?

Testing it might be a bit tricky. Currently there is no snapshot dependency, so it should just work, but would want to check that it does actually stop when there is such a dependency, for instance if the root pom used is on snapshot.