### PR TITLE
AER-4271 When importing Non Urban Road with multiple vehicles to check if can be combined check on converted maximumspeed

### DIFF
--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/GML2Road.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/GML2Road.java
@@ -92,16 +92,23 @@ abstract class GML2Road<T extends IsGmlRoadEmissionSource, S extends RoadEmissio
       final StandardVehicles vse = new StandardVehicles();
 
       vse.setMaximumSpeed(getMaximumSpeed(gmlRoadTypeCode, sv.getMaximumSpeed()));
-      vse.setStrictEnforcement(sv.isStrictEnforcement());
       vse.setTimeUnit(TimeUnit.valueOf(sv.getTimeUnit().name()));
       mergingStandardVehicles.add(vse);
       addToVehicles.add(vse);
       return vse;
     });
-    final ValuesPerVehicleType valuesPerVehicleType = new ValuesPerVehicleType();
-    valuesPerVehicleType.setStagnationFraction(sv.getStagnationFactor());
-    valuesPerVehicleType.setVehiclesPerTimeUnit(sv.getVehiclesPerTimeUnit());
-    standardVehicle.getValuesPerVehicleTypes().put(sv.getVehicleType(), valuesPerVehicleType);
+
+    if (sv.isStrictEnforcement() != null) {
+      // Set strict enforcement to handle case were both null and false strict enforcement would be present, in which case false should be set.
+      standardVehicle.setStrictEnforcement(sv.isStrictEnforcement());
+    }
+    final ValuesPerVehicleType vpvt = standardVehicle.getValuesPerVehicleTypes().computeIfAbsent(sv.getVehicleType(), t -> {
+      final ValuesPerVehicleType valuesPerVehicleType = new ValuesPerVehicleType();
+
+      valuesPerVehicleType.setStagnationFraction(sv.getStagnationFactor());
+      return valuesPerVehicleType;
+    });
+    vpvt.setVehiclesPerTimeUnit(sv.getVehiclesPerTimeUnit() + vpvt.getVehiclesPerTimeUnit());
   }
 
   /**
@@ -128,10 +135,9 @@ abstract class GML2Road<T extends IsGmlRoadEmissionSource, S extends RoadEmissio
       final String gmlRoadTypeCode) {
     return mergingStandardVehicles.stream()
         .filter(x -> Objects.equals(x.getMaximumSpeed(), getMaximumSpeed(gmlRoadTypeCode, sv.getMaximumSpeed())))
-        .filter(x -> Objects.equals(x.getStrictEnforcement(), sv.isStrictEnforcement()))
+        .filter(x -> Boolean.TRUE.equals(x.getStrictEnforcement()) == Boolean.TRUE.equals((sv.isStrictEnforcement())))
         .filter(x -> x.getTimeUnit() == TimeUnit.valueOf(sv.getTimeUnit().name()))
         .filter(x -> !x.getValuesPerVehicleTypes().containsKey(sv.getVehicleType()))
         .findFirst();
   }
-
 }

--- a/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/GML2Road.java
+++ b/source/imaer-gml/src/main/java/nl/overheid/aerius/gml/base/source/road/GML2Road.java
@@ -78,9 +78,9 @@ abstract class GML2Road<T extends IsGmlRoadEmissionSource, S extends RoadEmissio
 
     switch (av) {
       case final IsGmlStandardVehicle standardVehicle ->
-      addEmissionValues(gmlRoadTypeCode, addToVehicles, source, standardVehicle, mergingStandardVehicles);
+        addEmissionValues(gmlRoadTypeCode, addToVehicles, source, standardVehicle, mergingStandardVehicles);
       case final IsGmlSpecificVehicle specificVehicle ->
-      addToVehicles.add(GML2VehicleUtil.convertEmissionValuesSpecific(source, specificVehicle, getConversionData()));
+        addToVehicles.add(GML2VehicleUtil.convertEmissionValuesSpecific(source, specificVehicle, getConversionData()));
       case final IsGmlCustomVehicle customVehicle -> addToVehicles.add(GML2VehicleUtil.convertEmissionValuesCustom(customVehicle));
       default -> throw new IllegalArgumentException("Instance not supported:" + av.getClass().getCanonicalName());
     }
@@ -88,7 +88,7 @@ abstract class GML2Road<T extends IsGmlRoadEmissionSource, S extends RoadEmissio
 
   private void addEmissionValues(final String gmlRoadTypeCode, final List<Vehicles> addToVehicles, final T source, final IsGmlStandardVehicle sv,
       final List<StandardVehicles> mergingStandardVehicles) {
-    final StandardVehicles standardVehicle = findExistingMatch(sv, mergingStandardVehicles).orElseGet(() -> {
+    final StandardVehicles standardVehicle = findExistingMatch(sv, mergingStandardVehicles, gmlRoadTypeCode).orElseGet(() -> {
       final StandardVehicles vse = new StandardVehicles();
 
       vse.setMaximumSpeed(getMaximumSpeed(gmlRoadTypeCode, sv.getMaximumSpeed()));
@@ -124,9 +124,10 @@ abstract class GML2Road<T extends IsGmlRoadEmissionSource, S extends RoadEmissio
     };
   }
 
-  private Optional<StandardVehicles> findExistingMatch(final IsGmlStandardVehicle sv, final List<StandardVehicles> mergingStandardVehicles) {
+  private Optional<StandardVehicles> findExistingMatch(final IsGmlStandardVehicle sv, final List<StandardVehicles> mergingStandardVehicles,
+      final String gmlRoadTypeCode) {
     return mergingStandardVehicles.stream()
-        .filter(x -> Objects.equals(x.getMaximumSpeed(), sv.getMaximumSpeed()))
+        .filter(x -> Objects.equals(x.getMaximumSpeed(), getMaximumSpeed(gmlRoadTypeCode, sv.getMaximumSpeed())))
         .filter(x -> Objects.equals(x.getStrictEnforcement(), sv.isStrictEnforcement()))
         .filter(x -> x.getTimeUnit() == TimeUnit.valueOf(sv.getTimeUnit().name()))
         .filter(x -> !x.getValuesPerVehicleTypes().containsKey(sv.getVehicleType()))

--- a/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/base/source/road/GML2RoadTest.java
+++ b/source/imaer-gml/src/test/java/nl/overheid/aerius/gml/base/source/road/GML2RoadTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright the State of the Netherlands
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU Affero General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see http://www.gnu.org/licenses/.
+ */
+package nl.overheid.aerius.gml.base.source.road;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import nl.overheid.aerius.gml.base.GMLConversionData;
+import nl.overheid.aerius.gml.v6_0.source.TimeUnit;
+import nl.overheid.aerius.gml.v6_0.source.road.SRM2Road;
+import nl.overheid.aerius.gml.v6_0.source.road.StandardVehicle;
+import nl.overheid.aerius.gml.v6_0.source.road.VehiclesProperty;
+import nl.overheid.aerius.shared.domain.v2.source.SRM2RoadEmissionSource;
+import nl.overheid.aerius.shared.exception.AeriusException;
+
+/**
+ * Unit test to test merging of standardVehicle sub sources.
+ */
+@ExtendWith(MockitoExtension.class)
+class GML2RoadTest {
+
+  private @Mock GMLConversionData conversionData;
+
+  /**
+   * Test merging sub sources. vehicle types with the same configuration can be joined into a single sub source.
+   */
+  @ParameterizedTest
+  @CsvSource({"NON_URBAN_ROAD_NATIONAL", "Other"})
+  void testStandardVehicleMerge(final String roadTypeCode) throws AeriusException {
+    final SRM2Road gmlRoad = new SRM2Road();
+    gmlRoad.setRoadTypeCode(roadTypeCode);
+    gmlRoad.getVehicles().addAll(generateAllCombinations());
+
+    final SRM2RoadEmissionSource converted = new GML2SRM2Road<>(conversionData).convert(gmlRoad);
+    assertEquals(24, converted.getSubSources().size(), "Merging sub sources did not give the expected number of sub sources ");
+  }
+
+  private static List<VehiclesProperty> generateAllCombinations() {
+    final TimeUnit[] timeUnits = {TimeUnit.DAY, TimeUnit.YEAR};
+    final Boolean[] strictEnforcements = {null, false, true};
+    final Integer[] maxSpeeds = {null, 0, 80, 100};
+    final String[] vehicleTypes = {"A", "B"};
+    final List<VehiclesProperty> subSources = new ArrayList<>();
+
+    for (final TimeUnit second : timeUnits) {
+      for (final Boolean third : strictEnforcements) {
+        for (final Integer fourth : maxSpeeds) {
+          for (final String first : vehicleTypes) {
+            subSources.add(createStandardVehicle(first, second, third, fourth));
+          }
+        }
+      }
+    }
+    return subSources;
+  }
+
+  private static VehiclesProperty createStandardVehicle(final String vehicleType, final TimeUnit timeUnit, final Boolean strictEnforcement,
+      final Integer maxSpeed) {
+    final StandardVehicle vehicle = new StandardVehicle();
+
+    vehicle.setVehicleType(vehicleType);
+    vehicle.setTimeUnit(timeUnit);
+    vehicle.setStrictEnforcement(strictEnforcement);
+    vehicle.setMaximumSpeed(maxSpeed);
+    vehicle.setVehiclesPerTimeUnit(10);
+    vehicle.setStagnationFactor(20);
+    return new VehiclesProperty(vehicle);
+  }
+}

--- a/source/imaer-gml/src/test/resources/gml/v0_5/roundtrip/road_non_urban.gml
+++ b/source/imaer-gml/src/test/resources/gml/v0_5/roundtrip/road_non_urban.gml
@@ -53,6 +53,12 @@
                 </imaer:Emission>
             </imaer:emission>
             <imaer:vehicles>
+                <imaer:StandardVehicle vehicleType="HEAVY_FREIGHT">
+                    <imaer:vehiclesPerDay>5000.0</imaer:vehiclesPerDay>
+                    <imaer:stagnationFactor>0.2</imaer:stagnationFactor>
+                </imaer:StandardVehicle>
+            </imaer:vehicles>
+            <imaer:vehicles>
                 <imaer:StandardVehicle vehicleType="LIGHT_TRAFFIC">
                     <imaer:vehiclesPerDay>15000.0</imaer:vehiclesPerDay>
                     <imaer:stagnationFactor>0.1</imaer:stagnationFactor>

--- a/source/imaer-gml/src/test/resources/gml/v1_0/roundtrip/road_non_urban.gml
+++ b/source/imaer-gml/src/test/resources/gml/v1_0/roundtrip/road_non_urban.gml
@@ -53,6 +53,12 @@
                 </imaer:Emission>
             </imaer:emission>
             <imaer:vehicles>
+                <imaer:StandardVehicle vehicleType="HEAVY_FREIGHT">
+                    <imaer:vehiclesPerDay>5000.0</imaer:vehiclesPerDay>
+                    <imaer:stagnationFactor>0.2</imaer:stagnationFactor>
+                </imaer:StandardVehicle>
+            </imaer:vehicles>
+            <imaer:vehicles>
                 <imaer:StandardVehicle vehicleType="LIGHT_TRAFFIC">
                     <imaer:vehiclesPerDay>15000.0</imaer:vehiclesPerDay>
                     <imaer:stagnationFactor>0.1</imaer:stagnationFactor>

--- a/source/imaer-gml/src/test/resources/gml/v1_1/roundtrip/road_non_urban.gml
+++ b/source/imaer-gml/src/test/resources/gml/v1_1/roundtrip/road_non_urban.gml
@@ -53,6 +53,12 @@
                 </imaer:Emission>
             </imaer:emission>
             <imaer:vehicles>
+                <imaer:StandardVehicle vehicleType="HEAVY_FREIGHT">
+                    <imaer:vehiclesPerDay>5000.0</imaer:vehiclesPerDay>
+                    <imaer:stagnationFactor>0.2</imaer:stagnationFactor>
+                </imaer:StandardVehicle>
+            </imaer:vehicles>
+            <imaer:vehicles>
                 <imaer:StandardVehicle vehicleType="LIGHT_TRAFFIC">
                     <imaer:vehiclesPerDay>15000.0</imaer:vehiclesPerDay>
                     <imaer:stagnationFactor>0.1</imaer:stagnationFactor>

--- a/source/imaer-gml/src/test/resources/gml/v2_0/roundtrip/road_non_urban.gml
+++ b/source/imaer-gml/src/test/resources/gml/v2_0/roundtrip/road_non_urban.gml
@@ -68,6 +68,12 @@
                 </imaer:Emission>
             </imaer:emission>
             <imaer:vehicles>
+                <imaer:StandardVehicle vehicleType="HEAVY_FREIGHT">
+                    <imaer:vehiclesPerDay>5000.0</imaer:vehiclesPerDay>
+                    <imaer:stagnationFactor>0.2</imaer:stagnationFactor>
+                </imaer:StandardVehicle>
+            </imaer:vehicles>
+            <imaer:vehicles>
                 <imaer:StandardVehicle vehicleType="LIGHT_TRAFFIC">
                     <imaer:vehiclesPerDay>15000.0</imaer:vehiclesPerDay>
                     <imaer:stagnationFactor>0.1</imaer:stagnationFactor>

--- a/source/imaer-gml/src/test/resources/gml/v2_1/roundtrip/road_non_urban.gml
+++ b/source/imaer-gml/src/test/resources/gml/v2_1/roundtrip/road_non_urban.gml
@@ -68,6 +68,13 @@
                 </imaer:Emission>
             </imaer:emission>
             <imaer:vehicles>
+                <imaer:StandardVehicle vehicleType="HEAVY_FREIGHT">
+                    <imaer:vehiclesPerTimeUnit>5000.0</imaer:vehiclesPerTimeUnit>
+                    <imaer:timeUnit>DAY</imaer:timeUnit>
+                    <imaer:stagnationFactor>0.2</imaer:stagnationFactor>
+                </imaer:StandardVehicle>
+            </imaer:vehicles>
+            <imaer:vehicles>
                 <imaer:StandardVehicle vehicleType="LIGHT_TRAFFIC">
                     <imaer:vehiclesPerTimeUnit>15000.0</imaer:vehiclesPerTimeUnit>
                     <imaer:timeUnit>DAY</imaer:timeUnit>

--- a/source/imaer-gml/src/test/resources/gml/v2_2/roundtrip/road_non_urban.gml
+++ b/source/imaer-gml/src/test/resources/gml/v2_2/roundtrip/road_non_urban.gml
@@ -72,6 +72,13 @@
                 </imaer:Emission>
             </imaer:emission>
             <imaer:vehicles>
+                <imaer:StandardVehicle vehicleType="HEAVY_FREIGHT">
+                    <imaer:vehiclesPerTimeUnit>5000.0</imaer:vehiclesPerTimeUnit>
+                    <imaer:timeUnit>DAY</imaer:timeUnit>
+                    <imaer:stagnationFactor>0.2</imaer:stagnationFactor>
+                </imaer:StandardVehicle>
+            </imaer:vehicles>
+            <imaer:vehicles>
                 <imaer:StandardVehicle vehicleType="LIGHT_TRAFFIC">
                     <imaer:vehiclesPerTimeUnit>15000.0</imaer:vehiclesPerTimeUnit>
                     <imaer:timeUnit>DAY</imaer:timeUnit>

--- a/source/imaer-gml/src/test/resources/gml/v3_0/roundtrip/road_non_urban.gml
+++ b/source/imaer-gml/src/test/resources/gml/v3_0/roundtrip/road_non_urban.gml
@@ -72,6 +72,13 @@
                 </imaer:Emission>
             </imaer:emission>
             <imaer:vehicles>
+                <imaer:StandardVehicle vehicleType="HEAVY_FREIGHT">
+                    <imaer:vehiclesPerTimeUnit>5000.0</imaer:vehiclesPerTimeUnit>
+                    <imaer:timeUnit>DAY</imaer:timeUnit>
+                    <imaer:stagnationFactor>0.2</imaer:stagnationFactor>
+                </imaer:StandardVehicle>
+            </imaer:vehicles>
+            <imaer:vehicles>
                 <imaer:StandardVehicle vehicleType="LIGHT_TRAFFIC">
                     <imaer:vehiclesPerTimeUnit>15000.0</imaer:vehiclesPerTimeUnit>
                     <imaer:timeUnit>DAY</imaer:timeUnit>

--- a/source/imaer-gml/src/test/resources/gml/v3_1/roundtrip/road_non_urban.gml
+++ b/source/imaer-gml/src/test/resources/gml/v3_1/roundtrip/road_non_urban.gml
@@ -72,6 +72,13 @@
                 </imaer:Emission>
             </imaer:emission>
             <imaer:vehicles>
+                <imaer:StandardVehicle vehicleType="HEAVY_FREIGHT">
+                    <imaer:vehiclesPerTimeUnit>5000.0</imaer:vehiclesPerTimeUnit>
+                    <imaer:timeUnit>DAY</imaer:timeUnit>
+                    <imaer:stagnationFactor>0.2</imaer:stagnationFactor>
+                </imaer:StandardVehicle>
+            </imaer:vehicles>
+            <imaer:vehicles>
                 <imaer:StandardVehicle vehicleType="LIGHT_TRAFFIC">
                     <imaer:vehiclesPerTimeUnit>15000.0</imaer:vehiclesPerTimeUnit>
                     <imaer:timeUnit>DAY</imaer:timeUnit>

--- a/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/road_non_urban.gml
+++ b/source/imaer-gml/src/test/resources/gml/v4_0/roundtrip/road_non_urban.gml
@@ -73,6 +73,13 @@
                 </imaer:Emission>
             </imaer:emission>
             <imaer:vehicles>
+                <imaer:StandardVehicle vehicleType="HEAVY_FREIGHT">
+                    <imaer:vehiclesPerTimeUnit>5000.0</imaer:vehiclesPerTimeUnit>
+                    <imaer:timeUnit>DAY</imaer:timeUnit>
+                    <imaer:stagnationFactor>0.2</imaer:stagnationFactor>
+                </imaer:StandardVehicle>
+            </imaer:vehicles>
+            <imaer:vehicles>
                 <imaer:StandardVehicle vehicleType="LIGHT_TRAFFIC">
                     <imaer:vehiclesPerTimeUnit>15000.0</imaer:vehiclesPerTimeUnit>
                     <imaer:timeUnit>DAY</imaer:timeUnit>

--- a/source/imaer-gml/src/test/resources/gml/v5_0/roundtrip/road_non_urban.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_0/roundtrip/road_non_urban.gml
@@ -73,6 +73,13 @@
                 </imaer:Emission>
             </imaer:emission>
             <imaer:vehicles>
+                <imaer:StandardVehicle vehicleType="HEAVY_FREIGHT">
+                    <imaer:vehiclesPerTimeUnit>5000.0</imaer:vehiclesPerTimeUnit>
+                    <imaer:timeUnit>DAY</imaer:timeUnit>
+                    <imaer:stagnationFactor>0.2</imaer:stagnationFactor>
+                </imaer:StandardVehicle>
+            </imaer:vehicles>
+            <imaer:vehicles>
                 <imaer:StandardVehicle vehicleType="LIGHT_TRAFFIC">
                     <imaer:vehiclesPerTimeUnit>15000.0</imaer:vehiclesPerTimeUnit>
                     <imaer:timeUnit>DAY</imaer:timeUnit>

--- a/source/imaer-gml/src/test/resources/gml/v5_1/roundtrip/road_non_urban.gml
+++ b/source/imaer-gml/src/test/resources/gml/v5_1/roundtrip/road_non_urban.gml
@@ -73,6 +73,13 @@
                 </imaer:Emission>
             </imaer:emission>
             <imaer:vehicles>
+                <imaer:StandardVehicle vehicleType="HEAVY_FREIGHT">
+                    <imaer:vehiclesPerTimeUnit>5000.0</imaer:vehiclesPerTimeUnit>
+                    <imaer:timeUnit>DAY</imaer:timeUnit>
+                    <imaer:stagnationFactor>0.2</imaer:stagnationFactor>
+                </imaer:StandardVehicle>
+            </imaer:vehicles>
+            <imaer:vehicles>
                 <imaer:StandardVehicle vehicleType="LIGHT_TRAFFIC">
                     <imaer:vehiclesPerTimeUnit>15000.0</imaer:vehiclesPerTimeUnit>
                     <imaer:timeUnit>DAY</imaer:timeUnit>

--- a/source/imaer-gml/src/test/resources/gml/v6_0/roundtrip/road_non_urban.gml
+++ b/source/imaer-gml/src/test/resources/gml/v6_0/roundtrip/road_non_urban.gml
@@ -54,24 +54,32 @@
             </imaer:geometry>
             <imaer:emission>
                 <imaer:Emission substance="NH3">
-                    <imaer:value>24.525329736565443</imaer:value>
+                    <imaer:value>54.36755426564444</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NOX">
-                    <imaer:value>95.61190577751265</imaer:value>
+                    <imaer:value>1013.5599616318192</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="PM10">
-                    <imaer:value>13.553471696523006</imaer:value>
+                    <imaer:value>37.34119753123686</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
             <imaer:emission>
                 <imaer:Emission substance="NO2">
-                    <imaer:value>19.73090437453009</imaer:value>
+                    <imaer:value>62.60413116965389</imaer:value>
                 </imaer:Emission>
             </imaer:emission>
+            <imaer:vehicles>
+                <imaer:StandardVehicle vehicleType="HEAVY_FREIGHT">
+                    <imaer:vehiclesPerTimeUnit>5000.0</imaer:vehiclesPerTimeUnit>
+                    <imaer:timeUnit>DAY</imaer:timeUnit>
+                    <imaer:stagnationFactor>0.2</imaer:stagnationFactor>
+                    <imaer:maximumSpeed>80</imaer:maximumSpeed>
+                </imaer:StandardVehicle>
+            </imaer:vehicles>
             <imaer:vehicles>
                 <imaer:StandardVehicle vehicleType="LIGHT_TRAFFIC">
                     <imaer:vehiclesPerTimeUnit>15000.0</imaer:vehiclesPerTimeUnit>


### PR DESCRIPTION
Because when creating a StandardVehicles source it changes the maximum speed for the source for non urban roads. Than the other vehicle sources should be compared to that speed to check on matching, otherwise it will try to match a non converted with converted source which will result in the vehicle source to be separated. Updated round trip sources to include 2 different vehicle type sources. Note that the round trip test did catch this case because when exporting it will merge again. Therefore the export was correct, and wasn't detecting the issue.