### PR TITLE
AER-3162 - Group XSD validation errors by source location

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
@@ -172,10 +172,6 @@ public final class GMLReaderFactory {
   }
 
   private static List<AeriusException> newValidationFailed(final List<ValidationEvent> list) {
-    // Group events that share a source location (line + column), discard the ones whose
-    // information is already covered by a higher-severity event at the same location, then
-    // combine the survivors into one message per location. Each combined message is prefixed
-    // with [line N, col M] so users can find the offending value.
     final Map<LocationKey, List<ValidationEvent>> grouped = new LinkedHashMap<>();
     for (final ValidationEvent event : list) {
       grouped.computeIfAbsent(LocationKey.of(event.getLocator()), k -> new ArrayList<>()).add(event);
@@ -194,25 +190,7 @@ public final class GMLReaderFactory {
     return errors;
   }
 
-  /**
-   * Drops events at a single source location whose severity is below the maximum present in the
-   * group. <strong>This is a deliberate, lossy step</strong>: the dropped events are not surfaced
-   * to the user.
-   *
-   * <p>What gets dropped, concretely: when JAXB fails to parse a primitive value (e.g. {@code
-   * "None"} where a {@code double} is expected), the validator reports it twice for the same
-   * location:
-   * <ul>
-   *   <li>a severity-1 ({@code ERROR}) event whose message is just the offending value, e.g.
-   *       {@code "None"}, originating from the wrapped {@code NumberFormatException};</li>
-   *   <li>one or more severity-2 ({@code FATAL_ERROR}) {@code cvc-*} events from the XSD
-   *       validator, e.g. {@code "cvc-datatype-valid.1.2.1: 'None' is not a valid value for
-   *       'double'."} and {@code "cvc-type.3.1.3: The value 'None' of element 'imaer:foo' is not
-   *       valid."}.</li>
-   * </ul>
-   * The lower-severity message conveys nothing the higher-severity ones don't already say
-   * (offending value, element, expected type), so dropping it removes only redundant noise.
-   */
+  /** Lossy: drops events below the group's max severity (e.g. JAXB's bare "None" when a cvc-* FATAL covers it). */
   private static List<ValidationEvent> discardRedundantLowerSeverityEvents(final List<ValidationEvent> sameLocation) {
     final int maxSeverity = sameLocation.stream().mapToInt(ValidationEvent::getSeverity).max().orElse(0);
     return sameLocation.stream()

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
@@ -20,6 +20,7 @@ import java.io.InputStream;
 import java.io.UTFDataFormatException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -173,17 +174,19 @@ public final class GMLReaderFactory {
 
   private static List<AeriusException> newValidationFailed(final List<ValidationEvent> list) {
     final Map<String, List<ValidationEvent>> grouped = new LinkedHashMap<>();
+    final Map<String, String> prefixByKey = new HashMap<>();
     for (final ValidationEvent event : list) {
-      grouped.computeIfAbsent(locationKey(event.getLocator()), k -> new ArrayList<>()).add(event);
+      final String key = locationKey(event.getLocator());
+      grouped.computeIfAbsent(key, k -> new ArrayList<>()).add(event);
+      prefixByKey.computeIfAbsent(key, k -> locationPrefix(event.getLocator()));
     }
 
     final List<AeriusException> errors = new ArrayList<>();
-    for (final List<ValidationEvent> group : grouped.values()) {
-      final List<ValidationEvent> kept = discardRedundantLowerSeverityEvents(group);
-      final String body = kept.stream()
+    for (final Map.Entry<String, List<ValidationEvent>> entry : grouped.entrySet()) {
+      final String body = discardRedundantLowerSeverityEvents(entry.getValue()).stream()
           .map(e -> e.getMessage().trim())
           .collect(Collectors.joining(" "));
-      final String message = locationPrefix(kept.get(0).getLocator()) + body;
+      final String message = prefixByKey.get(entry.getKey()) + body;
       errors.add(new AeriusException(ImaerExceptionReason.GML_VALIDATION_FAILED, message));
       LOG.debug("validation error: {}", message);
     }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
@@ -204,13 +204,16 @@ public final class GMLReaderFactory {
     }
 
     String prefix() {
-      if (line < 0 && column < 0) {
-        return "";
-      }
       if (line >= 0 && column >= 0) {
-        return "[line " + line + ", col " + column + "] ";
+        return "[line %d, col %d] ".formatted(line, column);
       }
-      return line >= 0 ? "[line " + line + "] " : "[col " + column + "] ";
+      if (line >= 0) {
+        return "[line %d] ".formatted(line);
+      }
+      if (column >= 0) {
+        return "[col %d] ".formatted(column);
+      }
+      return "";
     }
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
@@ -20,17 +20,22 @@ import java.io.InputStream;
 import java.io.UTFDataFormatException;
 import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 
 import jakarta.xml.bind.JAXBContext;
 import jakarta.xml.bind.JAXBException;
 import jakarta.xml.bind.Unmarshaller;
 import jakarta.xml.bind.ValidationEvent;
-import javax.xml.stream.XMLInputFactory;
-import javax.xml.stream.XMLStreamException;
-import javax.xml.stream.XMLStreamReader;
+import jakarta.xml.bind.ValidationEventLocator;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -167,13 +172,44 @@ public final class GMLReaderFactory {
   }
 
   private static List<AeriusException> newValidationFailed(final List<ValidationEvent> list) {
-    final List<AeriusException> errors = new ArrayList<>();
+    // Group events that share a source location (line + column). Within each group keep only the
+    // events at the highest severity and combine their messages, so a single bad value (e.g. a
+    // type mismatch surfacing as separate datatype + element validation events at the same spot)
+    // produces one error instead of several. Prefix the combined message with the location so the
+    // user can find it in the file.
+    final Map<LocationKey, List<ValidationEvent>> grouped = new LinkedHashMap<>();
     for (final ValidationEvent event : list) {
-      final String errorMessage = event.getMessage().trim();
-      final AeriusException error = new AeriusException(ImaerExceptionReason.GML_VALIDATION_FAILED, errorMessage);
-      errors.add(error);
-      LOG.debug("validation error: {}", errorMessage);
+      grouped.computeIfAbsent(LocationKey.of(event.getLocator()), k -> new ArrayList<>()).add(event);
+    }
+
+    final List<AeriusException> errors = new ArrayList<>();
+    for (final Map.Entry<LocationKey, List<ValidationEvent>> entry : grouped.entrySet()) {
+      final List<ValidationEvent> group = entry.getValue();
+      final int maxSeverity = group.stream().mapToInt(ValidationEvent::getSeverity).max().orElse(0);
+      final String body = group.stream()
+          .filter(e -> e.getSeverity() == maxSeverity)
+          .map(e -> e.getMessage().trim())
+          .collect(Collectors.joining(" "));
+      final String message = entry.getKey().prefix() + body;
+      errors.add(new AeriusException(ImaerExceptionReason.GML_VALIDATION_FAILED, message));
+      LOG.debug("validation error: {}", message);
     }
     return errors;
+  }
+
+  private record LocationKey(int line, int column) {
+    static LocationKey of(final ValidationEventLocator locator) {
+      return locator == null ? new LocationKey(-1, -1) : new LocationKey(locator.getLineNumber(), locator.getColumnNumber());
+    }
+
+    String prefix() {
+      if (line < 0 && column < 0) {
+        return "";
+      }
+      if (line >= 0 && column >= 0) {
+        return "[line " + line + ", col " + column + "] ";
+      }
+      return line >= 0 ? "[line " + line + "] " : "[col " + column + "] ";
+    }
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
@@ -172,18 +172,18 @@ public final class GMLReaderFactory {
   }
 
   private static List<AeriusException> newValidationFailed(final List<ValidationEvent> list) {
-    final Map<LocationKey, List<ValidationEvent>> grouped = new LinkedHashMap<>();
+    final Map<String, List<ValidationEvent>> grouped = new LinkedHashMap<>();
     for (final ValidationEvent event : list) {
-      grouped.computeIfAbsent(LocationKey.of(event.getLocator()), k -> new ArrayList<>()).add(event);
+      grouped.computeIfAbsent(locationKey(event.getLocator()), k -> new ArrayList<>()).add(event);
     }
 
     final List<AeriusException> errors = new ArrayList<>();
-    for (final Map.Entry<LocationKey, List<ValidationEvent>> entry : grouped.entrySet()) {
-      final List<ValidationEvent> kept = discardRedundantLowerSeverityEvents(entry.getValue());
+    for (final List<ValidationEvent> group : grouped.values()) {
+      final List<ValidationEvent> kept = discardRedundantLowerSeverityEvents(group);
       final String body = kept.stream()
           .map(e -> e.getMessage().trim())
           .collect(Collectors.joining(" "));
-      final String message = entry.getKey().prefix() + body;
+      final String message = locationPrefix(kept.get(0).getLocator()) + body;
       errors.add(new AeriusException(ImaerExceptionReason.GML_VALIDATION_FAILED, message));
       LOG.debug("validation error: {}", message);
     }
@@ -198,22 +198,28 @@ public final class GMLReaderFactory {
         .toList();
   }
 
-  private record LocationKey(int line, int column) {
-    static LocationKey of(final ValidationEventLocator locator) {
-      return locator == null ? new LocationKey(-1, -1) : new LocationKey(locator.getLineNumber(), locator.getColumnNumber());
+  private static String locationKey(final ValidationEventLocator locator) {
+    if (locator == null) {
+      return "-1:-1";
     }
+    return locator.getLineNumber() + ":" + locator.getColumnNumber();
+  }
 
-    String prefix() {
-      if (line >= 0 && column >= 0) {
-        return "[line %d, col %d] ".formatted(line, column);
-      }
-      if (line >= 0) {
-        return "[line %d] ".formatted(line);
-      }
-      if (column >= 0) {
-        return "[col %d] ".formatted(column);
-      }
+  private static String locationPrefix(final ValidationEventLocator locator) {
+    if (locator == null) {
       return "";
     }
+    final int line = locator.getLineNumber();
+    final int col = locator.getColumnNumber();
+    if (line >= 0 && col >= 0) {
+      return "[line %d, col %d] ".formatted(line, col);
+    }
+    if (line >= 0) {
+      return "[line %d] ".formatted(line);
+    }
+    if (col >= 0) {
+      return "[col %d] ".formatted(col);
+    }
+    return "";
   }
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
@@ -172,11 +172,10 @@ public final class GMLReaderFactory {
   }
 
   private static List<AeriusException> newValidationFailed(final List<ValidationEvent> list) {
-    // Group events that share a source location (line + column) and combine their messages, so a
-    // single bad value (e.g. a type mismatch surfacing as separate datatype + element validation
-    // events at the same spot) produces one error instead of several. Every event's message is
-    // preserved in document order - no events are dropped, so no information is lost. Each
-    // combined message is prefixed with [line N, col M] so users can find the offending value.
+    // Group events that share a source location (line + column), discard the ones whose
+    // information is already covered by a higher-severity event at the same location, then
+    // combine the survivors into one message per location. Each combined message is prefixed
+    // with [line N, col M] so users can find the offending value.
     final Map<LocationKey, List<ValidationEvent>> grouped = new LinkedHashMap<>();
     for (final ValidationEvent event : list) {
       grouped.computeIfAbsent(LocationKey.of(event.getLocator()), k -> new ArrayList<>()).add(event);
@@ -184,7 +183,8 @@ public final class GMLReaderFactory {
 
     final List<AeriusException> errors = new ArrayList<>();
     for (final Map.Entry<LocationKey, List<ValidationEvent>> entry : grouped.entrySet()) {
-      final String body = entry.getValue().stream()
+      final List<ValidationEvent> kept = discardRedundantLowerSeverityEvents(entry.getValue());
+      final String body = kept.stream()
           .map(e -> e.getMessage().trim())
           .collect(Collectors.joining(" "));
       final String message = entry.getKey().prefix() + body;
@@ -192,6 +192,32 @@ public final class GMLReaderFactory {
       LOG.debug("validation error: {}", message);
     }
     return errors;
+  }
+
+  /**
+   * Drops events at a single source location whose severity is below the maximum present in the
+   * group. <strong>This is a deliberate, lossy step</strong>: the dropped events are not surfaced
+   * to the user.
+   *
+   * <p>What gets dropped, concretely: when JAXB fails to parse a primitive value (e.g. {@code
+   * "None"} where a {@code double} is expected), the validator reports it twice for the same
+   * location:
+   * <ul>
+   *   <li>a severity-1 ({@code ERROR}) event whose message is just the offending value, e.g.
+   *       {@code "None"}, originating from the wrapped {@code NumberFormatException};</li>
+   *   <li>one or more severity-2 ({@code FATAL_ERROR}) {@code cvc-*} events from the XSD
+   *       validator, e.g. {@code "cvc-datatype-valid.1.2.1: 'None' is not a valid value for
+   *       'double'."} and {@code "cvc-type.3.1.3: The value 'None' of element 'imaer:foo' is not
+   *       valid."}.</li>
+   * </ul>
+   * The lower-severity message conveys nothing the higher-severity ones don't already say
+   * (offending value, element, expected type), so dropping it removes only redundant noise.
+   */
+  private static List<ValidationEvent> discardRedundantLowerSeverityEvents(final List<ValidationEvent> sameLocation) {
+    final int maxSeverity = sameLocation.stream().mapToInt(ValidationEvent::getSeverity).max().orElse(0);
+    return sameLocation.stream()
+        .filter(e -> e.getSeverity() == maxSeverity)
+        .toList();
   }
 
   private record LocationKey(int line, int column) {

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/GMLReaderFactory.java
@@ -172,11 +172,11 @@ public final class GMLReaderFactory {
   }
 
   private static List<AeriusException> newValidationFailed(final List<ValidationEvent> list) {
-    // Group events that share a source location (line + column). Within each group keep only the
-    // events at the highest severity and combine their messages, so a single bad value (e.g. a
-    // type mismatch surfacing as separate datatype + element validation events at the same spot)
-    // produces one error instead of several. Prefix the combined message with the location so the
-    // user can find it in the file.
+    // Group events that share a source location (line + column) and combine their messages, so a
+    // single bad value (e.g. a type mismatch surfacing as separate datatype + element validation
+    // events at the same spot) produces one error instead of several. Every event's message is
+    // preserved in document order - no events are dropped, so no information is lost. Each
+    // combined message is prefixed with [line N, col M] so users can find the offending value.
     final Map<LocationKey, List<ValidationEvent>> grouped = new LinkedHashMap<>();
     for (final ValidationEvent event : list) {
       grouped.computeIfAbsent(LocationKey.of(event.getLocator()), k -> new ArrayList<>()).add(event);
@@ -184,10 +184,7 @@ public final class GMLReaderFactory {
 
     final List<AeriusException> errors = new ArrayList<>();
     for (final Map.Entry<LocationKey, List<ValidationEvent>> entry : grouped.entrySet()) {
-      final List<ValidationEvent> group = entry.getValue();
-      final int maxSeverity = group.stream().mapToInt(ValidationEvent::getSeverity).max().orElse(0);
-      final String body = group.stream()
-          .filter(e -> e.getSeverity() == maxSeverity)
+      final String body = entry.getValue().stream()
           .map(e -> e.getMessage().trim())
           .collect(Collectors.joining(" "));
       final String message = entry.getKey().prefix() + body;

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateErrorsTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateErrorsTest.java
@@ -92,14 +92,22 @@ class GMLValidateErrorsTest {
 
   @Test
   void testGMLMultipleErrors() throws IOException, AeriusException {
+    // Events sharing a source location are grouped; within each group only the highest-severity
+    // events are reported (combined into one message), prefixed with [line N, col M] so the user
+    // can locate the offending value. The vehiclesPerTimeUnit/timeUnit groups each have a
+    // NumberFormatException event at ERROR severity that is dropped in favour of the FATAL_ERROR
+    // XSD events at the same location.
     final List<String> expectedErrors = List.of(
-        "None",
-        "cvc-datatype-valid.1.2.1: 'None' is not a valid value for 'double'.",
-        "cvc-type.3.1.3: The value 'None' of element 'imaer:vehiclesPerTimeUnit' is not valid.",
-        "cvc-enumeration-valid: Value 'None' is not facet-valid with respect to enumeration '[HOUR, DAY, MONTH, YEAR]'. It must be a value from the enumeration.",
-        "cvc-type.3.1.3: The value 'None' of element 'imaer:timeUnit' is not valid.",
-        "cvc-complex-type.2.4.b: The content of element 'imaer:CustomVehicle' is not complete. One of '{\"http://imaer.aerius.nl/5.1\":emission}' is expected.",
-        "cvc-complex-type.2.4.a: Invalid content was found starting with element '{\"http://imaer.aerius.nl/5.1\":diurnalVariation}'. One of '{\"http://imaer.aerius.nl/5.1\":vehicles, \"http://imaer.aerius.nl/5.1\":roadManager, \"http://imaer.aerius.nl/5.1\":trafficDirection, \"http://imaer.aerius.nl/5.1\":width}' is expected.");
+        "[line 33, col 80] cvc-datatype-valid.1.2.1: 'None' is not a valid value for 'double'."
+            + " cvc-type.3.1.3: The value 'None' of element 'imaer:vehiclesPerTimeUnit' is not valid.",
+        "[line 34, col 58] cvc-enumeration-valid: Value 'None' is not facet-valid with respect to enumeration '[HOUR, DAY, MONTH, YEAR]'."
+            + " It must be a value from the enumeration."
+            + " cvc-type.3.1.3: The value 'None' of element 'imaer:timeUnit' is not valid.",
+        "[line 36, col 39] cvc-complex-type.2.4.b: The content of element 'imaer:CustomVehicle' is not complete."
+            + " One of '{\"http://imaer.aerius.nl/5.1\":emission}' is expected.",
+        "[line 38, col 37] cvc-complex-type.2.4.a: Invalid content was found starting with element '{\"http://imaer.aerius.nl/5.1\":diurnalVariation}'."
+            + " One of '{\"http://imaer.aerius.nl/5.1\":vehicles, \"http://imaer.aerius.nl/5.1\":roadManager,"
+            + " \"http://imaer.aerius.nl/5.1\":trafficDirection, \"http://imaer.aerius.nl/5.1\":width}' is expected.");
     assertResults("fout_multiple_errors", expectedErrors, ImaerExceptionReason.GML_VALIDATION_FAILED);
   }
 

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateErrorsTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateErrorsTest.java
@@ -92,13 +92,13 @@ class GMLValidateErrorsTest {
 
   @Test
   void testGMLMultipleErrors() throws IOException, AeriusException {
-    // Events sharing a source location are grouped and joined into one message in document
-    // order, prefixed with [line N, col M] so the user can locate the offending value. No events
-    // are dropped. The first group includes the bare "None" from JAXB's NumberFormatException
-    // alongside the two FATAL_ERROR XSD events at the same location.
+    // Events sharing a source location are grouped; within each group lower-severity events are
+    // dropped (see discardRedundantLowerSeverityEvents) and the survivors are joined into one
+    // message, prefixed with [line N, col M]. The vehiclesPerTimeUnit group's bare "None" from
+    // JAXB's NumberFormatException is dropped in favour of the FATAL_ERROR XSD events at the
+    // same location.
     final List<String> expectedErrors = List.of(
-        "[line 33, col 80] None"
-            + " cvc-datatype-valid.1.2.1: 'None' is not a valid value for 'double'."
+        "[line 33, col 80] cvc-datatype-valid.1.2.1: 'None' is not a valid value for 'double'."
             + " cvc-type.3.1.3: The value 'None' of element 'imaer:vehiclesPerTimeUnit' is not valid.",
         "[line 34, col 58] cvc-enumeration-valid: Value 'None' is not facet-valid with respect to enumeration '[HOUR, DAY, MONTH, YEAR]'."
             + " It must be a value from the enumeration."

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateErrorsTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateErrorsTest.java
@@ -92,13 +92,13 @@ class GMLValidateErrorsTest {
 
   @Test
   void testGMLMultipleErrors() throws IOException, AeriusException {
-    // Events sharing a source location are grouped; within each group only the highest-severity
-    // events are reported (combined into one message), prefixed with [line N, col M] so the user
-    // can locate the offending value. The vehiclesPerTimeUnit/timeUnit groups each have a
-    // NumberFormatException event at ERROR severity that is dropped in favour of the FATAL_ERROR
-    // XSD events at the same location.
+    // Events sharing a source location are grouped and joined into one message in document
+    // order, prefixed with [line N, col M] so the user can locate the offending value. No events
+    // are dropped. The first group includes the bare "None" from JAXB's NumberFormatException
+    // alongside the two FATAL_ERROR XSD events at the same location.
     final List<String> expectedErrors = List.of(
-        "[line 33, col 80] cvc-datatype-valid.1.2.1: 'None' is not a valid value for 'double'."
+        "[line 33, col 80] None"
+            + " cvc-datatype-valid.1.2.1: 'None' is not a valid value for 'double'."
             + " cvc-type.3.1.3: The value 'None' of element 'imaer:vehiclesPerTimeUnit' is not valid.",
         "[line 34, col 58] cvc-enumeration-valid: Value 'None' is not facet-valid with respect to enumeration '[HOUR, DAY, MONTH, YEAR]'."
             + " It must be a value from the enumeration."

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateErrorsTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/GMLValidateErrorsTest.java
@@ -92,11 +92,6 @@ class GMLValidateErrorsTest {
 
   @Test
   void testGMLMultipleErrors() throws IOException, AeriusException {
-    // Events sharing a source location are grouped; within each group lower-severity events are
-    // dropped (see discardRedundantLowerSeverityEvents) and the survivors are joined into one
-    // message, prefixed with [line N, col M]. The vehiclesPerTimeUnit group's bare "None" from
-    // JAXB's NumberFormatException is dropped in favour of the FATAL_ERROR XSD events at the
-    // same location.
     final List<String> expectedErrors = List.of(
         "[line 33, col 80] cvc-datatype-valid.1.2.1: 'None' is not a valid value for 'double'."
             + " cvc-type.3.1.3: The value 'None' of element 'imaer:vehiclesPerTimeUnit' is not valid.",


### PR DESCRIPTION
Validation events from JAXB are now grouped by their (line, column) locator so a single bad value no longer produces multiple separate errors.

Within each group only the highest-severity events are kept and their messages combined. Each combined message is prefixed with [line N, col M] so users can locate the offending value in larger GML files.